### PR TITLE
refactor(hooks): Eliminate duplication with factory pattern #208

### DIFF
--- a/apps/web/src/hooks/__tests__/use-goals.test.ts
+++ b/apps/web/src/hooks/__tests__/use-goals.test.ts
@@ -20,6 +20,15 @@ jest.mock('@/lib/api', () => ({
   },
 }))
 
+// Mock logger
+jest.mock('@/lib/logger', () => ({
+  log: {
+    component: jest.fn(),
+    error: jest.fn(),
+    userAction: jest.fn(),
+  },
+}))
+
 // Import after mocks
 import { useGoals } from '../use-goals'
 

--- a/apps/web/src/hooks/utils/__tests__/hook-error-handler.test.ts
+++ b/apps/web/src/hooks/utils/__tests__/hook-error-handler.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @jest-environment jsdom
+ */
+import { handleHookError } from '../hook-error-handler';
+
+// Mock logger
+const mockLogError = jest.fn();
+jest.mock('@/lib/logger', () => ({
+  log: {
+    error: (...args: unknown[]) => mockLogError(...args),
+  },
+}));
+
+describe('handleHookError', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('error message extraction', () => {
+    it('should extract message from Error instance', () => {
+      const error = new Error('Test error message');
+      const result = handleHookError(error, 'useTest', 'fetch');
+
+      expect(result).toBe('Test error message');
+    });
+
+    it('should use default message for non-Error values', () => {
+      const result = handleHookError('string error', 'useTest', 'fetch');
+
+      expect(result).toBe('Failed to fetch');
+    });
+
+    it('should use custom default message when provided', () => {
+      const result = handleHookError(
+        'string error',
+        'useTest',
+        'fetch',
+        {},
+        'Custom error message'
+      );
+
+      expect(result).toBe('Custom error message');
+    });
+
+    it('should handle null error', () => {
+      const result = handleHookError(null, 'useTest', 'fetch');
+
+      expect(result).toBe('Failed to fetch');
+    });
+
+    it('should handle undefined error', () => {
+      const result = handleHookError(undefined, 'useTest', 'fetch');
+
+      expect(result).toBe('Failed to fetch');
+    });
+  });
+
+  describe('logging', () => {
+    it('should log error with correct message format', () => {
+      const error = new Error('Test error');
+      handleHookError(error, 'useTest', 'fetch data');
+
+      expect(mockLogError).toHaveBeenCalledWith(
+        'Failed to fetch data',
+        error,
+        expect.objectContaining({
+          component: 'useTest',
+          action: 'fetch_data_error',
+        })
+      );
+    });
+
+    it('should include additional context in log', () => {
+      const error = new Error('Test error');
+      handleHookError(error, 'useTest', 'create', { taskId: '123', goalId: 'goal-1' });
+
+      expect(mockLogError).toHaveBeenCalledWith(
+        'Failed to create',
+        error,
+        expect.objectContaining({
+          component: 'useTest',
+          action: 'create_error',
+          taskId: '123',
+          goalId: 'goal-1',
+        })
+      );
+    });
+
+    it('should convert action with spaces to underscores in action field', () => {
+      const error = new Error('Test error');
+      handleHookError(error, 'useTasks', 'fetch tasks');
+
+      expect(mockLogError).toHaveBeenCalledWith(
+        'Failed to fetch tasks',
+        error,
+        expect.objectContaining({
+          action: 'fetch_tasks_error',
+        })
+      );
+    });
+
+    it('should log non-Error values', () => {
+      const errorValue = { code: 500, message: 'Server error' };
+      handleHookError(errorValue, 'useTest', 'fetch');
+
+      expect(mockLogError).toHaveBeenCalledWith(
+        'Failed to fetch',
+        errorValue,
+        expect.objectContaining({
+          component: 'useTest',
+        })
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty hook name', () => {
+      const error = new Error('Test error');
+      const result = handleHookError(error, '', 'fetch');
+
+      expect(result).toBe('Test error');
+      expect(mockLogError).toHaveBeenCalledWith(
+        'Failed to fetch',
+        error,
+        expect.objectContaining({
+          component: '',
+        })
+      );
+    });
+
+    it('should handle empty action', () => {
+      const error = new Error('Test error');
+      const result = handleHookError(error, 'useTest', '');
+
+      expect(result).toBe('Test error');
+      expect(mockLogError).toHaveBeenCalledWith(
+        'Failed to ',
+        error,
+        expect.objectContaining({
+          action: '_error',
+        })
+      );
+    });
+  });
+});

--- a/apps/web/src/hooks/utils/hook-error-handler.ts
+++ b/apps/web/src/hooks/utils/hook-error-handler.ts
@@ -1,0 +1,31 @@
+import { log } from '@/lib/logger';
+
+/**
+ * Centralized error handling for React hooks.
+ * Provides consistent error message extraction and logging.
+ *
+ * @param err - The caught error
+ * @param hookName - Name of the hook for logging context
+ * @param action - The action being performed (e.g., "fetch tasks", "create task")
+ * @param context - Additional context for logging
+ * @param defaultMessage - Default message if error doesn't have a message
+ * @returns The error message string for state
+ */
+export function handleHookError(
+  err: unknown,
+  hookName: string,
+  action: string,
+  context: Record<string, unknown> = {},
+  defaultMessage?: string
+): string {
+  const errorMessage =
+    err instanceof Error ? err.message : defaultMessage || `Failed to ${action}`;
+
+  log.error(`Failed to ${action}`, err, {
+    component: hookName,
+    action: `${action.replace(/\s+/g, '_')}_error`,
+    ...context,
+  });
+
+  return errorMessage;
+}


### PR DESCRIPTION
## Summary
- Introduce `createTasksHook` factory function to eliminate 95%+ code duplication between `useTasks` and `useProjectTasks`
- Add `handleHookError` utility for consistent error handling and logging across all hooks
- Standardize logging in `use-goals.ts` (previously had no logging)
- Add missing logging in `use-projects.ts` for update/delete operations

## Changes
### New Files
- `apps/web/src/hooks/utils/hook-error-handler.ts` - Centralized error handling utility
- `apps/web/src/hooks/utils/__tests__/hook-error-handler.test.ts` - Tests for error handler

### Modified Files
- `apps/web/src/hooks/use-tasks.ts` - Factory pattern refactoring
- `apps/web/src/hooks/use-goals.ts` - Added logging
- `apps/web/src/hooks/use-projects.ts` - Standardized logging
- `apps/web/src/hooks/__tests__/use-goals.test.ts` - Added logger mock

## Test plan
- [x] All existing hooks tests pass
- [x] New hook-error-handler tests pass
- [x] TypeScript compilation passes
- [ ] Manual testing of task/goal/project CRUD operations

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)