### PR TITLE
Fix goal creation authentication error in production (issue #172)

### DIFF
--- a/apps/api/src/humancompiler_api/config.py
+++ b/apps/api/src/humancompiler_api/config.py
@@ -130,6 +130,7 @@ class Settings(BaseSettings):
                 expanded_origins.extend(
                     [
                         "https://humancompiler.vercel.app",
+                        "https://human-compiler.vercel.app",  # Add hyphenated domain
                         "https://humancompiler-five.vercel.app",
                         # Allow humancompiler prefixed domains only for security
                     ]

--- a/apps/api/src/humancompiler_api/routers/goals.py
+++ b/apps/api/src/humancompiler_api/routers/goals.py
@@ -31,6 +31,15 @@ def get_session():
         404: {"model": ErrorResponse, "description": "Project not found"},
     },
 )
+@router.post(
+    "",  # Handle requests without trailing slash
+    response_model=GoalResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        404: {"model": ErrorResponse, "description": "Project not found"},
+    },
+    include_in_schema=False,  # Don't duplicate in OpenAPI schema
+)
 async def create_goal(
     goal_data: GoalCreate,
     session: Annotated[Session, Depends(get_session)],
@@ -69,6 +78,14 @@ async def get_goals_by_project(
         404: {"model": ErrorResponse, "description": "Goal not found"},
     },
 )
+@router.get(
+    "/{goal_id}/",  # Handle requests with trailing slash
+    response_model=GoalResponse,
+    responses={
+        404: {"model": ErrorResponse, "description": "Goal not found"},
+    },
+    include_in_schema=False,  # Don't duplicate in OpenAPI schema
+)
 async def get_goal(
     goal_id: str,
     session: Annotated[Session, Depends(get_session)],
@@ -95,6 +112,15 @@ async def get_goal(
         404: {"model": ErrorResponse, "description": "Goal not found"},
         422: {"model": ErrorResponse, "description": "Invalid status transition"},
     },
+)
+@router.put(
+    "/{goal_id}/",  # Handle requests with trailing slash
+    response_model=GoalResponse,
+    responses={
+        404: {"model": ErrorResponse, "description": "Goal not found"},
+        422: {"model": ErrorResponse, "description": "Invalid status transition"},
+    },
+    include_in_schema=False,  # Don't duplicate in OpenAPI schema
 )
 async def update_goal(
     goal_id: str,
@@ -147,6 +173,14 @@ async def update_goal(
     responses={
         404: {"model": ErrorResponse, "description": "Goal not found"},
     },
+)
+@router.delete(
+    "/{goal_id}/",  # Handle requests with trailing slash
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        404: {"model": ErrorResponse, "description": "Goal not found"},
+    },
+    include_in_schema=False,  # Don't duplicate in OpenAPI schema
 )
 async def delete_goal(
     goal_id: str,


### PR DESCRIPTION
## Summary
- Fix CORS configuration to explicitly allow `human-compiler.vercel.app` domain
- Add trailing slash handling to all goals API endpoints for consistency
- Resolve 403 authentication error when creating goals in production

## Root Cause Analysis
The issue occurred due to two problems:
1. **CORS Configuration**: The static origins list only included `humancompiler.vercel.app` but not `human-compiler.vercel.app` (with hyphen)
2. **Trailing Slash Mismatch**: Goals router only handled `/` endpoints while projects router handled both `/` and `""` endpoints

## Changes
1. **apps/api/src/humancompiler_api/config.py**:
   - Added `https://human-compiler.vercel.app` to CORS static origins list

2. **apps/api/src/humancompiler_api/routers/goals.py**:
   - Added trailing slash variants for all endpoints (GET, POST, PUT, DELETE)
   - Consistent with projects router implementation

## Test Plan
- [x] Linting and type checking passes
- [x] All tests pass
- [ ] Verify goal creation works in production environment

Fixes #172

🤖 Generated with [Claude Code](https://claude.ai/code)