### PR TITLE
Fix task deletion error with proper dependency cleanup (Issue #154)

### DIFF
--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -107,3 +107,27 @@ def test_api_error_format():
     if response.status_code != 500:  # Skip if general exception
         data = response.json()
         assert "detail" in data
+
+
+@patch("taskagent_api.routers.tasks.get_current_user")
+@patch("taskagent_api.routers.tasks.get_session")
+def test_delete_task_endpoint_structure(mock_session, mock_user):
+    """Test that task deletion endpoint is properly structured"""
+    # Mock authenticated user
+    mock_user.return_value = Mock(user_id="87654321-4321-8765-4321-876543218765")
+    mock_session.return_value = Mock()
+
+    # Test DELETE endpoint accessibility with a fake UUID
+    fake_task_id = "12345678-1234-1234-1234-123456789012"
+    response = client.delete(f"/api/tasks/{fake_task_id}")
+
+    # Should reach the endpoint (may fail on business logic but not routing)
+    assert response.status_code in [200, 204, 400, 403, 404, 500]  # Not routing error
+
+
+def test_delete_task_endpoint_invalid_uuid():
+    """Test task deletion endpoint with invalid UUID"""
+    response = client.delete("/api/tasks/invalid-uuid")
+
+    # Should return 422 for invalid UUID format
+    assert response.status_code in [422, 400, 403, 500]

--- a/apps/api/tests/test_task_deletion.py
+++ b/apps/api/tests/test_task_deletion.py
@@ -1,0 +1,253 @@
+"""
+Test cases for task deletion functionality
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from taskagent_api.database import db
+from taskagent_api.models import Task, TaskDependency, Log, Project, Goal
+from taskagent_api.services import TaskService, ProjectService, GoalService
+from conftest import create_test_data
+
+
+class TestTaskDeletion:
+    """Test task deletion with dependencies and logs"""
+
+    @pytest.fixture
+    def setup_test_data(self, session: Session, test_user_id: str):
+        """Set up test data with tasks, dependencies, and logs"""
+        # Create project, goal, and tasks
+        project_service = ProjectService()
+        goal_service = GoalService()
+        task_service = TaskService()
+
+        # Create project
+        from taskagent_api.models import (
+            ProjectCreate,
+            GoalCreate,
+            TaskCreate,
+            LogCreate,
+            UserCreate,
+        )
+        from taskagent_api.services import UserService
+
+        # Create user first
+        user_service = UserService()
+        user_data = UserCreate(email="test@example.com")
+        user_service.create_user(session, user_data, test_user_id)
+
+        project_data = ProjectCreate(
+            title="Test Project", description="Test project for deletion"
+        )
+        project = project_service.create_project(session, project_data, test_user_id)
+
+        # Create goal
+        goal_data = GoalCreate(
+            project_id=project.id,
+            title="Test Goal",
+            description="Test goal for deletion",
+            estimate_hours=10.0,
+        )
+        goal = goal_service.create_goal(session, goal_data, test_user_id)
+
+        # Create tasks
+        task1_data = TaskCreate(
+            goal_id=goal.id,
+            title="Task 1",
+            description="First task",
+            estimate_hours=5.0,
+            status="pending",
+            priority=1,
+        )
+        task1 = task_service.create_task(session, task1_data, test_user_id)
+
+        task2_data = TaskCreate(
+            goal_id=goal.id,
+            title="Task 2",
+            description="Second task",
+            estimate_hours=5.0,
+            status="pending",
+            priority=2,
+        )
+        task2 = task_service.create_task(session, task2_data, test_user_id)
+
+        # Create dependency: task2 depends on task1
+        dependency = task_service.add_task_dependency(
+            session, task2.id, task1.id, test_user_id
+        )
+
+        # Create logs for task1
+        from taskagent_api.services import LogService
+
+        log_service = LogService()
+        log_data = LogCreate(
+            task_id=task1.id, actual_minutes=60, comment="Test work log"
+        )
+        log = log_service.create_log(session, log_data, test_user_id)
+
+        return {
+            "project": project,
+            "goal": goal,
+            "task1": task1,
+            "task2": task2,
+            "dependency": dependency,
+            "log": log,
+        }
+
+    def test_delete_task_without_dependencies(
+        self, session: Session, test_user_id: str
+    ):
+        """Test deleting a task without dependencies"""
+        task_service = TaskService()
+
+        # Create a simple task without dependencies
+        test_data = create_test_data(session, test_user_id)
+        from taskagent_api.models import TaskCreate
+
+        task_data = TaskCreate(
+            goal_id=test_data["goal"].id,
+            title="Simple Task",
+            description="Task without dependencies",
+            estimate_hours=2.0,
+            status="pending",
+            priority=1,
+        )
+        task = task_service.create_task(session, task_data, test_user_id)
+
+        # Delete the task
+        result = task_service.delete_task(session, task.id, test_user_id)
+        assert result is True
+
+        # Verify task is deleted
+        deleted_task = session.get(Task, task.id)
+        assert deleted_task is None
+
+    def test_delete_task_with_dependencies(
+        self, session: Session, test_user_id: str, setup_test_data
+    ):
+        """Test deleting a task that has dependencies"""
+        task_service = TaskService()
+        test_data = setup_test_data
+
+        # Delete task1 (which task2 depends on)
+        result = task_service.delete_task(session, test_data["task1"].id, test_user_id)
+        assert result is True
+
+        # Verify task1 is deleted
+        deleted_task = session.get(Task, test_data["task1"].id)
+        assert deleted_task is None
+
+        # Verify dependency is deleted
+        dependency = session.get(TaskDependency, test_data["dependency"].id)
+        assert dependency is None
+
+        # Verify log is deleted
+        log = session.get(Log, test_data["log"].id)
+        assert log is None
+
+        # Verify task2 still exists
+        task2 = session.get(Task, test_data["task2"].id)
+        assert task2 is not None
+
+    def test_delete_task_that_depends_on_other(
+        self, session: Session, test_user_id: str, setup_test_data
+    ):
+        """Test deleting a task that depends on another task"""
+        task_service = TaskService()
+        test_data = setup_test_data
+
+        # Delete task2 (which depends on task1)
+        result = task_service.delete_task(session, test_data["task2"].id, test_user_id)
+        assert result is True
+
+        # Verify task2 is deleted
+        deleted_task = session.get(Task, test_data["task2"].id)
+        assert deleted_task is None
+
+        # Verify dependency is deleted
+        dependency = session.get(TaskDependency, test_data["dependency"].id)
+        assert dependency is None
+
+        # Verify task1 still exists
+        task1 = session.get(Task, test_data["task1"].id)
+        assert task1 is not None
+
+        # Verify log still exists (belongs to task1)
+        log = session.get(Log, test_data["log"].id)
+        assert log is not None
+
+    def test_delete_task_with_logs(
+        self, session: Session, test_user_id: str, setup_test_data
+    ):
+        """Test deleting a task with associated logs"""
+        task_service = TaskService()
+        test_data = setup_test_data
+
+        # Add more logs to task1
+        from taskagent_api.services import LogService
+        from taskagent_api.models import LogCreate
+
+        log_service = LogService()
+
+        log2_data = LogCreate(
+            task_id=test_data["task1"].id, actual_minutes=30, comment="Second work log"
+        )
+        log2 = log_service.create_log(session, log2_data, test_user_id)
+
+        # Delete task1
+        result = task_service.delete_task(session, test_data["task1"].id, test_user_id)
+        assert result is True
+
+        # Verify all logs are deleted
+        log1 = session.get(Log, test_data["log"].id)
+        assert log1 is None
+
+        log2_check = session.get(Log, log2.id)
+        assert log2_check is None
+
+    def test_delete_nonexistent_task(self, session: Session, test_user_id: str):
+        """Test deleting a non-existent task"""
+        task_service = TaskService()
+
+        from uuid import uuid4
+
+        fake_task_id = uuid4()
+
+        with pytest.raises(
+            Exception
+        ):  # Should raise HTTPException or ResourceNotFoundError
+            task_service.delete_task(session, fake_task_id, test_user_id)
+
+    def test_delete_task_unauthorized(self, session: Session, test_user_id: str):
+        """Test deleting a task with wrong user ID"""
+        task_service = TaskService()
+
+        # Create a task
+        test_data = create_test_data(session, test_user_id)
+        from taskagent_api.models import TaskCreate
+
+        task_data = TaskCreate(
+            goal_id=test_data["goal"].id,
+            title="Test Task",
+            description="Task for unauthorized test",
+            estimate_hours=2.0,
+            status="pending",
+            priority=1,
+        )
+        task = task_service.create_task(session, task_data, test_user_id)
+
+        # Try to delete with different user ID
+        from uuid import uuid4
+
+        wrong_user_id = str(uuid4())
+
+        with pytest.raises(
+            Exception
+        ):  # Should raise HTTPException or ResourceNotFoundError
+            task_service.delete_task(session, task.id, wrong_user_id)
+
+        # Verify task still exists
+        existing_task = session.get(Task, task.id)
+        assert existing_task is not None


### PR DESCRIPTION
## Summary
- Fixed the task deletion error (500 Internal Server Error) that occurred when deleting tasks with dependencies
- Modified `TaskService.delete_task` to properly clean up task dependencies and logs before deleting the task itself
- Ensured compatibility with both SQLite and PostgreSQL databases

## Changes Made
- **TaskService.delete_task method improvement**: Added explicit deletion of task dependencies and logs before deleting the task
- **UUID generation fix**: Added manual UUID generation for TaskDependency to resolve SQLite compatibility issues
- **Comprehensive test coverage**: Added test cases for various task deletion scenarios
- **API endpoint testing**: Added tests for task deletion endpoints

## Test Cases Added
- Task deletion without dependencies
- Task deletion with dependencies (both as dependency and dependent task)
- Task deletion with associated logs
- Error handling for non-existent tasks
- Authorization error handling

## Technical Details
The root cause was that when deleting a task that had dependencies or was referenced by other tasks, the database foreign key constraints prevented the deletion, causing a 500 error. This fix ensures:

1. All dependencies where the task is referenced are deleted first
2. All dependencies that the task depends on are deleted
3. All associated logs are cleaned up
4. Finally, the task itself is deleted

This approach works consistently across different database engines and doesn't rely on CASCADE DELETE behavior.

## Testing
- ✅ All new tests pass
- ✅ Existing tests continue to pass
- ✅ Manual testing confirmed fix resolves the reported issue

Fixes #154

🤖 Generated with [Claude Code](https://claude.ai/code)