### PR TITLE
chore: Migrate claude-code-action from beta to v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,9 +20,9 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -33,18 +33,18 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Allow bots to trigger the action
           allowed_bots: "*"
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Optional: Specify model via claude_args (defaults to Claude Sonnet 4)
+          # claude_args: "--model claude-opus-4-1-20250805"
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Prompt for automated review (no @claude mention needed)
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
@@ -58,7 +58,7 @@ jobs:
           use_sticky_comment: true
 
           # Optional: Customize review based on file types
-          # direct_prompt: |
+          # prompt: |
           #   Review this PR focusing on:
           #   - For TypeScript files: Type safety and proper interface usage
           #   - For API endpoints: Security, input validation, and error handling
@@ -66,13 +66,13 @@ jobs:
           #   - For tests: Coverage, edge cases, and test quality
 
           # Optional: Different prompts for different authors
-          # direct_prompt: |
+          # prompt: |
           #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
           #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
 
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(pnpm run test),Bash(pnpm run lint),Bash(pnpm run typecheck)"
+          # Optional: Add specific tools for running tests or linting via claude_args
+          # claude_args: "--allowed-tools Bash(pnpm run test) Bash(pnpm run lint) Bash(pnpm run typecheck)"
 
           # Optional: Skip review for certain conditions
           # if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,16 +32,12 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Optional: Specify model via claude_args (defaults to Claude Sonnet 4)
+          # claude_args: "--model claude-opus-4-1-20250805"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
@@ -49,14 +45,11 @@ jobs:
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
 
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(pnpm install),Bash(pnpm run build),Bash(pnpm run test:*),Bash(pnpm run lint:*)"
+          # Optional: Allow Claude to run specific commands via claude_args
+          # claude_args: "--allowed-tools Bash(pnpm install) Bash(pnpm run build) Bash(pnpm run test:*) Bash(pnpm run lint:*)"
 
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
+          # Optional: Add custom instructions for Claude via claude_args
+          # claude_args: "--system-prompt 'Follow our coding standards. Ensure all new code has tests.'"
 
           # Optional: Custom environment variables for Claude
           # claude_env: |


### PR DESCRIPTION
## Summary
- Update anthropics/claude-code-action from @beta to @v1
- Change permissions from read to write (required for v1)
- Replace deprecated `direct_prompt` with `prompt`
- Update comments to use `claude_args` format for model/tools config
- Remove deprecated `additional_permissions` input

## Breaking changes in v1
- `direct_prompt` -> `prompt`
- `model`/`allowed_tools`/`custom_instructions` -> `claude_args`

## References
- [claude-code-action releases](https://github.com/anthropics/claude-code-action/releases)
- [Migration guide](https://github.com/anthropics/claude-code-action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)