### PR TITLE
Sync scheduler priority integration docs

### DIFF
--- a/docs/dev/scheduler-integration-notes.md
+++ b/docs/dev/scheduler-integration-notes.md
@@ -39,9 +39,10 @@ priority, kind, due date, goal ID, and project ID.
 - Daily scheduling currently returns slot assignments rather than true timeline
   blocks. Multiple tasks assigned to the same slot can share the same
   `start_time`.
-- Regular task priority is not passed through to the daily optimizer yet. The
-  adapter currently uses priority `3` for regular tasks while quick tasks pass
-  their real priority.
+- Regular task priority is now passed through to the daily optimizer and to
+  unscheduled task response data. The remaining priority work is manual app
+  validation that same-condition priority `1` tasks are favored over priority
+  `5` tasks.
 - Deadline scoring is task-level for the target date and does not yet strongly
   explain why a task was placed earlier or later within the day.
 - The daily response does not include unscheduled reasons or score breakdowns.

--- a/docs/dev/scheduler-phase1-payload.md
+++ b/docs/dev/scheduler-phase1-payload.md
@@ -142,8 +142,9 @@ task_dependencies:
 
 ## Current Gaps For Later Phases
 
-- Regular task priority is still hardcoded to `3` before the daily optimizer.
-  Quick tasks already pass their real priority.
+- Regular task priority is passed through to the daily optimizer and appears in
+  unscheduled task response data. Quick tasks continue to pass their real
+  priority.
 - The current daily API does not expose unscheduled reasons, score breakdowns,
   or constraint violations.
 - Current assignments are slot-shaped. Multiple tasks in one slot can still


### PR DESCRIPTION
## Summary
- update scheduler integration docs to reflect that regular task priority now reaches the daily optimizer
- keep the remaining work framed as manual app validation
- clarify that quick task priority behavior is unchanged

## Validation
- uv run --no-sync pytest tests/test_scheduler.py::TestSchedulerAPI::test_create_daily_schedule_uses_regular_task_priority -q