### PR TITLE
fix: Include weekly recurring tasks in weekly schedules and daily scheduling

### DIFF
--- a/apps/api/.pre-commit-config.yaml
+++ b/apps/api/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: bash -c 'cd apps/api && source /home/masato/git-repos/lifemanagement/.venv/bin/activate && python -m mypy src --config-file=pyproject.toml'
+        entry: bash -c 'cd apps/api && python -m mypy src --config-file=pyproject.toml'
         language: system
         types: [python]
         pass_filenames: false
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: bash -c 'cd apps/api && source /home/masato/git-repos/lifemanagement/.venv/bin/activate && PYTHONPATH=src python -m pytest --ignore=tests/test_backup_scheduler.py'
+        entry: bash -c 'cd apps/api && PYTHONPATH=src python -m pytest --ignore=tests/test_backup_scheduler.py'
         language: system
         types: [python]
         pass_filenames: false

--- a/apps/api/src/taskagent_api/ai/openai_client.py
+++ b/apps/api/src/taskagent_api/ai/openai_client.py
@@ -223,7 +223,8 @@ class OpenAIClient:
             selected_recurring_tasks = []
             if context.selected_recurring_task_ids:
                 selected_recurring_tasks = [
-                    rt for rt in context.weekly_recurring_tasks
+                    rt
+                    for rt in context.weekly_recurring_tasks
                     if str(rt.id) in context.selected_recurring_task_ids
                 ]
             else:

--- a/apps/api/src/taskagent_api/ai/task_utils.py
+++ b/apps/api/src/taskagent_api/ai/task_utils.py
@@ -18,7 +18,7 @@ def filter_valid_tasks(
     """
     Filter task plans to include only valid tasks and weekly recurring tasks that exist in the database context.
 
-    This function validates task IDs against the available tasks and weekly recurring tasks in the 
+    This function validates task IDs against the available tasks and weekly recurring tasks in the
     weekly plan context and creates TaskPlan objects only for valid items. Unknown or invalid IDs are
     logged and excluded from the results.
 

--- a/apps/api/src/taskagent_api/ai/weekly_task_solver.py
+++ b/apps/api/src/taskagent_api/ai/weekly_task_solver.py
@@ -393,9 +393,7 @@ class WeeklyTaskSolver:
                 if str(weekly_task.id) in context.selected_recurring_task_ids:
                     # Weekly recurring tasks get high priority to ensure they are included
                     recurring_score = 8.0  # High priority for consistency
-                    effort_score = 10 - min(
-                        float(weekly_task.estimate_hours or 0), 10
-                    )
+                    effort_score = 10 - min(float(weekly_task.estimate_hours or 0), 10)
                     total_score = (
                         recurring_score * 0.7  # High weight for weekly consistency
                         + effort_score * constraints.effort_efficiency_weight
@@ -468,15 +466,17 @@ class WeeklyTaskSolver:
         if context.selected_recurring_task_ids:
             for rt in context.weekly_recurring_tasks:
                 if str(rt.id) in context.selected_recurring_task_ids:
-                    selected_recurring_tasks_data.append({
-                        "id": rt.id,
-                        "title": f"[週課] {rt.title}",
-                        "description": rt.description,
-                        "estimate_hours": rt.estimate_hours,
-                        "due_date": None,  # Weekly recurring tasks don't have specific due dates
-                        "status": "weekly_recurring",
-                        "category": rt.category,
-                    })
+                    selected_recurring_tasks_data.append(
+                        {
+                            "id": rt.id,
+                            "title": f"[週課] {rt.title}",
+                            "description": rt.description,
+                            "estimate_hours": rt.estimate_hours,
+                            "due_date": None,  # Weekly recurring tasks don't have specific due dates
+                            "status": "weekly_recurring",
+                            "category": rt.category,
+                        }
+                    )
 
         # Combine regular tasks and selected weekly recurring tasks
         all_available_tasks = tasks_data + selected_recurring_tasks_data


### PR DESCRIPTION
Fixes issue #113 where weekly recurring tasks (週課) were not appearing in generated weekly schedules even when selected.

## Changes

- Updated OpenAI context formatting to include selected weekly recurring tasks
- Enhanced task filtering utility to support both regular tasks and weekly recurring tasks
- Modified weekly task solver to include weekly recurring tasks in both AI and heuristic selection
- Extended daily scheduler to handle weekly recurring tasks from weekly schedules
- Added proper identification and processing of weekly recurring tasks in scheduling

## Benefits

Users can now:
- See selected weekly recurring tasks in AI-generated weekly plans
- Track progress on weekly recurring tasks as separate objects each week
- Select weekly recurring tasks in daily scheduler when using weekly schedule as task source

Generated with [Claude Code](https://claude.ai/code)