### PR TITLE
fix: Make schedule history tasks scrollable to show all tasks

### DIFF
--- a/apps/web/src/app/schedule-history/page.tsx
+++ b/apps/web/src/app/schedule-history/page.tsx
@@ -211,14 +211,13 @@ export default function ScheduleHistoryPage() {
                   {/* Note: Unscheduled tasks count is intentionally not displayed per issue #85 */}
                 </div>
 
-                {/* Task Assignments Preview */}
+                {/* Task Assignments */}
                 {schedule.plan_json.assignments.length > 0 && (
                   <div>
                     <h4 className="font-semibold mb-2">スケジュール済みタスク</h4>
-                    <div className="space-y-2">
+                    <div className="space-y-2 max-h-80 overflow-y-auto border border-gray-200 rounded-lg p-2">
                       {schedule.plan_json.assignments
                         .sort((a, b) => a.start_time.localeCompare(b.start_time))
-                        .slice(0, 3)
                         .map((assignment, index) => (
                         <div key={index} className="flex items-center justify-between p-2 bg-gray-50 rounded">
                           <div className="flex items-center gap-3">
@@ -258,11 +257,6 @@ export default function ScheduleHistoryPage() {
                           </div>
                         </div>
                       ))}
-                      {schedule.plan_json.assignments.length > 3 && (
-                        <div className="text-center text-sm text-gray-500 pt-2">
-                          他 {schedule.plan_json.assignments.length - 3} 個のタスク
-                        </div>
-                      )}
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- Fixed issue #163 where schedule history page only showed max 3 tasks per day
- Changed to display all tasks in a scrollable container
- Improved visual layout with borders and proper spacing

## Changes Made
- Removed `.slice(0, 3)` limit on task assignments display
- Added scrollable container with `max-h-80 overflow-y-auto`  
- Removed "other N tasks" message since all tasks are now shown
- Added border and padding for better visual organization

## Test Plan
- [x] TypeScript type check passes
- [x] ESLint passes (no new warnings)
- [x] Next.js build completes successfully
- [x] Visual layout works correctly with scrolling when many tasks exist

Closes #163

🤖 Generated with [Claude Code](https://claude.ai/code)