### PR TITLE
[codex] fix task not found service errors

### DIFF
--- a/apps/api/src/humancompiler_api/common/__init__.py
+++ b/apps/api/src/humancompiler_api/common/__init__.py
@@ -11,6 +11,7 @@ from .error_handlers import (
     check_resource_ownership,
     handle_service_error,
     safe_execute,
+    service_exception_handler,
     validate_uuid,
 )
 
@@ -22,6 +23,7 @@ __all__ = [
     "ExternalServiceError",
     "handle_service_error",
     "safe_execute",
+    "service_exception_handler",
     "validate_uuid",
     "check_resource_ownership",
 ]

--- a/apps/api/src/humancompiler_api/common/error_handlers.py
+++ b/apps/api/src/humancompiler_api/common/error_handlers.py
@@ -7,8 +7,16 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 from uuid import UUID
 
-from fastapi import HTTPException, status
+from fastapi import HTTPException, Request, status
+from fastapi.responses import JSONResponse
+from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
+
+from humancompiler_api.exceptions import (
+    HumanCompilerException,
+    ResourceNotFoundError as ApiResourceNotFoundError,
+    ValidationError as ApiValidationError,
+)
 from humancompiler_api.models import ErrorResponse
 
 logger = logging.getLogger(__name__)
@@ -16,29 +24,28 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-class ServiceError(Exception):
+class ServiceError(HumanCompilerException):
     """Base exception for service-layer errors"""
 
     def __init__(self, message: str, error_code: str | None = None):
-        self.message = message
-        self.error_code = error_code
-        super().__init__(self.message)
+        super().__init__(message, error_code)
 
 
-class ResourceNotFoundError(ServiceError):
+class ResourceNotFoundError(ApiResourceNotFoundError, ServiceError):
     """Raised when a requested resource is not found"""
 
     def __init__(self, resource_type: str, resource_id: str | UUID):
-        message = f"{resource_type} with ID {resource_id} not found"
-        super().__init__(message, "RESOURCE_NOT_FOUND")
+        self.resource_type = resource_type
+        self.resource_id = str(resource_id)
+        super().__init__(resource_type, self.resource_id)
 
 
-class ValidationError(ServiceError):
+class ValidationError(ApiValidationError, ServiceError):
     """Raised when validation fails"""
 
     def __init__(self, message: str, field: str | None = None):
         self.field = field
-        super().__init__(message, "VALIDATION_ERROR")
+        super().__init__(message, field)
 
 
 class AuthorizationError(ServiceError):
@@ -55,6 +62,27 @@ class ExternalServiceError(ServiceError):
     def __init__(self, service_name: str, message: str):
         full_message = f"{service_name} service error: {message}"
         super().__init__(full_message, "EXTERNAL_SERVICE_ERROR")
+
+
+async def service_exception_handler(request: Request, exc: ServiceError):
+    """Handle service-layer exceptions with HTTP status codes."""
+    status_code = status.HTTP_400_BAD_REQUEST
+
+    if isinstance(exc, ResourceNotFoundError):
+        status_code = status.HTTP_404_NOT_FOUND
+    elif isinstance(exc, AuthorizationError):
+        status_code = status.HTTP_403_FORBIDDEN
+    elif isinstance(exc, ExternalServiceError):
+        status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "detail": exc.message,
+            "error_code": exc.error_code,
+            "path": str(request.url),
+        },
+    )
 
 
 def handle_service_error(error: Exception) -> HTTPException:
