### PR TITLE
Fix: Task work type always saved as 'light_work' (Issue #91)

### DIFF
--- a/apps/api/src/taskagent_api/services.py
+++ b/apps/api/src/taskagent_api/services.py
@@ -437,6 +437,7 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
             estimate_hours=data.estimate_hours,
             due_date=data.due_date,
             status=data.status,
+            work_type=data.work_type,
         )
 
     def _get_user_filter(self, user_id: str | UUID):


### PR DESCRIPTION
## Summary
- Fixed a bug where the work_type field was always being saved as 'light_work' regardless of user selection
- Added missing work_type parameter to Task instance creation in TaskService

## Root Cause
The `TaskService._create_instance()` method was not passing the `work_type` field when creating a new Task instance, causing it to always use the default value of `WorkType.LIGHT_WORK`.

## Changes
- Added `work_type=data.work_type` to the Task instance creation in `services.py:440`

## Test Plan
- [x] Created test script to verify all work types are correctly saved
- [x] Verified light_work, study, and focused_work are all saved and retrieved correctly
- [x] Ran linting (ruff) and type checking (mypy) - all passed
- [x] Pre-commit hooks passed

Fixes #91

🤖 Generated with [Claude Code](https://claude.ai/code)