### PR TITLE
[codex] fix dependency cycle detection

### DIFF
--- a/apps/api/src/humancompiler_api/routers/goal_dependencies.py
+++ b/apps/api/src/humancompiler_api/routers/goal_dependencies.py
@@ -121,37 +121,22 @@ async def delete_goal_dependency(
 
 
 def _has_circular_dependency(
-    db: Session, goal_id: UUID, depends_on_goal_id: UUID, max_depth: int = 100
+    db: Session, goal_id: UUID, depends_on_goal_id: UUID
 ) -> bool:
     """
     Check if adding a dependency would create a circular dependency.
-    Uses iterative BFS approach for better performance and depth limiting.
+    Uses iterative BFS approach with visited nodes to handle existing cycles.
     """
 
     # Use BFS to detect cycles more efficiently
-    queue: deque[tuple[UUID, int]] = deque(
-        [(depends_on_goal_id, 0)]
-    )  # (goal_id, depth)
+    queue: deque[UUID] = deque([depends_on_goal_id])
     visited: set[UUID] = {depends_on_goal_id}
 
     # Cache queries for better performance
     dependency_cache: dict[UUID, list[UUID]] = {}
 
     while queue:
-        current_goal_id, depth = queue.popleft()
-
-        # Depth limit to prevent infinite loops in corrupted data
-        if depth >= max_depth:
-            # Log warning about deep dependency chain
-            import logging
-
-            logger = logging.getLogger(__name__)
-
-            logger.warning(
-                f"Goal dependency chain depth limit reached: {max_depth}",
-                extra={"goal_id": str(goal_id), "depends_on": str(depends_on_goal_id)},
-            )
-            return False  # Assume no cycle if we hit depth limit
+        current_goal_id = queue.popleft()
 
         # Check if we've found a cycle
         if current_goal_id == goal_id:
@@ -174,6 +159,6 @@ def _has_circular_dependency(
         for dependent_goal_id in dependent_goals:
             if dependent_goal_id not in visited:
                 visited.add(dependent_goal_id)
-                queue.append((dependent_goal_id, depth + 1))
+                queue.append(dependent_goal_id)
 
     return False

--- a/apps/api/src/humancompiler_api/routers/goal_dependencies.py
+++ b/apps/api/src/humancompiler_api/routers/goal_dependencies.py
@@ -157,12 +157,12 @@ def _has_circular_dependency(
         if current_goal_id == goal_id:
             return True
 
-        # Get dependent goals (with caching)
+        # Get this goal's prerequisites (with caching)
         if current_goal_id not in dependency_cache:
             dependent_goals = list(
                 db.exec(
-                    select(GoalDependency.goal_id).where(
-                        GoalDependency.depends_on_goal_id == current_goal_id
+                    select(GoalDependency.depends_on_goal_id).where(
+                        GoalDependency.goal_id == current_goal_id
                     )
                 ).all()
             )
@@ -170,7 +170,7 @@ def _has_circular_dependency(
         else:
             dependent_goals = dependency_cache[current_goal_id]
 
-        # Add unvisited dependent goals to queue
+        # Add unvisited prerequisites to queue
         for dependent_goal_id in dependent_goals:
             if dependent_goal_id not in visited:
                 visited.add(dependent_goal_id)

--- a/apps/api/src/humancompiler_api/routers/task_dependencies.py
+++ b/apps/api/src/humancompiler_api/routers/task_dependencies.py
@@ -151,18 +151,18 @@ def _has_circular_dependency(
         if current_task_id == task_id:
             return True
 
-        # Get dependent tasks (with caching)
+        # Get this task's prerequisites (with caching)
         if current_task_id not in dependency_cache:
             dependent_tasks = db.exec(
-                select(TaskDependency.task_id).where(
-                    TaskDependency.depends_on_task_id == current_task_id
+                select(TaskDependency.depends_on_task_id).where(
+                    TaskDependency.task_id == current_task_id
                 )
             ).all()
             dependency_cache[current_task_id] = dependent_tasks
         else:
             dependent_tasks = dependency_cache[current_task_id]
 
-        # Add unvisited dependent tasks to queue
+        # Add unvisited prerequisites to queue
         for dependent_task_id in dependent_tasks:
             if dependent_task_id not in visited:
                 visited.add(dependent_task_id)

--- a/apps/api/src/humancompiler_api/routers/task_dependencies.py
+++ b/apps/api/src/humancompiler_api/routers/task_dependencies.py
@@ -118,34 +118,23 @@ async def delete_task_dependency(
 
 
 def _has_circular_dependency(
-    db: Session, task_id: UUID, depends_on_task_id: UUID, max_depth: int = 100
+    db: Session, task_id: UUID, depends_on_task_id: UUID
 ) -> bool:
     """
     Check if adding a dependency would create a circular dependency.
-    Uses iterative BFS approach for better performance and depth limiting.
+    Uses iterative BFS approach with visited nodes to handle existing cycles.
     """
     from collections import deque
 
     # Use BFS to detect cycles more efficiently
-    queue = deque([(depends_on_task_id, 0)])  # (task_id, depth)
+    queue = deque([depends_on_task_id])
     visited = {depends_on_task_id}
 
     # Cache queries for better performance
     dependency_cache = {}
 
     while queue:
-        current_task_id, depth = queue.popleft()
-
-        # Depth limit to prevent infinite loops in corrupted data
-        if depth >= max_depth:
-            # Log warning about deep dependency chain
-            from humancompiler_api.logger import logger
-
-            logger.warning(
-                f"Dependency chain depth limit reached: {max_depth}",
-                extra={"task_id": str(task_id), "depends_on": str(depends_on_task_id)},
-            )
-            return False  # Assume no cycle if we hit depth limit
+        current_task_id = queue.popleft()
 
         # Check if we've found a cycle
         if current_task_id == task_id:
@@ -166,6 +155,6 @@ def _has_circular_dependency(
         for dependent_task_id in dependent_tasks:
             if dependent_task_id not in visited:
                 visited.add(dependent_task_id)
-                queue.append((dependent_task_id, depth + 1))
+                queue.append(dependent_task_id)
 
     return False

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -63,21 +63,17 @@ def _dependency_path_exists(
     depends_on_id_column,
     from_node_id: str | UUID,
     to_node_id: str | UUID,
-    max_depth: int = 100,
 ) -> bool:
     """Return True when from_node_id already depends on to_node_id."""
     start_id = UUID(str(from_node_id))
     target_id = UUID(str(to_node_id))
-    queue: deque[tuple[UUID, int]] = deque([(start_id, 0)])
+    queue: deque[UUID] = deque([start_id])
     visited = {start_id}
 
     while queue:
-        current_id, depth = queue.popleft()
+        current_id = queue.popleft()
         if current_id == target_id:
             return True
-
-        if depth >= max_depth:
-            return False
 
         next_ids = session.exec(
             select(depends_on_id_column).where(node_id_column == current_id)
@@ -85,7 +81,7 @@ def _dependency_path_exists(
         for next_id in next_ids:
             if next_id not in visited:
                 visited.add(next_id)
-                queue.append((next_id, depth + 1))
+                queue.append(next_id)
 
     return False
 

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -2,6 +2,7 @@
 Refactored services using base service class
 """
 
+from collections import deque
 from datetime import datetime, UTC
 from decimal import Decimal, ROUND_HALF_UP
 from uuid import UUID
@@ -54,6 +55,39 @@ from humancompiler_api.models import (
     SlotTemplateCreate,
     SlotTemplateUpdate,
 )
+
+
+def _dependency_path_exists(
+    session: Session,
+    node_id_column,
+    depends_on_id_column,
+    from_node_id: str | UUID,
+    to_node_id: str | UUID,
+    max_depth: int = 100,
+) -> bool:
+    """Return True when from_node_id already depends on to_node_id."""
+    start_id = UUID(str(from_node_id))
+    target_id = UUID(str(to_node_id))
+    queue: deque[tuple[UUID, int]] = deque([(start_id, 0)])
+    visited = {start_id}
+
+    while queue:
+        current_id, depth = queue.popleft()
+        if current_id == target_id:
+            return True
+
+        if depth >= max_depth:
+            return False
+
+        next_ids = session.exec(
+            select(depends_on_id_column).where(node_id_column == current_id)
+        ).all()
+        for next_id in next_ids:
+            if next_id not in visited:
+                visited.add(next_id)
+                queue.append((next_id, depth + 1))
+
+    return False
 
 
 class UserService:
@@ -394,10 +428,21 @@ class GoalService(BaseService[Goal, GoalCreate, GoalUpdate]):
             )
 
         # Check for circular dependency
-        if goal_id == depends_on_goal_id:
+        if UUID(str(goal_id)) == UUID(str(depends_on_goal_id)):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Goal cannot depend on itself",
+            )
+        if _dependency_path_exists(
+            session,
+            GoalDependency.goal_id,
+            GoalDependency.depends_on_goal_id,
+            depends_on_goal_id,
+            goal_id,
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Creating this dependency would create a circular dependency",
             )
 
         # Check if dependency already exists
@@ -690,10 +735,21 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
             )
 
         # Check for circular dependency
-        if task_id == depends_on_task_id:
+        if UUID(str(task_id)) == UUID(str(depends_on_task_id)):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Task cannot depend on itself",
+            )
+        if _dependency_path_exists(
+            session,
+            TaskDependency.task_id,
+            TaskDependency.depends_on_task_id,
+            depends_on_task_id,
+            task_id,
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Creating this dependency would create a circular dependency",
             )
 
         # Check if dependency already exists

--- a/apps/api/tests/test_dependency_cycle_detection.py
+++ b/apps/api/tests/test_dependency_cycle_detection.py
@@ -1,0 +1,134 @@
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlmodel import Session
+
+from humancompiler_api.models import Goal, GoalDependency, Project, Task, User
+from humancompiler_api.services import GoalService, TaskService
+
+
+def _create_goal(session: Session, project_id, title: str) -> Goal:
+    goal = Goal(
+        id=uuid4(),
+        project_id=project_id,
+        title=title,
+        description=f"{title} description",
+        estimate_hours=10.0,
+    )
+    session.add(goal)
+    session.commit()
+    session.refresh(goal)
+    return goal
+
+
+def _create_task(session: Session, goal_id, title: str) -> Task:
+    task = Task(
+        id=uuid4(),
+        goal_id=goal_id,
+        title=title,
+        description=f"{title} description",
+        estimate_hours=2.0,
+    )
+    session.add(task)
+    session.commit()
+    session.refresh(task)
+    return task
+
+
+@pytest.fixture
+def dependency_graph_data(session: Session):
+    user = User(id=uuid4(), email="dependency-cycles@example.com")
+    project = Project(
+        id=uuid4(),
+        owner_id=user.id,
+        title="Dependency Cycle Project",
+        description="Project for dependency cycle tests",
+    )
+    session.add(user)
+    session.add(project)
+    session.commit()
+    session.refresh(user)
+    session.refresh(project)
+
+    goals = [
+        _create_goal(session, project.id, "Goal A"),
+        _create_goal(session, project.id, "Goal B"),
+        _create_goal(session, project.id, "Goal C"),
+    ]
+    tasks = [
+        _create_task(session, goals[0].id, "Task A"),
+        _create_task(session, goals[0].id, "Task B"),
+        _create_task(session, goals[0].id, "Task C"),
+    ]
+
+    return user, goals, tasks
+
+
+def _assert_circular_dependency_rejected(exc_info):
+    assert exc_info.value.status_code == 400
+    assert "circular dependency" in exc_info.value.detail
+
+
+class TestTaskDependencyCycleDetection:
+    def test_rejects_two_task_cycle(self, session: Session, dependency_graph_data):
+        user, _, tasks = dependency_graph_data
+        task_a, task_b, _ = tasks
+        service = TaskService()
+
+        service.add_task_dependency(session, task_a.id, task_b.id, user.id)
+
+        with pytest.raises(HTTPException) as exc_info:
+            service.add_task_dependency(session, task_b.id, task_a.id, user.id)
+
+        _assert_circular_dependency_rejected(exc_info)
+
+    def test_rejects_transitive_task_cycle(
+        self, session: Session, dependency_graph_data
+    ):
+        user, _, tasks = dependency_graph_data
+        task_a, task_b, task_c = tasks
+        service = TaskService()
+
+        service.add_task_dependency(session, task_a.id, task_b.id, user.id)
+        service.add_task_dependency(session, task_b.id, task_c.id, user.id)
+
+        with pytest.raises(HTTPException) as exc_info:
+            service.add_task_dependency(session, task_c.id, task_a.id, user.id)
+
+        _assert_circular_dependency_rejected(exc_info)
+
+
+class TestGoalDependencyCycleDetection:
+    def test_rejects_two_goal_cycle(self, session: Session, dependency_graph_data):
+        user, goals, _ = dependency_graph_data
+        goal_a, goal_b, _ = goals
+        service = GoalService()
+        session.add(
+            GoalDependency(id=uuid4(), goal_id=goal_a.id, depends_on_goal_id=goal_b.id)
+        )
+        session.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            service.add_goal_dependency(session, goal_b.id, goal_a.id, user.id)
+
+        _assert_circular_dependency_rejected(exc_info)
+
+    def test_rejects_transitive_goal_cycle(
+        self, session: Session, dependency_graph_data
+    ):
+        user, goals, _ = dependency_graph_data
+        goal_a, goal_b, goal_c = goals
+        service = GoalService()
+        session.add(
+            GoalDependency(id=uuid4(), goal_id=goal_a.id, depends_on_goal_id=goal_b.id)
+        )
+        session.add(
+            GoalDependency(id=uuid4(), goal_id=goal_b.id, depends_on_goal_id=goal_c.id)
+        )
+        session.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            service.add_goal_dependency(session, goal_c.id, goal_a.id, user.id)
+
+        _assert_circular_dependency_rejected(exc_info)

--- a/apps/api/tests/test_dependency_cycle_detection.py
+++ b/apps/api/tests/test_dependency_cycle_detection.py
@@ -4,7 +4,14 @@ import pytest
 from fastapi import HTTPException
 from sqlmodel import Session
 
-from humancompiler_api.models import Goal, GoalDependency, Project, Task, User
+from humancompiler_api.models import (
+    Goal,
+    GoalDependency,
+    Project,
+    Task,
+    TaskDependency,
+    User,
+)
 from humancompiler_api.services import GoalService, TaskService
 
 
@@ -98,6 +105,31 @@ class TestTaskDependencyCycleDetection:
 
         _assert_circular_dependency_rejected(exc_info)
 
+    def test_rejects_task_cycle_after_long_dependency_chain(
+        self, session: Session, dependency_graph_data
+    ):
+        user, goals, _ = dependency_graph_data
+        tasks = [
+            _create_task(session, goals[0].id, f"Long Chain Task {index}")
+            for index in range(102)
+        ]
+        for index in range(len(tasks) - 1):
+            session.add(
+                TaskDependency(
+                    id=uuid4(),
+                    task_id=tasks[index].id,
+                    depends_on_task_id=tasks[index + 1].id,
+                )
+            )
+        session.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            TaskService().add_task_dependency(
+                session, tasks[-1].id, tasks[0].id, user.id
+            )
+
+        _assert_circular_dependency_rejected(exc_info)
+
 
 class TestGoalDependencyCycleDetection:
     def test_rejects_two_goal_cycle(self, session: Session, dependency_graph_data):
@@ -130,5 +162,30 @@ class TestGoalDependencyCycleDetection:
 
         with pytest.raises(HTTPException) as exc_info:
             service.add_goal_dependency(session, goal_c.id, goal_a.id, user.id)
+
+        _assert_circular_dependency_rejected(exc_info)
+
+    def test_rejects_goal_cycle_after_long_dependency_chain(
+        self, session: Session, dependency_graph_data
+    ):
+        user, goals, _ = dependency_graph_data
+        chain_goals = [
+            _create_goal(session, goals[0].project_id, f"Long Chain Goal {index}")
+            for index in range(102)
+        ]
+        for index in range(len(chain_goals) - 1):
+            session.add(
+                GoalDependency(
+                    id=uuid4(),
+                    goal_id=chain_goals[index].id,
+                    depends_on_goal_id=chain_goals[index + 1].id,
+                )
+            )
+        session.commit()
+
+        with pytest.raises(HTTPException) as exc_info:
+            GoalService().add_goal_dependency(
+                session, chain_goals[-1].id, chain_goals[0].id, user.id
+            )
 
         _assert_circular_dependency_rejected(exc_info)


### PR DESCRIPTION
## Summary

- Add service-layer cycle detection for task and goal dependencies.
- Traverse existing prerequisite chains from the proposed dependency target to reject both direct and transitive cycles.
- Align legacy task/goal dependency router helpers to traverse prerequisites in the same direction.
- Add regression tests for two-node and transitive cycles for tasks and goals.

Closes #281

## Validation

- `.venv/bin/python -m pytest tests/test_dependency_cycle_detection.py -s`
- `.venv/bin/python -m pytest tests/test_task_deletion.py tests/test_goal_status.py -s`
- `.venv/bin/python -m ruff check src/humancompiler_api/services.py src/humancompiler_api/routers/task_dependencies.py src/humancompiler_api/routers/goal_dependencies.py tests/test_dependency_cycle_detection.py`
- pre-commit hooks on commit: ruff, ruff format, trim trailing whitespace, end-of-file, merge conflict checks