### PR TITLE
Fix task priority not being saved during creation (Issue #134)

### DIFF
--- a/apps/api/src/taskagent_api/services.py
+++ b/apps/api/src/taskagent_api/services.py
@@ -478,6 +478,7 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
             estimate_hours=data.estimate_hours,
             due_date=data.due_date,
             status=data.status,
+            priority=data.priority,
             work_type=data.work_type,
         )
 


### PR DESCRIPTION
## Summary
- TaskService._create_instanceメソッドでタスク作成時にpriority=data.priorityの指定が漏れていた問題を修正
- フロントエンドで選択された優先度が正しくデータベースに保存されるようになった
- 修正前は選択した優先度に関係なく常に「中」（3）で保存されていた

## Changes
- `src/taskagent_api/services.py` のTaskService._create_instanceメソッドに `priority=data.priority,` を追加

## Test plan
- [x] 既存の全テストケースが正常に実行されることを確認 (224 passed, 5 skipped)
- [x] 異なる優先度値（1, 3, 5）でタスクインスタンス作成を検証
- [x] Priority値が正しく設定されることを確認

Fixes #134

🤖 Generated with [Claude Code](https://claude.ai/code)