### PR TITLE
fix: Fix user registration email redirect URL issue (Issue #142)

### DIFF
--- a/SUPABASE_SETTINGS.md
+++ b/SUPABASE_SETTINGS.md
@@ -1,0 +1,93 @@
+# Supabase Settings for TaskAgent
+
+This document outlines the required Supabase configuration for proper user authentication and email verification.
+
+## Required Supabase Dashboard Settings
+
+### 1. Authentication Settings
+
+**Location**: Authentication > Settings
+
+#### Site URL Configuration
+Set the Site URL to your application's URL:
+- **Development**: `http://localhost:3000`
+- **Production**: `https://taskagent-web.vercel.app` (or your actual domain)
+
+#### Redirect URLs
+Add the following URLs to the **Redirect URLs** list:
+- **Development**: `http://localhost:3000/auth/callback`
+- **Production**: `https://taskagent-web.vercel.app/auth/callback`
+
+### 2. Email Template Configuration
+
+**Location**: Authentication > Email Templates
+
+#### Confirm signup template
+The default template should work, but ensure the redirect URL uses the correct variable:
+```html
+<a href="{{ .ConfirmationURL }}">Confirm your email</a>
+```
+
+The `ConfirmationURL` will automatically use the `emailRedirectTo` parameter we set in the `signUp` function.
+
+### 3. Auth Settings Check
+
+**Location**: Authentication > Settings
+
+Ensure the following settings are configured:
+- ✅ **Enable email confirmations**: Should be enabled
+- ✅ **Disable signup**: Should be disabled (to allow new user registrations)
+- ✅ **Enable email change**: Recommended to be enabled
+- ✅ **Enable password recovery**: Recommended to be enabled
+
+### 4. User Management
+
+**Location**: Authentication > Users
+
+After fixing the configuration:
+1. Test user registration with a valid email
+2. Check if the user appears in the Users table with `email_confirmed_at` timestamp after clicking the confirmation link
+
+## Testing Checklist
+
+1. [ ] User can register with a valid email address
+2. [ ] Confirmation email is received with correct redirect URL
+3. [ ] Clicking the confirmation link redirects to `/auth/callback`
+4. [ ] User is successfully redirected to dashboard after confirmation
+5. [ ] User can log in with confirmed credentials
+6. [ ] User cannot log in before email confirmation (if email confirmation is required)
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Invalid login credentials" error for newly registered users**
+   - Ensure email confirmation is complete
+   - Check if user exists in Authentication > Users with `email_confirmed_at` set
+
+2. **Confirmation email shows localhost in production**
+   - Verify `NEXT_PUBLIC_APP_URL` environment variable is set correctly in production
+   - Check that the correct redirect URLs are configured in Supabase dashboard
+
+3. **Email not being sent**
+   - Check Supabase project's email rate limits
+   - Verify email template is not disabled
+   - Check spam folder
+
+### Environment Variables Checklist
+
+Ensure these environment variables are set:
+
+**Development (.env.local):**
+```bash
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+```
+
+**Production (Vercel Environment Variables):**
+```bash
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+NEXT_PUBLIC_APP_URL=https://taskagent-web.vercel.app
+```

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -5,5 +5,8 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY="your-supabase-anon-key"
 # API Configuration
 NEXT_PUBLIC_API_URL="http://localhost:8000"
 
+# Application URL (for Supabase redirects)
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
+
 # Environment
 NEXT_PUBLIC_ENVIRONMENT="development"

--- a/apps/web/src/app/auth/callback/page.tsx
+++ b/apps/web/src/app/auth/callback/page.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { toast } from '@/hooks/use-toast'
+import { Loader2 } from 'lucide-react'
+
+export default function AuthCallbackPage() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const handleAuthCallback = async () => {
+      try {
+        // Get the hash fragment from the URL
+        const hash = window.location.hash
+        if (!hash) {
+          throw new Error('No authentication data found')
+        }
+
+        // Handle the auth callback
+        const { data, error } = await supabase.auth.getSession()
+
+        if (error) {
+          console.error('Authentication callback error:', error)
+          toast({
+            title: '認証に失敗しました',
+            description: error.message || 'メール認証に失敗しました',
+            variant: 'destructive',
+          })
+          router.push('/login')
+          return
+        }
+
+        if (data.session) {
+          toast({
+            title: '認証完了',
+            description: 'メール認証が完了しました。ダッシュボードにリダイレクトしています。',
+          })
+          router.push('/dashboard')
+        } else {
+          // No active session, redirect to login
+          router.push('/login')
+        }
+      } catch (error) {
+        console.error('Authentication callback failed:', error)
+        toast({
+          title: '認証エラー',
+          description: error instanceof Error ? error.message : '認証処理でエラーが発生しました',
+          variant: 'destructive',
+        })
+        router.push('/login')
+      }
+    }
+
+    handleAuthCallback()
+  }, [router])
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <div className="text-center">
+        <Loader2 className="mx-auto h-8 w-8 animate-spin mb-4" />
+        <h1 className="text-xl font-semibold mb-2">認証を処理しています...</h1>
+        <p className="text-gray-600 dark:text-gray-400">
+          少々お待ちください
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -11,6 +11,9 @@ export async function signUp(email: string, password: string) {
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
+    options: {
+      emailRedirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback`
+    }
   })
 
   if (error) throw error


### PR DESCRIPTION
## Summary
- Fixes user registration email redirect URL issue where confirmation emails contained localhost:3000
- Adds proper environment variable configuration for application URL
- Implements email verification callback handling

## Changes Made

### 1. Environment Configuration
- Added `NEXT_PUBLIC_APP_URL` to `.env.example` for proper redirect URL configuration
- Provides clear examples for both development and production environments

### 2. Authentication Flow Improvements  
- Updated `signUp` function in `apps/web/src/lib/auth.ts` to include `emailRedirectTo` option
- Ensures confirmation emails redirect to the correct application URL instead of hardcoded localhost

### 3. Email Verification Callback
- Created new auth callback page at `/auth/callback` to handle email verification redirects
- Provides user feedback during authentication process with loading states
- Proper error handling for authentication failures

### 4. Documentation
- Added comprehensive `SUPABASE_SETTINGS.md` guide for required Supabase dashboard configuration
- Includes testing checklist and troubleshooting guide
- Documents required environment variables and redirect URL settings

### 5. Dependencies
- Installed missing dependencies (`date-fns`, `html2canvas`) to resolve TypeScript errors

## Testing Checklist

- [x] TypeScript compilation passes
- [x] ESLint passes (warnings only, no errors)
- [ ] Manual testing of user registration flow (requires Supabase configuration)
- [ ] Email confirmation redirect works correctly
- [ ] New users can login after email confirmation

## Supabase Configuration Required

**Important**: This fix requires updating Supabase dashboard settings. Please refer to `SUPABASE_SETTINGS.md` for detailed configuration instructions:

1. Update Site URL in Authentication settings
2. Add redirect URLs to allow list  
3. Verify email template configuration
4. Set correct environment variables in production

## Fixes

Closes #142

🤖 Generated with [Claude Code](https://claude.ai/code)