### PR TITLE
🔧 Fix critical code quality issues (issue #28)

### DIFF
--- a/apps/api/conftest.py
+++ b/apps/api/conftest.py
@@ -65,6 +65,8 @@ def db():
     finally:
         db.close()
         SQLModel.metadata.drop_all(bind=engine)
+        # Ensure all connections are properly closed
+        engine.dispose()
 
 
 @pytest.fixture(scope="function")

--- a/apps/api/src/taskagent_api/base_service.py
+++ b/apps/api/src/taskagent_api/base_service.py
@@ -3,7 +3,7 @@ Base service class with common CRUD operations
 """
 
 from abc import ABC, abstractmethod
-from datetime import datetime
+from datetime import datetime, timezone, UTC
 from typing import Generic, TypeVar
 from uuid import UUID, uuid4
 
@@ -112,7 +112,7 @@ class BaseService(ABC, Generic[T, CreateT, UpdateT]):
                     setattr(entity, field, value)
 
             if hasattr(entity, "updated_at"):
-                entity.updated_at = datetime.utcnow()
+                entity.updated_at = datetime.now(UTC)
 
             session.add(entity)
             session.flush()

--- a/apps/api/src/taskagent_api/models.py
+++ b/apps/api/src/taskagent_api/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone, UTC
 from decimal import Decimal
 from enum import Enum
 from typing import Any
@@ -33,8 +33,8 @@ class User(UserBase, table=True):
     __tablename__ = "users"
 
     id: UUID | None = SQLField(default=None, primary_key=True)
-    created_at: datetime | None = SQLField(default_factory=datetime.utcnow)
-    updated_at: datetime | None = SQLField(default_factory=datetime.utcnow)
+    created_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
 
     # Relationships
     projects: list["Project"] = Relationship(back_populates="owner")
@@ -55,8 +55,8 @@ class Project(ProjectBase, table=True):
 
     id: UUID | None = SQLField(default=None, primary_key=True)
     owner_id: UUID = SQLField(foreign_key="users.id")
-    created_at: datetime | None = SQLField(default_factory=datetime.utcnow)
-    updated_at: datetime | None = SQLField(default_factory=datetime.utcnow)
+    created_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
 
     # Relationships
     owner: User | None = Relationship(back_populates="projects")
@@ -78,8 +78,8 @@ class Goal(GoalBase, table=True):
 
     id: UUID | None = SQLField(default=None, primary_key=True)
     project_id: UUID = SQLField(foreign_key="projects.id", ondelete="CASCADE")
-    created_at: datetime | None = SQLField(default_factory=datetime.utcnow)
-    updated_at: datetime | None = SQLField(default_factory=datetime.utcnow)
+    created_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
 
     # Relationships
     project: Project | None = Relationship(back_populates="goals")
@@ -108,8 +108,8 @@ class Task(TaskBase, table=True):
 
     id: UUID | None = SQLField(default=None, primary_key=True)
     goal_id: UUID = SQLField(foreign_key="goals.id", ondelete="CASCADE")
-    created_at: datetime | None = SQLField(default_factory=datetime.utcnow)
-    updated_at: datetime | None = SQLField(default_factory=datetime.utcnow)
+    created_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
 
     # Relationships
     goal: Goal | None = Relationship(back_populates="tasks")
@@ -130,8 +130,8 @@ class Schedule(ScheduleBase, table=True):
 
     id: UUID | None = SQLField(default=None, primary_key=True)
     user_id: UUID = SQLField(foreign_key="users.id")
-    created_at: datetime | None = SQLField(default_factory=datetime.utcnow)
-    updated_at: datetime | None = SQLField(default_factory=datetime.utcnow)
+    created_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
 
     # Relationships
     user: User | None = Relationship(back_populates="schedules")
@@ -151,7 +151,7 @@ class Log(LogBase, table=True):
 
     id: UUID | None = SQLField(default=None, primary_key=True)
     task_id: UUID = SQLField(foreign_key="tasks.id", ondelete="CASCADE")
-    created_at: datetime | None = SQLField(default_factory=datetime.utcnow)
+    created_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
 
     # Relationships
     task: Task | None = Relationship(back_populates="logs")

--- a/apps/api/src/taskagent_api/routers/scheduler.py
+++ b/apps/api/src/taskagent_api/routers/scheduler.py
@@ -7,7 +7,7 @@ import logging
 # Always use mock implementation for Docker/Production deployments
 # Real scheduler package requires complex monorepo setup
 import os
-from datetime import datetime, time
+from datetime import datetime, time, timezone, UTC
 from typing import Any
 from uuid import uuid4
 
@@ -555,7 +555,7 @@ async def save_daily_schedule(
         if existing_schedule:
             # Update existing schedule
             existing_schedule.plan_json = plan_data
-            existing_schedule.updated_at = datetime.utcnow()
+            existing_schedule.updated_at = datetime.now(UTC)
             session.add(existing_schedule)
             session.commit()
             session.refresh(existing_schedule)

--- a/apps/api/src/taskagent_api/services.py
+++ b/apps/api/src/taskagent_api/services.py
@@ -2,7 +2,7 @@
 Refactored services using base service class
 """
 
-from datetime import datetime
+from datetime import datetime, timezone, UTC
 from uuid import UUID
 
 from fastapi import HTTPException, status
@@ -68,7 +68,7 @@ class UserService:
         for field, value in update_data.items():
             setattr(user, field, value)
 
-        user.updated_at = datetime.utcnow()
+        user.updated_at = datetime.now(UTC)
         session.add(user)
         session.commit()
         session.refresh(user)

--- a/apps/api/tests/test_base_service.py
+++ b/apps/api/tests/test_base_service.py
@@ -39,7 +39,9 @@ def memory_db():
     """Create in-memory SQLite database for testing"""
     engine = create_engine("sqlite:///:memory:")
     SQLModel.metadata.create_all(engine)
-    return engine
+    yield engine
+    # Properly dispose of the engine after use
+    engine.dispose()
 
 
 @pytest.fixture

--- a/apps/api/tests/test_project_performance.py
+++ b/apps/api/tests/test_project_performance.py
@@ -28,8 +28,12 @@ def test_session():
     )
     SQLModel.metadata.create_all(engine)
 
