### PR TITLE
Fix: Remove unused dashboard elements (#161)

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -238,42 +238,6 @@ export default function DashboardPage() {
           </TimelineErrorBoundary>
         </div>
 
-        {/* Recent Projects */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          <Card>
-            <CardHeader>
-              <CardTitle>最近のプロジェクト</CardTitle>
-              <CardDescription>
-                進行中のプロジェクト一覧
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="text-center py-8 text-gray-500">
-                <p>まだプロジェクトがありません</p>
-                <Button className="mt-4" onClick={() => router.push('/projects')}>
-                  最初のプロジェクトを作成
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>今日のタスク</CardTitle>
-              <CardDescription>
-                本日予定されているタスク
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="text-center py-8 text-gray-500">
-                <p>本日のタスクはありません</p>
-                <Button className="mt-4">
-                  タスクを追加
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
       </main>
     </div>
   )


### PR DESCRIPTION
## Summary
- Remove unused "最近のプロジェクト" (Recent Projects) section from dashboard
- Remove unused "今日のタスク" (Today's Tasks) section from dashboard  
- These elements were displaying dummy content and were not functional

## Changes
- Clean up dashboard UI by removing non-functional elements
- Improve user experience by removing misleading placeholder content
- No backend changes required as these were frontend-only dummy elements

## Test plan
- [x] Verify TypeScript compilation passes
- [x] Verify ESLint check passes with no new errors
- [x] Confirm dashboard page renders correctly without removed elements
- [x] Manual testing: Dashboard page should no longer show "Recent Projects" and "Today's Tasks" sections

Resolves #161

🤖 Generated with [Claude Code](https://claude.ai/code)