### PR TITLE
Reduce fly.io memory allocation from 1024MB to 512MB

### DIFF
--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -37,7 +37,7 @@ primary_region = "nrt"  # Tokyo region for lower latency
 [vm]
   cpu_kind = "shared"
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 512
 
 [deploy]
   release_command = "python -c 'print(\"Starting HumanCompiler API...\")'"


### PR DESCRIPTION
## Summary
- Downgrade fly.io machine memory from **1024MB to 512MB**
- Reduce monthly costs from ~$7.76 to ~$3.88 (50% reduction)

## Changes
- Update `apps/api/fly.toml` memory configuration

## Cost Impact
| Before | After | Savings |
|--------|-------|---------|
| 1024MB (~$7.76/month) | 512MB (~$3.88/month) | ~$3.88/month (50%) |

## Test Plan
- [ ] CI deploy succeeds with new memory configuration
- [ ] API health check passes after deployment
- [ ] Monitor API performance and memory usage after deployment
- [ ] Verify no OOM (out of memory) errors in fly.io logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)