@@ -111,20 +139,22 @@ def safe_execute(
         result = operation()
         session.commit()
         return result
+    except HumanCompilerException:
+        if rollback_on_error:
+            session.rollback()
+        raise
+    except IntegrityError as e:
+        if rollback_on_error:
+            session.rollback()
+
+        logger.error(f"Database operation failed: {e}")
+        raise ValidationError("Database constraint violation") from e
     except Exception as e:
         if rollback_on_error:
             session.rollback()
 
-        # Log the error
         logger.error(f"Database operation failed: {e}")
-
-        # Re-raise as service error
-        if "not found" in str(e).lower():
-            raise ResourceNotFoundError("Resource", "unknown") from e
-        elif "constraint" in str(e).lower():
-            raise ValidationError("Database constraint violation") from e
-        else:
-            raise ServiceError(f"Database operation failed: {str(e)}") from e
+        raise ServiceError(f"Database operation failed: {str(e)}") from e
 
 
 def validate_uuid(value: str | UUID, name: str) -> UUID:

--- a/apps/api/src/humancompiler_api/common/error_handlers.py
+++ b/apps/api/src/humancompiler_api/common/error_handlers.py
@@ -66,10 +66,12 @@ class ExternalServiceError(ServiceError):
 
 async def service_exception_handler(request: Request, exc: ServiceError):
     """Handle service-layer exceptions with HTTP status codes."""
-    status_code = status.HTTP_400_BAD_REQUEST
+    status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
 
     if isinstance(exc, ResourceNotFoundError):
         status_code = status.HTTP_404_NOT_FOUND
+    elif isinstance(exc, ValidationError):
+        status_code = status.HTTP_400_BAD_REQUEST
     elif isinstance(exc, AuthorizationError):
         status_code = status.HTTP_403_FORBIDDEN
     elif isinstance(exc, ExternalServiceError):

--- a/apps/api/src/humancompiler_api/main.py
+++ b/apps/api/src/humancompiler_api/main.py
@@ -14,6 +14,10 @@ from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError
 
 from humancompiler_api.config import settings
+from humancompiler_api.common.error_handlers import (
+    ServiceError,
+    service_exception_handler,
+)
 from humancompiler_api.database import db
 from humancompiler_api.performance_monitor import performance_monitor
 from humancompiler_api.rate_limiter import configure_rate_limiting, limiter
@@ -287,6 +291,7 @@ configure_rate_limiting(app)
 app.add_exception_handler(HTTPException, http_exception_handler)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)
 app.add_exception_handler(ValidationError, pydantic_validation_exception_handler)
+app.add_exception_handler(ServiceError, service_exception_handler)
 app.add_exception_handler(HumanCompilerException, humancompiler_exception_handler)
 app.add_exception_handler(Exception, general_exception_handler)
 

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Generator
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query, status
 from sqlmodel import Session
 
 from humancompiler_api.auth import AuthUser, get_current_user
@@ -177,15 +177,6 @@ async def get_task(
 ) -> TaskResponse:
     """Get specific task"""
     task = task_service.get_task(session, task_id, current_user.user_id)
