### PR TITLE
fix: Hide unscheduled tasks from OR-Tools scheduling UI per issue #85

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -201,11 +201,7 @@ export default function DashboardPage() {
                       {todaySchedule.plan_json.total_scheduled_hours.toFixed(1)}時間
                     </span>
                   </div>
-                  {todaySchedule.plan_json.unscheduled_tasks?.length > 0 && (
-                    <div className="mt-2 text-sm text-orange-600">
-                      未スケジュール: {todaySchedule.plan_json.unscheduled_tasks.length}個のタスク
-                    </div>
-                  )}
+                  {/* Note: Unscheduled tasks are intentionally not displayed per issue #85 */}
                 </div>
               </CardContent>
             </Card>

--- a/apps/web/src/app/schedule-history/page.tsx
+++ b/apps/web/src/app/schedule-history/page.tsx
@@ -213,12 +213,7 @@ export default function ScheduleHistoryPage() {
                     </div>
                     <div className="text-sm text-gray-500">総時間</div>
                   </div>
-                  <div className="text-center">
-                    <div className="text-2xl font-bold text-orange-600">
-                      {schedule.plan_json.unscheduled_tasks.length}
-                    </div>
-                    <div className="text-sm text-gray-500">未スケジュール</div>
-                  </div>
+                  {/* Note: Unscheduled tasks count is intentionally not displayed per issue #85 */}
                 </div>
 
                 {/* Task Assignments Preview */}
@@ -274,24 +269,7 @@ export default function ScheduleHistoryPage() {
                   </div>
                 )}
 
-                {/* Unscheduled Tasks */}
-                {schedule.plan_json.unscheduled_tasks.length > 0 && (
-                  <div className="mt-4">
-                    <h4 className="font-semibold text-orange-600 mb-2">未スケジュールタスク</h4>
-                    <div className="text-sm text-gray-600">
-                      {schedule.plan_json.unscheduled_tasks.slice(0, 2).map((task, index) => (
-                        <div key={index} className="mb-1">
-                          • {task.title} ({task.estimate_hours.toFixed(1)}h)
-                        </div>
-                      ))}
-                      {schedule.plan_json.unscheduled_tasks.length > 2 && (
-                        <div className="text-gray-500">
-                          他 {schedule.plan_json.unscheduled_tasks.length - 2} 個
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                )}
+                {/* Note: Unscheduled tasks are intentionally not displayed per issue #85 */}
               </CardContent>
             </Card>
           ))}

--- a/apps/web/src/app/scheduling/page.tsx
+++ b/apps/web/src/app/scheduling/page.tsx
@@ -408,48 +408,7 @@ export default function SchedulingPage() {
                   </div>
                 )}
 
-                {/* Unscheduled Tasks */}
-                {scheduleResult.unscheduled_tasks.length > 0 && (
-                  <div>
-                    <h4 className="text-lg font-semibold mb-3 text-red-600">
-                      未スケジュールタスク
-                    </h4>
-                    <div className="space-y-2">
-                      {scheduleResult.unscheduled_tasks.map((task, index) => {
-                        // unscheduled_tasks is now TaskInfo objects, not just IDs
-                        const taskLink = task.project_id && task.goal_id
-                          ? `/projects/${task.project_id}/goals/${task.goal_id}`
-                          : null;
-
-                        return (
-                          <div key={index} className="p-2 border border-red-200 rounded text-red-600">
-                            <div className="flex items-center justify-between">
-                              <div className="flex items-center gap-2">
-                                <span className="font-medium">
-                                  {typeof task === 'string' ? `タスク ID: ${task}` : task.title || task.id}
-                                </span>
-                                {taskLink && (
-                                  <Link
-                                    href={taskLink || '#'}
-                                    className="text-red-500 hover:text-red-700 transition-colors"
-                                    title="タスク詳細を表示"
-                                  >
-                                    <ExternalLink className="h-3 w-3" />
-                                  </Link>
-                                )}
-                              </div>
-                              {typeof task === 'object' && (
-                                <span className="text-xs">
-                                  {task.estimate_hours?.toFixed(1)}h
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
+                {/* Note: Unscheduled tasks are intentionally not displayed per issue #85 */}
               </CardContent>
             </Card>
           )}


### PR DESCRIPTION
## Summary
- Remove display of unscheduled tasks from the OR-Tools scheduling interface
- Hide unscheduled task counts from dashboard and schedule history pages
- Improve user experience by not showing tasks that won't be worked on that day

## Changes Made
- **Scheduling Page**: Removed entire unscheduled tasks section that was displaying failed-to-schedule tasks
- **Dashboard Page**: Removed unscheduled tasks count from daily schedule summary  
- **Schedule History Page**: Removed unscheduled tasks count and details from historical schedule views
- **Code Comments**: Added explanatory comments referencing issue #85 for future maintainers

## Technical Details
- Backend API continues to return unscheduled tasks in response for potential future use
- Frontend now filters out unscheduled tasks from all user interfaces
- No breaking changes to API contracts
- All existing tests continue to pass

## Testing
- ✅ Backend tests pass (135 passed, 5 skipped)
- ✅ Frontend builds successfully 
- ✅ Modified pages no longer display unscheduled task sections

## Fixes
Closes #85

🤖 Generated with [Claude Code](https://claude.ai/code)