### PR TITLE
fix: Remove unassigned schedules from database storage (Issue #141)

### DIFF
--- a/apps/api/src/taskagent_api/migrations/remove_unscheduled_tasks_from_schedules.py
+++ b/apps/api/src/taskagent_api/migrations/remove_unscheduled_tasks_from_schedules.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Migration script to remove unscheduled_tasks from existing schedules in database.
+
+This script addresses Issue #141 by cleaning up existing schedule records
+that contain unscheduled_tasks data, which is no longer needed.
+
+Usage:
+    cd apps/api
+    PYTHONPATH=src python src/taskagent_api/migrations/remove_unscheduled_tasks_from_schedules.py
+"""
+
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from taskagent_api.database import db
+from taskagent_api.models import Schedule
+from taskagent_api.safe_migration import DataBackupManager
+from sqlmodel import Session, select
+
+# Set up logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def remove_unscheduled_tasks_from_schedules():
+    """
+    Remove unscheduled_tasks from all existing schedule records.
+
+    This function:
+    1. Creates a backup of current schedule data
+    2. Updates all schedule records to remove unscheduled_tasks from plan_json
+    3. Reports the number of updated records
+    """
+    logger.info("Starting removal of unscheduled_tasks from existing schedules")
+
+    try:
+        # Create backup before migration
+        backup_manager = DataBackupManager()
+        backup_path = backup_manager.create_backup("pre_remove_unscheduled_tasks")
+        logger.info(f"Created backup at: {backup_path}")
+
+        # Get database engine and session
+        engine = db.get_engine()
+        with Session(engine) as session:
+            # Get all schedules that have unscheduled_tasks in plan_json
+            logger.info("Fetching schedules with unscheduled_tasks...")
+
+            schedules = session.exec(select(Schedule)).all()
+            updated_count = 0
+
+            for schedule in schedules:
+                if (
+                    schedule.plan_json
+                    and isinstance(schedule.plan_json, dict)
+                    and "unscheduled_tasks" in schedule.plan_json
+                ):
+                    # Remove unscheduled_tasks from plan_json
+                    original_keys = list(schedule.plan_json.keys())
+                    unscheduled_count = len(schedule.plan_json["unscheduled_tasks"])
+
+                    # Create new plan_json without unscheduled_tasks
+                    new_plan_json = {
+                        key: value
+                        for key, value in schedule.plan_json.items()
+                        if key != "unscheduled_tasks"
+                    }
+
+                    schedule.plan_json = new_plan_json
+                    schedule.updated_at = datetime.utcnow()
+
+                    updated_count += 1
+                    logger.info(
+                        f"Updated schedule {schedule.id}: removed {unscheduled_count} unscheduled_tasks"
+                    )
+
+            if updated_count > 0:
+                # Commit all changes
+                session.commit()
+                logger.info(f"Successfully updated {updated_count} schedule records")
+            else:
+                logger.info("No schedules found with unscheduled_tasks to remove")
+
+            # Verify the changes
+            logger.info("Verifying migration results...")
+            remaining_schedules_with_unscheduled = session.exec(select(Schedule)).all()
+
+            remaining_count = 0
+            for schedule in remaining_schedules_with_unscheduled:
+                if (
+                    schedule.plan_json
+                    and isinstance(schedule.plan_json, dict)
+                    and "unscheduled_tasks" in schedule.plan_json
+                ):
+                    remaining_count += 1
+
+            if remaining_count == 0:
+                logger.info(
+                    "✅ Migration completed successfully - no unscheduled_tasks found in any schedules"
+                )
+            else:
+                logger.error(
+                    f"❌ Migration incomplete - {remaining_count} schedules still contain unscheduled_tasks"
+                )
+                return False
+
+    except Exception as e:
+        logger.error(f"Migration failed: {e}")
+        logger.error(
+            "You can restore from backup using DataBackupManager.restore_backup()"
+        )
+        return False
+
+    return True
+
+
+def main():
+    """Main function to run the migration."""
+    logger.info("=== Remove unscheduled_tasks from schedules migration ===")
+    logger.info(
+        "This migration removes unscheduled_tasks from existing schedule records"
+    )
+    logger.info("Addressing Issue #141: unassigned schedulesの削除")
+
+    success = remove_unscheduled_tasks_from_schedules()
+
+    if success:
+        logger.info("✅ Migration completed successfully")
+        sys.exit(0)
+    else:
+        logger.error("❌ Migration failed")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/api/src/taskagent_api/routers/scheduler.py
+++ b/apps/api/src/taskagent_api/routers/scheduler.py
@@ -1503,6 +1503,7 @@ async def save_daily_schedule(
         ).first()
 
         # Prepare schedule data for storage
+        # Note: unscheduled_tasks are intentionally not stored in database (Issue #141)
         plan_data = {
             "success": schedule_data.success,
             "assignments": [
@@ -1519,19 +1520,6 @@ async def save_daily_schedule(
                     "slot_kind": a.slot_kind,
                 }
                 for a in schedule_data.assignments
-            ],
-            "unscheduled_tasks": [
-                {
-                    "id": t.id,
-                    "title": t.title,
-                    "estimate_hours": t.estimate_hours,
-                    "priority": t.priority,
-                    "kind": t.kind,
-                    "due_date": t.due_date.isoformat() if t.due_date else None,
-                    "goal_id": t.goal_id,
-                    "project_id": t.project_id,
-                }
-                for t in schedule_data.unscheduled_tasks
             ],
             "total_scheduled_hours": schedule_data.total_scheduled_hours,
             "optimization_status": schedule_data.optimization_status,


### PR DESCRIPTION
## Summary

- Remove `unscheduled_tasks` from database storage in `save_daily_schedule` function
- Create migration script to clean up existing database records with `unscheduled_tasks`
- Add comprehensive test to verify `unscheduled_tasks` are not stored in database
- Maintain API response backward compatibility

## Changes Made

### Backend Changes
- **apps/api/src/taskagent_api/routers/scheduler.py**:
  - Modified `save_daily_schedule` to exclude `unscheduled_tasks` from `plan_data` 
  - Added comment referencing Issue #141
  - Maintains API response compatibility (still returns `unscheduled_tasks` in response)

### Migration Script
- **apps/api/src/taskagent_api/migrations/remove_unscheduled_tasks_from_schedules.py**:
  - Safe migration script with automatic backup creation
  - Removes `unscheduled_tasks` from existing schedule records
  - Comprehensive logging and verification
  - Follows established migration patterns with DataBackupManager

### Tests  
- **apps/api/tests/test_scheduler.py**:
  - Added `test_save_daily_schedule_unscheduled_tasks_not_stored` test
  - Verifies `unscheduled_tasks` are excluded from database storage
  - Maintains existing test coverage for API responses
  - Proper dependency mocking and cleanup

## Technical Details

**Issue**: OR-Tools solver was generating and storing large amounts of unassigned schedule data that served no purpose after Issue #85 hid them from the UI.

**Solution**: Remove `unscheduled_tasks` from database storage while maintaining API response compatibility for any existing integrations.

**Safety**: Migration script creates automatic backups and includes verification steps.

## Test Plan

- [x] All existing scheduler tests pass  
- [x] New test verifies `unscheduled_tasks` exclusion from database
- [x] API responses still include `unscheduled_tasks` field for compatibility
- [x] Migration script tested with backup/restore functionality
- [x] Code passes ruff, mypy, and formatting checks

This resolves Issue #141 by removing unnecessary unassigned schedule data from database storage while maintaining API compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)