-    if not task:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=ErrorResponse.create(
-                code="RESOURCE_NOT_FOUND",
-                message="Task not found",
-                details={"task_id": task_id},
-            ).model_dump(),
-        )
     # Get dependencies for the task
     task_response = TaskResponse.model_validate(task)
     dependencies = task_service.get_task_dependencies(

--- a/apps/api/tests/test_api.py
+++ b/apps/api/tests/test_api.py
@@ -1,4 +1,5 @@
 from unittest.mock import Mock, patch
+from uuid import uuid4
 
 from fastapi.testclient import TestClient
 
@@ -139,3 +140,47 @@ def test_delete_task_endpoint_invalid_uuid():
 
     # Should return 422 for invalid UUID format or auth error
     assert response.status_code in [401, 403, 422, 400, 500]
+
+
+def test_missing_task_endpoints_return_404(session):
+    """Missing tasks should use the service not-found handler, not 500."""
+    from humancompiler_api.auth import AuthUser, get_current_user
+    from humancompiler_api.routers.tasks import get_session
+
+    def override_session():
+        yield session
+
+    def override_user():
+        return AuthUser(
+            user_id="12345678-1234-1234-1234-123456789012",
+            email="test@example.com",
+        )
+
+    original_user_override = app.dependency_overrides.get(get_current_user)
+    original_session_override = app.dependency_overrides.get(get_session)
+    app.dependency_overrides[get_current_user] = override_user
+    app.dependency_overrides[get_session] = override_session
+
+    try:
+        fake_task_id = str(uuid4())
+        responses = [
+            client.get(f"/api/tasks/{fake_task_id}"),
+            client.put(f"/api/tasks/{fake_task_id}", json={"title": "Updated title"}),
+            client.delete(f"/api/tasks/{fake_task_id}"),
+        ]
+    finally:
+        if original_user_override is None:
+            app.dependency_overrides.pop(get_current_user, None)
+        else:
+            app.dependency_overrides[get_current_user] = original_user_override
+
+        if original_session_override is None:
+            app.dependency_overrides.pop(get_session, None)
+        else:
+            app.dependency_overrides[get_session] = original_session_override
+
+    for response in responses:
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"] != "Internal server error"
+        assert data["error_code"] == "RESOURCE_NOT_FOUND"

--- a/apps/api/tests/test_app_startup.py
+++ b/apps/api/tests/test_app_startup.py
@@ -55,11 +55,16 @@ class TestAppStartup:
 class TestRouterRegistration:
     """Tests for verifying router registration in the app."""
 
+    @staticmethod
+    def _route_paths(app):
+        """Return registered route paths, ignoring non-route app entries."""
+        return [route.path for route in app.routes if hasattr(route, "path")]
+
     def test_core_api_routes_registered(self):
         """Verify core API routes are registered."""
         from humancompiler_api.main import app
 
-        route_paths = [route.path for route in app.routes]
+        route_paths = self._route_paths(app)
 
         # Check core routes exist
         assert any("/api/projects" in path for path in route_paths)
@@ -70,14 +75,14 @@ class TestRouterRegistration:
         """Verify health check endpoint is registered."""
         from humancompiler_api.main import app
 
-        route_paths = [route.path for route in app.routes]
+        route_paths = self._route_paths(app)
         assert "/health" in route_paths
 
     def test_notes_routes_registered(self):
         """Verify notes routes are registered."""
         from humancompiler_api.main import app
 
-        route_paths = [route.path for route in app.routes]
+        route_paths = self._route_paths(app)
 
         # Notes routes should be registered
         assert any("/api/notes/projects" in path for path in route_paths)

--- a/apps/api/tests/test_app_startup.py
+++ b/apps/api/tests/test_app_startup.py
@@ -57,8 +57,8 @@ class TestRouterRegistration:
 
     @staticmethod
     def _route_paths(app):
-        """Return registered route paths, ignoring non-route app entries."""
-        return [route.path for route in app.routes if hasattr(route, "path")]
+        """Return registered HTTP paths from the generated OpenAPI schema."""
+        return list(app.openapi()["paths"].keys())
 
     def test_core_api_routes_registered(self):
         """Verify core API routes are registered."""

--- a/apps/api/tests/test_error_handlers.py
+++ b/apps/api/tests/test_error_handlers.py
@@ -1,0 +1,51 @@
+import json
+
+import pytest
+from fastapi import status
+from starlette.requests import Request
+
+from humancompiler_api.common.error_handlers import (
+    ResourceNotFoundError,
+    ServiceError,
+    ValidationError,
+    service_exception_handler,
+)
+
+
+def make_request() -> Request:
+    """Create a minimal request for exception handler tests."""
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/test",
+            "headers": [],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "client": ("testclient", 50000),
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_exception_handler_returns_500_for_plain_service_error():
+    response = await service_exception_handler(
+        make_request(), ServiceError("Database operation failed")
+    )
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert json.loads(response.body)["detail"] == "Database operation failed"
+
+
+@pytest.mark.asyncio
+async def test_service_exception_handler_maps_known_client_errors():
+    not_found_response = await service_exception_handler(
+        make_request(), ResourceNotFoundError("Task", "missing-id")
+    )
+    validation_response = await service_exception_handler(
+        make_request(), ValidationError("Invalid input")
+    )
+
+    assert not_found_response.status_code == status.HTTP_404_NOT_FOUND
+    assert validation_response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## Summary

Fixes #279.

- Unifies service-layer `ResourceNotFoundError` and `ValidationError` with the API exception hierarchy so FastAPI handlers no longer treat missing BaseService resources as generic 500s.
- Adds a service exception handler for service-layer status mapping and registers it with the app.
- Removes unreachable `if not task` dead code from the task GET route.
- Adds regression coverage for missing task GET, PUT, and DELETE returning 404 instead of `Internal server error`.

## Validation

- `apps/api/.venv/bin/python -m ruff check apps/api/src/humancompiler_api/common/error_handlers.py apps/api/src/humancompiler_api/common/__init__.py apps/api/src/humancompiler_api/main.py apps/api/src/humancompiler_api/routers/tasks.py apps/api/tests/test_api.py`
- `apps/api/.venv/bin/python -m pytest apps/api/tests/test_base_service.py apps/api/tests/test_api.py -q -s`