-    with Session(engine) as session:
-        yield session
+    try:
+        with Session(engine) as session:
+            yield session
+    finally:
+        # Properly dispose of the engine after use
+        engine.dispose()
 
 
 @pytest.fixture


### PR DESCRIPTION
## 概要

issue #28で特定された重要なコード品質問題を修正しました。

## ✅ 修正内容

### 高優先度の修正
- **datetime.utcnow() deprecation warnings**: `datetime.now(UTC)`への完全移行
- **Database connection resource leaks**: テスト用fixtureでのengine disposal追加
- **現代的なdatetime UTC alias使用**: Python 3.11+の`datetime.UTC`エイリアス統一

### 影響範囲
- `base_service.py`: updated_at設定時のdeprecation修正
- `models.py`: 全モデルのdefault_factory更新
- `routers/scheduler.py`: スケジュール更新時の修正
- `services.py`: ユーザー更新処理の修正
- テストファイル: SQLite engine適切なクリーンアップ

## 🧪 テスト結果

```
======================== 41 passed, 2 warnings in 1.06s ========================
```

- ✅ **全テスト通過**: 41/41 tests passing
- ✅ **Ruff linting**: All checks passed
- ✅ **Resource leak対策**: engine.dispose()追加でSQLite接続適切管理
- ⚠️ **残存warning**: Supabaseライブラリ由来（コード側では対応済み）

## 🎯 期待される効果

- **安定性向上**: Resource leakの解消
- **将来対応**: Deprecated API使用の解消
- **保守性**: 現代的なPython datetime APIの使用
- **開発効率**: Warning noiseの大幅削減

🤖 Generated with [Claude Code](https://claude.ai/code)