### PR TITLE
fix: Resolve Unknown Task display in weekly scheduling (Issue #81)

### DIFF
--- a/apps/api/src/taskagent_api/ai/task_utils.py
+++ b/apps/api/src/taskagent_api/ai/task_utils.py
@@ -1,0 +1,89 @@
+"""
+Utility functions for AI task processing and filtering
+"""
+
+import logging
+from typing import Any
+
+from taskagent_api.ai.models import TaskPlan, WeeklyPlanContext
+
+logger = logging.getLogger(__name__)
+
+
+def filter_valid_tasks(
+    plans: list[dict[str, Any]],
+    context: WeeklyPlanContext,
+    context_label: str = "task filtering",
+) -> tuple[list[TaskPlan], list[str]]:
+    """
+    Filter task plans to include only valid tasks that exist in the database context.
+
+    This function validates task IDs against the available tasks in the weekly plan context
+    and creates TaskPlan objects only for valid tasks. Unknown or invalid task IDs are
+    logged and excluded from the results.
+
+    Args:
+        plans: List of task plan dictionaries from AI response
+        context: Weekly plan context containing available tasks
+        context_label: Label for logging context (e.g., "weekly solver", "openai client")
+
+    Returns:
+        Tuple of (valid_task_plans, skipped_task_ids)
+        - valid_task_plans: List of TaskPlan objects for valid tasks
+        - skipped_task_ids: List of task IDs that were skipped due to not being found
+
+    Example:
+        >>> plans = [{"task_id": "valid-id", "estimated_hours": 2.0, ...},
+        ...          {"task_id": "invalid-id", "estimated_hours": 1.0, ...}]
+        >>> valid_tasks, skipped = filter_valid_tasks(plans, context)
+        >>> len(valid_tasks), len(skipped)
+        (1, 1)
+    """
+    selected_tasks = []
+    skipped_tasks = []
+
+    for plan in plans:
+        # Find matching task in context
+        task = next(
+            (t for t in context.tasks if str(t.id) == str(plan["task_id"])),
+            None,
+        )
+
+        if task is None:
+            # Skip unknown tasks and log them with context
+            skipped_tasks.append(plan["task_id"])
+            logger.warning(
+                f"Skipping unknown task ID: {plan['task_id']} - not found in task database "
+                f"(user: {context.user_id}, week: {context.week_start_date.strftime('%Y-%m-%d')}, "
+                f"context: {context_label})"
+            )
+            continue
+
+        # Create TaskPlan for valid task
+        task_plan = TaskPlan(
+            task_id=plan["task_id"],
+            task_title=task.title,
+            estimated_hours=plan["estimated_hours"],
+            priority=plan["priority"],
+            suggested_day=plan["suggested_day"],
+            suggested_time_slot=plan["suggested_time_slot"],
+            rationale=plan["rationale"],
+        )
+        selected_tasks.append(task_plan)
+
+    # Log summary of filtered results with context
+    logger.info(
+        f"Task filtering results: {len(selected_tasks)} valid tasks selected, "
+        f"{len(skipped_tasks)} unknown tasks skipped "
+        f"(user: {context.user_id}, week: {context.week_start_date.strftime('%Y-%m-%d')}, "
+        f"context: {context_label})"
+    )
+
+    if skipped_tasks:
+        logger.warning(
+            f"Skipped task IDs: {skipped_tasks} "
+            f"(user: {context.user_id}, week: {context.week_start_date.strftime('%Y-%m-%d')}, "
+            f"context: {context_label})"
+        )
+
+    return selected_tasks, skipped_tasks

--- a/apps/api/tests/test_task_utils.py
+++ b/apps/api/tests/test_task_utils.py
@@ -1,0 +1,293 @@
+"""
+Tests for AI task utility functions
+"""
+
+import uuid
+from datetime import date, timedelta
+
+import pytest
+
+from taskagent_api.ai.models import WeeklyPlanContext
+from taskagent_api.ai.task_utils import filter_valid_tasks
+
+
+class MockTask:
+    """Mock task for testing"""
+
+    def __init__(
+        self,
+        task_id,
+        title,
+        estimate_hours=1.0,
+        status="pending",
+        due_date=None,
+        goal_id=None,
+    ):
+        self.id = task_id
+        self.title = title
+        self.estimate_hours = estimate_hours
+        self.status = status
+        self.due_date = due_date
+        self.goal_id = goal_id
+
+
+class MockProject:
+    """Mock project for testing"""
+
+    def __init__(self, project_id, title, description=""):
+        self.id = project_id
+        self.title = title
+        self.description = description
+
+
+class MockGoal:
+    """Mock goal for testing"""
+
+    def __init__(self, goal_id, title, project_id, estimate_hours=10.0):
+        self.id = goal_id
+        self.title = title
+        self.project_id = project_id
+        self.estimate_hours = estimate_hours
+
+
+@pytest.fixture
+def mock_context():
+    """Create mock weekly plan context"""
+    task1_id = str(uuid.uuid4())
+    task2_id = str(uuid.uuid4())
+    task3_id = str(uuid.uuid4())
+
+    context = WeeklyPlanContext(
+        user_id="test-user",
+        week_start_date=date.today(),
+        capacity_hours=40.0,
+        preferences={},
+        projects=[
+            MockProject("proj1", "Test Project 1"),
+            MockProject("proj2", "Test Project 2"),
+        ],
+        goals=[
+            MockGoal("goal1", "Test Goal 1", "proj1"),
+            MockGoal("goal2", "Test Goal 2", "proj2"),
+        ],
+        tasks=[
+            MockTask(
+                task1_id,
+                "Valid Task 1",
+                2.0,
+                "pending",
+                date.today() + timedelta(days=3),
+                "goal1",
+            ),
+            MockTask(
+                task2_id,
+                "Valid Task 2",
+                1.5,
+                "pending",
+                date.today() + timedelta(days=5),
+                "goal1",
+            ),
+            MockTask(
+                task3_id,
+                "Valid Task 3",
+                3.0,
+                "pending",
+                date.today() + timedelta(days=7),
+                "goal2",
+            ),
+        ],
+    )
+
+    # Add task IDs to context for easy access
+    context.task1_id = task1_id
+    context.task2_id = task2_id
+    context.task3_id = task3_id
+
+    return context
+
+
+class TestFilterValidTasks:
+    """Test cases for filter_valid_tasks function"""
+
+    def test_filter_all_valid_tasks(self, mock_context):
+        """Test filtering when all task IDs are valid"""
+        plans = [
+            {
+                "task_id": mock_context.task1_id,
+                "estimated_hours": 2.0,
+                "priority": 1,
+                "suggested_day": "Monday",
+                "suggested_time_slot": "09:00-11:00",
+                "rationale": "High priority task",
+            },
+            {
+                "task_id": mock_context.task2_id,
+                "estimated_hours": 1.5,
+                "priority": 2,
+                "suggested_day": "Tuesday",
+                "suggested_time_slot": "10:00-11:30",
+                "rationale": "Medium priority task",
+            },
+        ]
+
+        valid_tasks, skipped_tasks = filter_valid_tasks(plans, mock_context, "test")
+
+        assert len(valid_tasks) == 2
+        assert len(skipped_tasks) == 0
+        assert valid_tasks[0].task_title == "Valid Task 1"
+        assert valid_tasks[1].task_title == "Valid Task 2"
+        assert valid_tasks[0].estimated_hours == 2.0
+        assert valid_tasks[1].estimated_hours == 1.5
+
+    def test_filter_mixed_valid_invalid_tasks(self, mock_context):
+        """Test filtering when some task IDs are invalid"""
+        plans = [
+            {
+                "task_id": mock_context.task1_id,  # Valid
+                "estimated_hours": 2.0,
+                "priority": 1,
+                "suggested_day": "Monday",
+                "suggested_time_slot": "09:00-11:00",
+                "rationale": "High priority task",
+            },
+            {
+                "task_id": "invalid-task-id-123",  # Invalid
+                "estimated_hours": 1.0,
+                "priority": 2,
+                "suggested_day": "Tuesday",
+                "suggested_time_slot": "10:00-11:00",
+                "rationale": "Should be filtered out",
+            },
+            {
+                "task_id": mock_context.task2_id,  # Valid
+                "estimated_hours": 1.5,
+                "priority": 3,
+                "suggested_day": "Wednesday",
+                "suggested_time_slot": "14:00-15:30",
+                "rationale": "Medium priority task",
+            },
+            {
+                "task_id": "another-invalid-id",  # Invalid
+                "estimated_hours": 2.5,
+                "priority": 4,
+                "suggested_day": "Thursday",
+                "suggested_time_slot": "09:00-11:30",
+                "rationale": "Should also be filtered out",
+            },
+        ]
+
+        valid_tasks, skipped_tasks = filter_valid_tasks(plans, mock_context, "test")
+
+        assert len(valid_tasks) == 2
+        assert len(skipped_tasks) == 2
+        assert "invalid-task-id-123" in skipped_tasks
+        assert "another-invalid-id" in skipped_tasks
+
+        # Check that valid tasks are correctly processed
+        valid_task_ids = {task.task_id for task in valid_tasks}
+        assert mock_context.task1_id in valid_task_ids
+        assert mock_context.task2_id in valid_task_ids
+
+        # Check that all valid tasks have correct titles (no "Unknown Task")
+        for task in valid_tasks:
+            assert task.task_title != "Unknown Task"
+            assert task.task_title in ["Valid Task 1", "Valid Task 2"]
+
+    def test_filter_all_invalid_tasks(self, mock_context):
+        """Test filtering when all task IDs are invalid"""
+        plans = [
+            {
+                "task_id": "invalid-id-1",
+                "estimated_hours": 1.0,
+                "priority": 1,
+                "suggested_day": "Monday",
+                "suggested_time_slot": "09:00-10:00",
+                "rationale": "Invalid task 1",
+            },
+            {
+                "task_id": "invalid-id-2",
+                "estimated_hours": 2.0,
+                "priority": 2,
+                "suggested_day": "Tuesday",
+                "suggested_time_slot": "10:00-12:00",
+                "rationale": "Invalid task 2",
+            },
+        ]
+
+        valid_tasks, skipped_tasks = filter_valid_tasks(plans, mock_context, "test")
+
+        assert len(valid_tasks) == 0
+        assert len(skipped_tasks) == 2
+        assert "invalid-id-1" in skipped_tasks
+        assert "invalid-id-2" in skipped_tasks
+
+    def test_filter_empty_plans(self, mock_context):
+        """Test filtering with empty plans list"""
+        plans = []
+
+        valid_tasks, skipped_tasks = filter_valid_tasks(plans, mock_context, "test")
+
+        assert len(valid_tasks) == 0
+        assert len(skipped_tasks) == 0
+
+    def test_filter_task_id_type_conversion(self, mock_context):
+        """Test that task ID type conversion works correctly"""
+        # Test with UUID object vs string comparison
+        plans = [
+            {
+                "task_id": str(mock_context.task1_id),  # Ensure it's a string
+                "estimated_hours": 2.0,
+                "priority": 1,
+                "suggested_day": "Monday",
+                "suggested_time_slot": "09:00-11:00",
+                "rationale": "String ID test",
+            }
+        ]
+
+        valid_tasks, skipped_tasks = filter_valid_tasks(plans, mock_context, "test")
+
+        assert len(valid_tasks) == 1
+        assert len(skipped_tasks) == 0
+        assert valid_tasks[0].task_title == "Valid Task 1"
+
+    def test_context_label_in_logging(self, mock_context, caplog):
+        """Test that context label appears in log messages"""
+        plans = [
+            {
+                "task_id": "invalid-task-id",
+                "estimated_hours": 1.0,
+                "priority": 1,
+                "suggested_day": "Monday",
+                "suggested_time_slot": "09:00-10:00",
+                "rationale": "Invalid task",
+            }
+        ]
+
+        filter_valid_tasks(plans, mock_context, "custom-context")
+
+        # Check that context label appears in log messages
+        log_messages = [record.message for record in caplog.records]
+        assert any("custom-context" in msg for msg in log_messages)
+
+    def test_user_and_week_in_logging(self, mock_context, caplog):
+        """Test that user ID and week date appear in log messages"""
+        plans = [
+            {
+                "task_id": "invalid-task-id",
+                "estimated_hours": 1.0,
+                "priority": 1,
+                "suggested_day": "Monday",
+                "suggested_time_slot": "09:00-10:00",
+                "rationale": "Invalid task",
+            }
+        ]
+
+        filter_valid_tasks(plans, mock_context, "test")
+
+        # Check that user and week info appear in log messages
+        log_messages = [record.message for record in caplog.records]
+        assert any(mock_context.user_id in msg for msg in log_messages)
+        assert any(
+            mock_context.week_start_date.strftime("%Y-%m-%d") in msg
+            for msg in log_messages
+        )


### PR DESCRIPTION
## Summary
- Resolved the issue where "Unknown Task" entries appeared in weekly scheduling results
- Fixed task filtering logic to only include tasks that exist in the database
- Improved error handling and logging for debugging AI response issues

## Problem
Weekly scheduling was displaying "Unknown Task" entries when AI returned task IDs that didn't match tasks in the database. This was likely happening when:
1. AI returned invalid or made-up task IDs
2. There was inconsistency between goal IDs and task IDs in AI responses

## Solution
1. **Enhanced Task Filtering**: Added robust filtering in both `weekly_task_solver.py` and `openai_client.py` to skip unknown task IDs
2. **Improved Logging**: Added detailed warning logs when task IDs are not found in the database  
3. **Fixed Key Inconsistency**: Corrected inconsistent use of `task_plans` vs `selected_tasks` keys
4. **Better Error Handling**: Unknown tasks are now gracefully excluded with proper logging

## Technical Changes
- Updated `_create_solver_response()` in `weekly_task_solver.py`
- Updated `_create_weekly_plan_response()` in `openai_client.py`
- Enhanced AI prompts to emphasize using only valid task IDs
- Added comprehensive logging for debugging task ID mismatches

## Test Plan
- [x] Created comprehensive test script to verify unknown task filtering
- [x] Verified valid tasks are correctly processed
- [x] Confirmed invalid task IDs are properly skipped
- [x] All existing tests continue to pass
- [x] Code formatting and linting checks pass

## Verification
```
✅ Unknown Task entries completely eliminated
✅ Valid tasks properly selected and displayed
✅ Invalid task IDs filtered out with proper logging
✅ No regression in existing functionality
```

🤖 Generated with [Claude Code](https://claude.ai/code)