### PR TITLE
Fix dashboard work type display bug (Issue #118)

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -14,6 +14,7 @@ import Link from 'next/link'
 import type { DailySchedule } from '@/types/api-responses'
 import { TimelineOverview } from '@/components/timeline/timeline-overview'
 import { useTimelineOverview } from '@/hooks/use-timeline'
+import { getSlotKindLabel } from '@/constants/schedule'
 
 export default function DashboardPage() {
   const { loading, isAuthenticated } = useAuth()
@@ -192,9 +193,7 @@ export default function DashboardPage() {
                             {assignment.duration_hours.toFixed(1)}時間
                             <span className="text-gray-400">•</span>
                             <Badge variant="outline" className="text-xs">
-                              {assignment.slot_kind === 'deep' ? '集中作業' :
-                               assignment.slot_kind === 'light' ? '軽作業' :
-                               assignment.slot_kind === 'study' ? '学習' : '会議'}
+                              {getSlotKindLabel(assignment.slot_kind)}
                             </Badge>
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- Fixed work type enum values in dashboard to match current backend implementation
- Updated dashboard badge display to use correct enum values: `focused_work`, `light_work`, `study`
- Replaced hardcoded type mapping with existing `getSlotKindLabel` helper for consistency

## Test plan
- [x] Verified type checking passes
- [x] Verified linting passes
- [x] Updated dashboard to use correct work type enum values
- [x] Dashboard now properly displays work types for all task types

## Changes Made
- Updated `/apps/web/src/app/dashboard/page.tsx`:
  - Fixed enum values: `deep` → `focused_work`, `light` → `light_work`
  - Replaced conditional logic with `getSlotKindLabel()` helper function
  - Added import for `getSlotKindLabel` from `@/constants/schedule`

## Issue Reference
Closes #118

🤖 Generated with [Claude Code](https://claude.ai/code)