### PR TITLE
feat: Add work log editing and deletion functionality (#192)

### DIFF
--- a/apps/web/src/components/logs/log-delete-dialog.tsx
+++ b/apps/web/src/components/logs/log-delete-dialog.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { log as logger } from '@/lib/logger';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { useDeleteLog } from '@/hooks/use-logs-query';
+import { toast } from '@/hooks/use-toast';
+import type { Log } from '@/types/log';
+
+interface LogDeleteDialogProps {
+  log: Log;
+  children: React.ReactNode;
+}
+
+export function LogDeleteDialog({ log, children }: LogDeleteDialogProps) {
+  const [open, setOpen] = useState(false);
+  const deleteLogMutation = useDeleteLog();
+
+  const formatDuration = (minutes: number) => {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    if (hours === 0) {
+      return `${mins}分`;
+    }
+    if (mins === 0) {
+      return `${hours}時間`;
+    }
+    return `${hours}時間${mins}分`;
+  };
+
+  const handleDelete = async () => {
+    try {
+      await deleteLogMutation.mutateAsync(log.id);
+
+      toast({
+        title: '作業ログを削除しました',
+        description: `${formatDuration(log.actual_minutes)}の記録が正常に削除されました。`,
+      });
+
+      setOpen(false);
+    } catch (error) {
+      logger.error('Failed to delete log', error, {
+        component: 'LogDeleteDialog',
+        logId: log.id,
+        action: 'deleteLog'
+      });
+
+      toast({
+        title: 'エラー',
+        description: '作業ログの削除に失敗しました。再試行してください。',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {children}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>作業ログの削除</DialogTitle>
+          <DialogDescription className="space-y-2">
+            <div>本当にこの作業ログを削除しますか？この操作は取り消せません。</div>
+            <div className="font-medium text-foreground">
+              削除される記録: {formatDuration(log.actual_minutes)}
+              {log.comment && (
+                <div className="text-sm text-muted-foreground mt-1">
+                  コメント: {log.comment}
+                </div>
+              )}
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex justify-end space-x-2 pt-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={deleteLogMutation.isPending}
+          >
+            キャンセル
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={deleteLogMutation.isPending}
+          >
+            {deleteLogMutation.isPending ? '削除中...' : '削除'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/logs/log-edit-dialog.tsx
+++ b/apps/web/src/components/logs/log-edit-dialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useUpdateLog } from "@/hooks/use-logs-query";
+import { showErrorToast } from "@/lib/error-toast";
+import { useToast } from "@/hooks/use-toast";
+import type { Log, LogUpdate } from "@/types/log";
+import { sanitizeInput, isInputSafe } from "@/lib/sanitize";
+
+const logEditFormSchema = z.object({
+  actual_hours: z.number().min(0.1, "実作業時間は0.1時間以上である必要があります"),
+  comment: z.string().optional().refine(
+    (value) => !value || isInputSafe(value),
+    { message: "コメントに不正な内容が含まれています" }
+  ),
+});
+
+type LogEditFormData = z.infer<typeof logEditFormSchema>;
+
+interface LogEditDialogProps {
+  log: Log;
+  trigger?: React.ReactNode;
+}
+
+export function LogEditDialog({ log, trigger }: LogEditDialogProps) {
+  const [open, setOpen] = useState(false);
+  const { toast } = useToast();
+  const updateLogMutation = useUpdateLog();
+
+  const form = useForm<LogEditFormData>({
+    resolver: zodResolver(logEditFormSchema),
+    defaultValues: {
+      actual_hours: log.actual_minutes / 60, // Convert minutes to hours
+      comment: log.comment || "",
+    },
+  });
+
+  const onSubmit = (data: LogEditFormData) => {
+    const updateData: LogUpdate = {
+      actual_minutes: Math.round(data.actual_hours * 60), // Convert hours to minutes for API
+      comment: data.comment ? sanitizeInput(data.comment) : undefined,
+    };
+
+    updateLogMutation.mutate(
+      { id: log.id, data: updateData },
+      {
+        onSuccess: () => {
+          toast({
+            title: "作業ログを更新しました",
+            description: "作業時間とコメントが正常に更新されました。",
+          });
+          setOpen(false);
+        },
+        onError: (error) => {
+          showErrorToast(error, { title: "作業ログの更新に失敗しました" });
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {trigger || (
+          <Button variant="outline" size="sm">
+            編集
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>作業ログの編集</DialogTitle>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="actual_hours"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>実作業時間（時間）</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      step="0.1"
+                      min="0.1"
+                      max="24"
+                      {...field}
+                      onChange={(e) => {
+                        const value = e.target.value;
+                        field.onChange(value === "" ? undefined : parseFloat(value) || undefined);
+                      }}
+                      placeholder="例: 2.5（2時間30分）"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="comment"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>コメント（任意）</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder="作業内容や感想を記録..."
+                      rows={3}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="flex justify-end space-x-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpen(false)}
+              >
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={updateLogMutation.isPending}>
+                {updateLogMutation.isPending ? "更新中..." : "更新"}
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/tasks/task-logs-memo-panel.tsx
+++ b/apps/web/src/components/tasks/task-logs-memo-panel.tsx
@@ -7,7 +7,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
-import { ChevronDown, ChevronRight, Clock, MessageSquare, Edit, Save, X } from 'lucide-react';
+import { ChevronDown, ChevronRight, Clock, MessageSquare, Edit, Save, X, Trash2 } from 'lucide-react';
 import { useLogsByTask } from '@/hooks/use-logs-query';
 import { useUpdateTask } from '@/hooks/use-tasks-query';
 import { useToast } from '@/hooks/use-toast';
@@ -15,6 +15,8 @@ import { sanitizeText } from '@/lib/security';
 import type { Task } from '@/types/task';
 import { log } from '@/lib/logger';
 import { formatJSTDateTime } from '@/lib/date-utils';
+import { LogEditDialog } from '@/components/logs/log-edit-dialog';
+import { LogDeleteDialog } from '@/components/logs/log-delete-dialog';
 
 interface TaskLogsMemoPanelProps {
   task: Task;
@@ -210,6 +212,33 @@ export function TaskLogsMemoPanel({ task }: TaskLogsMemoPanelProps) {
                             }}
                           />
                         )}
+                      </div>
+                      <div className="flex items-center gap-1 ml-2">
+                        <LogEditDialog
+                          log={logEntry}
+                          trigger={
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 w-8 p-0 text-gray-500 hover:text-blue-600"
+                            >
+                              <Edit className="h-4 w-4" />
+                              <span className="sr-only">ログを編集</span>
+                            </Button>
+                          }
+                        />
+                        <LogDeleteDialog
+                          log={logEntry}
+                        >
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 p-0 text-gray-500 hover:text-red-600"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                            <span className="sr-only">ログを削除</span>
+                          </Button>
+                        </LogDeleteDialog>
                       </div>
                     </div>
                   ))}


### PR DESCRIPTION
## Summary
- Issue #192の作業ログ削除・編集機能を実装
- 各ゴールのタスク一覧ページで作業ログを削除・編集するインターフェースを追加

## Changes
- **LogEditDialog**: 作業ログの編集ダイアログコンポーネント
- **LogDeleteDialog**: 作業ログの削除確認ダイアログコンポーネント  
- **TaskLogsMemoPanel**: 各ログエントリーに編集・削除ボタンを追加

## Technical Details
- 既存のバリデーションとエラーハンドリングパターンを継承
- 時間フォーマット変換（UI: 時間 ↔ API: 分）をサポート
- React Query による適切なキャッシュ無効化
- アクセシビリティ対応（sr-only テキスト）

## Test plan
- [x] TypeScript型チェックが通る
- [x] ESLintチェックが通る
- [x] 編集ダイアログが正常に表示・動作する
- [x] 削除ダイアログが確認メッセージと共に表示・動作する
- [x] 編集・削除ボタンが各ログエントリーに表示される

🤖 Generated with [Claude Code](https://claude.ai/code)