### PR TITLE
Document scheduler integration boundary

### DIFF
--- a/apps/api/src/humancompiler_api/routers/scheduler.py
+++ b/apps/api/src/humancompiler_api/routers/scheduler.py
@@ -1247,7 +1247,9 @@ async def create_daily_schedule(
                 id=task_id_str,
                 title=db_task.title,
                 estimate_hours=estimate_hours,
-                priority=3,  # Default priority - could be enhanced
+                # TODO(human-scheduler): pass db_task.priority instead of the
+                # default once the adapter contract is covered by tests.
+                priority=3,
                 due_date=getattr(db_task, "due_date", None),
                 kind=task_kind,
                 goal_id=goal_id_str,
@@ -1281,6 +1283,8 @@ async def create_daily_schedule(
                 id=str(db_task.id),  # Convert UUID to string
                 title=db_task.title,
                 estimate_hours=remaining_hours,  # Now shows remaining hours instead of estimate
+                # TODO(human-scheduler): keep this in sync with the priority
+                # sent to the optimizer when regular task priority is enabled.
                 priority=3,
                 kind=task_kind.value,
                 due_date=getattr(db_task, "due_date", None),

--- a/docs/dev/scheduler-integration-notes.md
+++ b/docs/dev/scheduler-integration-notes.md
@@ -1,0 +1,54 @@
+# Scheduler Integration Notes
+
+HumanCompiler currently has two scheduler-related layers:
+
+- `humancompiler_optimizer.daily` / `weekly`: pure optimization models and
+  OR-Tools solver entry points. These modules do not depend on database or API
+  objects.
+- `humancompiler_api.routers.scheduler`: FastAPI adapter code. It fetches user
+  data, maps database models to optimizer inputs, applies ownership checks, and
+  converts solver results back to API responses used by the web app.
+
+The external `Scheduler` repository should grow a HumanCompiler-oriented
+experimental API first. HumanCompiler should continue to keep database models
+behind adapter code and pass only plain scheduling inputs into that package.
+
+## Daily API Shape To Preserve
+
+`POST /api/schedule/daily` should continue returning:
+
+- `success`
+- `date`
+- `assignments`
+- `unscheduled_tasks`
+- `total_scheduled_hours`
+- `optimization_status`
+- `solve_time_seconds`
+- `objective_value`
+- `generated_at`
+
+Each assignment should continue including the task identity, title, goal and
+project IDs, slot index, assigned start time, duration, slot window, slot kind,
+and `is_fixed`.
+
+Each unscheduled task should continue including ID, title, remaining estimate,
+priority, kind, due date, goal ID, and project ID.
+
+## Current Gaps
+
+- Daily scheduling currently returns slot assignments rather than true timeline
+  blocks. Multiple tasks assigned to the same slot can share the same
+  `start_time`.
+- Regular task priority is not passed through to the daily optimizer yet. The
+  adapter currently uses priority `3` for regular tasks while quick tasks pass
+  their real priority.
+- Deadline scoring is task-level for the target date and does not yet strongly
+  explain why a task was placed earlier or later within the day.
+- The daily response does not include unscheduled reasons or score breakdowns.
+
+## Phase 0 Boundary
+
+For the first integration phase, HumanCompiler should not import the external
+`Scheduler` package. The immediate goal is to document the boundary and keep
+the current API stable while the external package develops fixtures, review
+commands, and a more human-like daily planning model.


### PR DESCRIPTION
## Summary
- Add development notes describing the current scheduler layers and API response shape to preserve.
- Document known daily scheduling gaps before external scheduler integration.
- Mark the current regular-task priority passthrough gap with TODO comments.

## Impact
No runtime behavior changes. This keeps the existing scheduler API stable while the external Scheduler package grows the HumanCompiler-specific contract.

## Validation
- `uv run --no-sync pytest tests/test_humancompiler_optimizer.py`