### PR TITLE
fix: Update OpenAI API key validation regex to support new sk-proj format (Issue #98)

### DIFF
--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -32,8 +32,8 @@ interface AvailableModels {
   [key: string]: ModelInfo
 }
 
-// OpenAI API key validation regex
-const OPENAI_API_KEY_REGEX = /^sk-[a-zA-Z0-9]{48}$/
+// OpenAI API key validation regex - supports both old and new formats
+const OPENAI_API_KEY_REGEX = /^sk-[a-zA-Z0-9-_]{20,}$/
 
 // Default model from environment or fallback
 const DEFAULT_MODEL = process.env.NEXT_PUBLIC_DEFAULT_OPENAI_MODEL || "gpt-5"


### PR DESCRIPTION
## Summary
- 古いOpenAI APIキー形式（`sk-`で始まる48文字）のみをサポートしていた正規表現を更新
- 新しい形式（`sk-proj-`で始まる長いキー）も受け入れるように修正
- フロントエンドのバリデーション処理を改善

## 変更内容
- `apps/web/src/app/settings/page.tsx`の`OPENAI_API_KEY_REGEX`を更新
- 旧フォーマット: `/^sk-[a-zA-Z0-9]{48}$/` → 新フォーマット: `/^sk-[a-zA-Z0-9-_]{20,}$/`

## テスト確認
- 古いAPIキー形式: ✅ 有効
- 新しいAPIキー形式 (`sk-proj-`): ✅ 有効  
- 無効なキー形式: ❌ 無効

## 関連Issue
Fixes #98

🤖 Generated with [Claude Code](https://claude.ai/code)