### PR TITLE
fix: Sort daily schedule tasks by time in chronological order (Issue #119)

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -180,7 +180,9 @@ export default function DashboardPage() {
               </CardHeader>
               <CardContent>
                 <div className="space-y-3">
-                  {todaySchedule.plan_json.assignments.map((assignment, index: number) => (
+                  {todaySchedule.plan_json.assignments
+                    .sort((a, b) => a.start_time.localeCompare(b.start_time))
+                    .map((assignment, index: number) => (
                     <div key={index} className="flex items-center justify-between p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
                       <div className="flex items-center gap-3">
                         <div className="text-lg font-semibold text-gray-600">

--- a/apps/web/src/app/schedule-history/page.tsx
+++ b/apps/web/src/app/schedule-history/page.tsx
@@ -216,7 +216,10 @@ export default function ScheduleHistoryPage() {
                   <div>
                     <h4 className="font-semibold mb-2">スケジュール済みタスク</h4>
                     <div className="space-y-2">
-                      {schedule.plan_json.assignments.slice(0, 3).map((assignment, index) => (
+                      {schedule.plan_json.assignments
+                        .sort((a, b) => a.start_time.localeCompare(b.start_time))
+                        .slice(0, 3)
+                        .map((assignment, index) => (
                         <div key={index} className="flex items-center justify-between p-2 bg-gray-50 rounded">
                           <div className="flex items-center gap-3">
                             <div className="text-sm font-semibold text-gray-600">

--- a/apps/web/src/app/scheduling/page.tsx
+++ b/apps/web/src/app/scheduling/page.tsx
@@ -476,7 +476,9 @@ export default function SchedulingPage() {
                   <div>
                     <h4 className="text-lg font-semibold mb-3">タスク割り当て</h4>
                     <div className="space-y-2">
-                      {scheduleResult.assignments.map((assignment, index) => {
+                      {scheduleResult.assignments
+                        .sort((a, b) => a.start_time.localeCompare(b.start_time))
+                        .map((assignment, index) => {
                         const slotInfo = timeSlots[assignment.slot_index];
                         const taskLink = assignment.project_id && assignment.goal_id
                           ? `/projects/${assignment.project_id}/goals/${assignment.goal_id}`


### PR DESCRIPTION
## Summary
- Add time-based sorting for task assignments in all schedule displays using `start_time.localeCompare()`
- Dashboard: Today's schedule now shows tasks sorted by start_time
- Scheduling page: Optimization results display tasks chronologically  
- Schedule history: Preview tasks are sorted by start_time

## Issue
Fixes #119 - 本日のスケジュールを時間順に表示

## Changes
- `src/app/dashboard/page.tsx`: Sort assignments by start_time in today's schedule display
- `src/app/scheduling/page.tsx`: Sort assignments by start_time in optimization results
- `src/app/schedule-history/page.tsx`: Sort assignments by start_time in schedule preview

## Test plan
- [x] TypeScript type check passes
- [x] ESLint check passes  
- [x] All schedule displays now show tasks in chronological order
- [x] No functional changes to OR-Tools optimization logic
- [x] Existing schedule data displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)