### PR TITLE
[codex] Fix goal detail task log N+1 requests

### DIFF
--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -936,7 +936,8 @@ class LogService(BaseService[Log, LogCreate, LogUpdate]):
             .where(and_(Project.owner_id == owner_id, Task.id.in_(task_ids)))
         )
         valid_tasks = session.exec(task_query).all()
-        valid_task_ids = {str(task.id) for task in valid_tasks}
+        valid_task_ids = [task.id for task in valid_tasks]
+        valid_task_id_strings = {str(task_id) for task_id in valid_task_ids}
 
         # Initialize result with empty lists for all requested tasks
         for task_id in task_ids:
@@ -946,13 +947,26 @@ class LogService(BaseService[Log, LogCreate, LogUpdate]):
         if not valid_task_ids:
             return result
 
-        # Fetch all logs for valid tasks in a single query
+        row_number = (
+            func.row_number()
+            .over(partition_by=Log.task_id, order_by=Log.created_at.desc())
+            .label("row_number")
+        )
+        ranked_logs = (
+            select(Log.id.label("log_id"), row_number)
+            .where(Log.task_id.in_(valid_task_ids))
+            .subquery()
+        )
+
+        # Fetch each task's requested page in a single query.
         logs_query = (
             select(Log)
-            .where(Log.task_id.in_(valid_task_ids))
-            .order_by(Log.created_at.desc())
-            .offset(skip)
-            .limit(limit * len(valid_task_ids))  # Adjust limit for multiple tasks
+            .join(ranked_logs, Log.id == ranked_logs.c.log_id)
+            .where(
+                ranked_logs.c.row_number > skip,
+                ranked_logs.c.row_number <= skip + limit,
+            )
+            .order_by(Log.task_id, Log.created_at.desc())
         )
 
         all_logs = session.exec(logs_query).all()
@@ -960,10 +974,8 @@ class LogService(BaseService[Log, LogCreate, LogUpdate]):
         # Group logs by task_id
         for log in all_logs:
             task_id_str = str(log.task_id)
-            if task_id_str in result:
-                # Respect per-task limit
-                if len(result[task_id_str]) < limit:
-                    result[task_id_str].append(log)
+            if task_id_str in valid_task_id_strings:
+                result[task_id_str].append(log)
 
         return result
 

--- a/apps/api/tests/test_log_service_batch.py
+++ b/apps/api/tests/test_log_service_batch.py
@@ -1,0 +1,119 @@
+"""
+Tests for batched log retrieval semantics.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from sqlmodel import Session
+
+from conftest import create_test_data
+from humancompiler_api.models import LogCreate, TaskCreate
+from humancompiler_api.services import LogService, TaskService
+
+
+def test_get_logs_batch_applies_limit_per_task(session: Session, test_user_id: str):
+    """A noisy task must not starve quieter tasks in batch results."""
+    test_data = create_test_data(session, test_user_id)
+    task_service = TaskService()
+    log_service = LogService()
+
+    noisy_task = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=test_data["goal"].id,
+            title="Noisy task",
+            estimate_hours=1.0,
+            status="pending",
+            priority=1,
+        ),
+        test_user_id,
+    )
+    quiet_task = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=test_data["goal"].id,
+            title="Quiet task",
+            estimate_hours=1.0,
+            status="pending",
+            priority=1,
+        ),
+        test_user_id,
+    )
+
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    for index in range(3):
+        log = log_service.create_log(
+            session,
+            LogCreate(
+                task_id=noisy_task.id,
+                actual_minutes=10 + index,
+                comment=f"noisy-{index}",
+            ),
+            test_user_id,
+        )
+        log.created_at = base_time + timedelta(minutes=10 + index)
+
+    quiet_log = log_service.create_log(
+        session,
+        LogCreate(task_id=quiet_task.id, actual_minutes=60, comment="quiet"),
+        test_user_id,
+    )
+    quiet_log.created_at = base_time
+    session.flush()
+
+    result = log_service.get_logs_batch(
+        session,
+        [noisy_task.id, quiet_task.id],
+        test_user_id,
+        skip=0,
+        limit=2,
+    )
+
+    assert [log.comment for log in result[str(noisy_task.id)]] == [
+        "noisy-2",
+        "noisy-1",
+    ]
+    assert [log.comment for log in result[str(quiet_task.id)]] == ["quiet"]
+
+
+def test_get_logs_batch_applies_skip_per_task(session: Session, test_user_id: str):
+    """Pagination offset is applied independently for every requested task."""
+    test_data = create_test_data(session, test_user_id)
+    task_service = TaskService()
+    log_service = LogService()
+
+    task = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=test_data["goal"].id,
+            title="Paged task",
+            estimate_hours=1.0,
+            status="pending",
+            priority=1,
+        ),
+        test_user_id,
+    )
+
+    base_time = datetime(2026, 1, 1, tzinfo=UTC)
+    for index in range(3):
+        log = log_service.create_log(
+            session,
+            LogCreate(
+                task_id=task.id,
+                actual_minutes=10 + index,
+                comment=f"log-{index}",
+            ),
+            test_user_id,
+        )
+        log.created_at = base_time + timedelta(minutes=index)
+    session.flush()
+
+    result = log_service.get_logs_batch(
+        session,
+        [task.id],
+        test_user_id,
+        skip=1,
+        limit=1,
+    )
+
+    assert [log.comment for log in result[str(task.id)]] == ["log-1"]

--- a/apps/web/src/app/projects/[id]/goals/[goalId]/page.tsx
+++ b/apps/web/src/app/projects/[id]/goals/[goalId]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { useRouter, useParams } from 'next/navigation';
 import { useAuth } from '@/hooks/use-auth';
@@ -10,7 +10,7 @@ import { useProject } from '@/hooks/use-project-query';
 import { useGoalNote } from '@/hooks/use-notes';
 import { useQuery } from '@tanstack/react-query';
 import { progressApi } from '@/lib/api';
-import { useTaskActualMinutes } from '@/hooks/use-logs-query';
+import { useBatchLogsQuery } from '@/hooks/use-logs-query';
 import { useUpdateTask } from '@/hooks/use-tasks-query';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
@@ -28,18 +28,6 @@ import { taskStatusLabels, taskStatusColors, workTypeLabels, workTypeColors, tas
 import type { TaskStatus, Task } from '@/types/task';
 import { log } from '@/lib/logger';
 import { AppHeader } from '@/components/layout/app-header';
-
-// Component to display actual time for a task
-function TaskActualTime({ taskId }: { taskId: string }) {
-  const { totalHours } = useTaskActualMinutes(taskId);
-
-  return (
-    <div className="flex items-center gap-1">
-      <Clock className="h-3 w-3 text-green-600" />
-      {totalHours.toFixed(1)}h
-    </div>
-  );
-}
 
 // Component for inline status editing
 function TaskStatusSelect({ task }: { task: Task }) {
@@ -125,6 +113,23 @@ export default function GoalDetailPage() {
     queryFn: () => progressApi.getGoal(goalId),
     enabled: !!goal,
   });
+
+  const taskIds = useMemo(() => tasks.map(task => task.id), [tasks]);
+  const {
+    data: logsByTask = {},
+    isLoading: logsLoading,
+    error: logsError,
+  } = useBatchLogsQuery(taskIds);
+
+  const taskActualMinutesById = useMemo(() => {
+    return Object.fromEntries(
+      taskIds.map(taskId => {
+        const logs = logsByTask[taskId] || [];
+        const totalMinutes = logs.reduce((sum, logEntry) => sum + (logEntry.actual_minutes || 0), 0);
+        return [taskId, totalMinutes];
+      })
+    );
+  }, [taskIds, logsByTask]);
 
   useEffect(() => {
     if (!authLoading && !user) {
@@ -462,7 +467,10 @@ export default function GoalDetailPage() {
                           </div>
                         </TableCell>
                         <TableCell>
-                          <TaskActualTime taskId={task.id} />
+                          <div className="flex items-center gap-1">
+                            <Clock className="h-3 w-3 text-green-600" />
+                            {((taskActualMinutesById[task.id] || 0) / 60).toFixed(1)}h
+                          </div>
                         </TableCell>
                         <TableCell>
                           {task.due_date ? (
@@ -505,7 +513,12 @@ export default function GoalDetailPage() {
                       </TableRow>
                       <TableRow>
                         <TableCell colSpan={10} className="p-0">
-                          <TaskLogsMemoPanel task={task} />
+                          <TaskLogsMemoPanel
+                            task={task}
+                            logs={logsByTask[task.id] || []}
+                            logsLoading={logsLoading}
+                            logsError={logsError}
+                          />
                         </TableCell>
                       </TableRow>
                     </React.Fragment>

--- a/apps/web/src/components/tasks/task-logs-memo-panel.tsx
+++ b/apps/web/src/components/tasks/task-logs-memo-panel.tsx
@@ -8,7 +8,6 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { ChevronDown, ChevronRight, Clock, MessageSquare, Edit, Save, X, Trash2, Timer, Pencil } from 'lucide-react';
-import { useLogsByTask } from '@/hooks/use-logs-query';
 import { useUpdateTask } from '@/hooks/use-tasks-query';
 import { useWorkSessionsByTask } from '@/hooks/use-work-sessions';
 import { SessionKptEditDialog } from '@/components/runner/session-kpt-edit-dialog';
@@ -23,9 +22,13 @@ import { log } from '@/lib/logger';
 import { formatJSTDateTime } from '@/lib/date-utils';
 import { LogEditDialog } from '@/components/logs/log-edit-dialog';
 import { LogDeleteDialog } from '@/components/logs/log-delete-dialog';
+import type { Log } from '@/types/log';
 
 interface TaskLogsMemoPanelProps {
   task: Task;
+  logs: Log[];
+  logsLoading?: boolean;
+  logsError?: Error | null;
 }
 
 /**
@@ -44,14 +47,19 @@ function calculateSessionWorkMinutes(session: WorkSession): number {
   return 0;
 }
 
-export function TaskLogsMemoPanel({ task }: TaskLogsMemoPanelProps) {
+export function TaskLogsMemoPanel({
+  task,
+  logs,
+  logsLoading = false,
+  logsError = null,
+}: TaskLogsMemoPanelProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isMemoEditing, setIsMemoEditing] = useState(false);
   const [memoText, setMemoText] = useState(task.memo || '');
   const [editSession, setEditSession] = useState<WorkSession | null>(null);
 
-  const { data: logs = [], isLoading: logsLoading, error: logsError } = useLogsByTask(task.id);
-  const { data: sessions = [], isLoading: sessionsLoading } = useWorkSessionsByTask(task.id);
+  const { data: sessions = [], isLoading: sessionsLoading } = useWorkSessionsByTask(task.id, 0, 20, isOpen);
+  const hasSessionSummary = isOpen || sessions.length > 0;
   const updateTaskMutation = useUpdateTask();
   const { toast } = useToast();
 
@@ -124,7 +132,7 @@ export function TaskLogsMemoPanel({ task }: TaskLogsMemoPanelProps) {
             <div className="flex items-center gap-1">
               <Timer className="h-4 w-4 text-purple-600" />
               <span className="text-sm font-medium">
-                セッション ({sessions.length}件, {(totalSessionTime / 60).toFixed(1)}h)
+                セッション{hasSessionSummary ? ` (${sessions.length}件, ${(totalSessionTime / 60).toFixed(1)}h)` : ''}
               </span>
             </div>
             <div className="flex items-center gap-1">

--- a/apps/web/src/hooks/__tests__/use-logs-query.test.ts
+++ b/apps/web/src/hooks/__tests__/use-logs-query.test.ts
@@ -8,7 +8,7 @@ import type { Log, LogCreate, LogUpdate } from '@/types/log'
 
 // Mock the API
 const mockGetByTask = jest.fn<Promise<Log[]>, [string, number?, number?]>()
-const mockGetBatch = jest.fn<Promise<Record<string, Log[]>>, [string[]]>()
+const mockGetBatch = jest.fn<Promise<Record<string, Log[]>>, [string[], number?, number?]>()
 const mockGetById = jest.fn<Promise<Log>, [string]>()
 const mockCreate = jest.fn<Promise<Log>, [LogCreate]>()
 const mockUpdate = jest.fn<Promise<Log>, [string, LogUpdate]>()
@@ -17,7 +17,7 @@ const mockDelete = jest.fn<Promise<void>, [string]>()
 jest.mock('@/lib/api', () => ({
   logsApi: {
     getByTask: (...args: [string, number?, number?]) => mockGetByTask(...args),
-    getBatch: (taskIds: string[]) => mockGetBatch(taskIds),
+    getBatch: (taskIds: string[], skip?: number, limit?: number) => mockGetBatch(taskIds, skip, limit),
     getById: (id: string) => mockGetById(id),
     create: (data: LogCreate) => mockCreate(data),
     update: (id: string, data: LogUpdate) => mockUpdate(id, data),
@@ -35,7 +35,7 @@ jest.mock('@/lib/query-keys', () => ({
       details: () => ['logs', 'detail'],
       detail: (id: string) => ['logs', 'detail', id],
       byTask: (taskId: string) => ['logs', 'task', taskId],
-      batch: (taskIds: string[]) => ['logs', 'batch', ...taskIds.sort()],
+      batch: (taskIds: string[], skip = 0, limit = 50) => ['logs', 'batch', { skip, limit }, ...[...taskIds].sort()],
     },
     progress: {
       all: ['progress'],
@@ -124,8 +124,20 @@ describe('useBatchLogsQuery', () => {
       expect(result.current.isSuccess).toBe(true)
     })
 
-    expect(mockGetBatch).toHaveBeenCalledWith(['task-1', 'task-2'])
+    expect(mockGetBatch).toHaveBeenCalledWith(['task-1', 'task-2'], 0, 50)
     expect(result.current.data).toEqual(batchResult)
+  })
+
+  it('should support pagination', async () => {
+    mockGetBatch.mockResolvedValue({})
+
+    const { result } = renderHookWithClient(() => useBatchLogsQuery(['task-1'], 10, 25))
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(mockGetBatch).toHaveBeenCalledWith(['task-1'], 10, 25)
   })
 
   it('should be disabled when taskIds is empty', async () => {

--- a/apps/web/src/hooks/__tests__/use-logs-query.test.ts
+++ b/apps/web/src/hooks/__tests__/use-logs-query.test.ts
@@ -35,6 +35,7 @@ jest.mock('@/lib/query-keys', () => ({
       details: () => ['logs', 'detail'],
       detail: (id: string) => ['logs', 'detail', id],
       byTask: (taskId: string) => ['logs', 'task', taskId],
+      batches: () => ['logs', 'batch'],
       batch: (taskIds: string[], skip = 0, limit = 50) => ['logs', 'batch', { skip, limit }, ...[...taskIds].sort()],
     },
     progress: {
@@ -232,6 +233,7 @@ describe('useCreateLog', () => {
     mockCreate.mockResolvedValue(newLog)
 
     const { result, queryClient } = renderHookWithClient(() => useCreateLog())
+    const setQueryDataSpy = jest.spyOn(queryClient, 'setQueryData')
 
     await act(async () => {
       await result.current.mutateAsync({
@@ -240,8 +242,7 @@ describe('useCreateLog', () => {
       })
     })
 
-    const cachedLog = queryClient.getQueryData(logKeys.detail('cached-log'))
-    expect(cachedLog).toEqual(newLog)
+    expect(setQueryDataSpy).toHaveBeenCalledWith(logKeys.detail('cached-log'), newLog)
   })
 })
 
@@ -356,6 +357,9 @@ describe('useDeleteLog', () => {
 
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: logKeys.lists(),
+    })
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: logKeys.batches(),
     })
   })
 })

--- a/apps/web/src/hooks/use-logs-query.ts
+++ b/apps/web/src/hooks/use-logs-query.ts
@@ -34,12 +34,12 @@ export function useLogsByTask(taskId: string, skip = 0, limit = 50) {
  * @param taskIds - Array of task UUIDs to fetch logs for
  * @returns UseQueryResult with logs grouped by task
  */
-export function useBatchLogsQuery(taskIds: string[]) {
+export function useBatchLogsQuery(taskIds: string[], skip = 0, limit = 50) {
   return useQuery({
-    queryKey: queryKeys.logs.batch(taskIds),
+    queryKey: queryKeys.logs.batch(taskIds, skip, limit),
     queryFn: async () => {
       // Use the new batch API endpoint for efficient fetching
-      return await logsApi.getBatch(taskIds);
+      return await logsApi.getBatch(taskIds, skip, limit);
     },
     enabled: taskIds.length > 0,
     staleTime: 5 * 60 * 1000, // 5 minutes
@@ -75,6 +75,11 @@ export function useCreateLog() {
   return useMutation({
     mutationFn: (logData: LogCreate) => logsApi.create(logData),
     onSuccess: (newLog: Log) => {
+      // Invalidate log caches, including batch queries used by goal detail.
+      queryClient.invalidateQueries({
+        queryKey: logKeys.all
+      })
+
       // Invalidate logs for the specific task
       queryClient.invalidateQueries({
         queryKey: logKeys.byTask(newLog.task_id)
@@ -111,6 +116,11 @@ export function useUpdateLog() {
         updatedLog
       )
 
+      // Invalidate log caches, including batch queries used by goal detail.
+      queryClient.invalidateQueries({
+        queryKey: logKeys.all
+      })
+
       // Invalidate logs for the task to reflect changes in list view
       queryClient.invalidateQueries({
         queryKey: logKeys.byTask(updatedLog.task_id)
@@ -142,6 +152,11 @@ export function useDeleteLog() {
 
       // Invalidate logs for the task if we know the task ID
       if (cachedLog?.task_id) {
+        // Invalidate log caches, including batch queries used by goal detail.
+        queryClient.invalidateQueries({
+          queryKey: logKeys.all
+        })
+
         queryClient.invalidateQueries({
           queryKey: logKeys.byTask(cachedLog.task_id)
         })

--- a/apps/web/src/hooks/use-logs-query.ts
+++ b/apps/web/src/hooks/use-logs-query.ts
@@ -75,9 +75,12 @@ export function useCreateLog() {
   return useMutation({
     mutationFn: (logData: LogCreate) => logsApi.create(logData),
     onSuccess: (newLog: Log) => {
-      // Invalidate log caches, including batch queries used by goal detail.
+      // Invalidate log list caches, including batch queries used by goal detail.
       queryClient.invalidateQueries({
-        queryKey: logKeys.all
+        queryKey: logKeys.lists()
+      })
+      queryClient.invalidateQueries({
+        queryKey: logKeys.batches()
       })
 
       // Invalidate logs for the specific task
@@ -116,9 +119,12 @@ export function useUpdateLog() {
         updatedLog
       )
 
-      // Invalidate log caches, including batch queries used by goal detail.
+      // Invalidate log list caches, including batch queries used by goal detail.
       queryClient.invalidateQueries({
-        queryKey: logKeys.all
+        queryKey: logKeys.lists()
+      })
+      queryClient.invalidateQueries({
+        queryKey: logKeys.batches()
       })
 
       // Invalidate logs for the task to reflect changes in list view
@@ -150,13 +156,16 @@ export function useDeleteLog() {
       // Remove log from cache
       queryClient.removeQueries({ queryKey: logKeys.detail(logId) })
 
+      // Invalidate log list caches, including batch queries used by goal detail.
+      queryClient.invalidateQueries({
+        queryKey: logKeys.lists()
+      })
+      queryClient.invalidateQueries({
+        queryKey: logKeys.batches()
+      })
+
       // Invalidate logs for the task if we know the task ID
       if (cachedLog?.task_id) {
-        // Invalidate log caches, including batch queries used by goal detail.
-        queryClient.invalidateQueries({
-          queryKey: logKeys.all
-        })
-
         queryClient.invalidateQueries({
           queryKey: logKeys.byTask(cachedLog.task_id)
         })

--- a/apps/web/src/hooks/use-work-sessions.ts
+++ b/apps/web/src/hooks/use-work-sessions.ts
@@ -55,11 +55,11 @@ export function useWorkSessionHistory(skip = 0, limit = 20) {
  * @param skip - Pagination offset
  * @param limit - Maximum results
  */
-export function useWorkSessionsByTask(taskId: string, skip = 0, limit = 20) {
+export function useWorkSessionsByTask(taskId: string, skip = 0, limit = 20, enabled = true) {
   return useQuery({
     queryKey: queryKeys.workSessions.byTask(taskId, skip, limit),
     queryFn: () => workSessionsApi.getByTask(taskId, skip, limit),
-    enabled: !!taskId,
+    enabled: !!taskId && enabled,
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -42,7 +42,8 @@ export const queryKeys = {
     details: () => [...queryKeys.logs.all, 'detail'] as const,
     detail: (id: string) => [...queryKeys.logs.details(), id] as const,
     byTask: (taskId: string) => [...queryKeys.logs.all, 'task', taskId] as const,
-    batch: (taskIds: string[], skip = 0, limit = 50) => ['logs', 'batch', { skip, limit }, ...[...taskIds].sort()] as const,
+    batches: () => [...queryKeys.logs.all, 'batch'] as const,
+    batch: (taskIds: string[], skip = 0, limit = 50) => [...queryKeys.logs.batches(), { skip, limit }, ...[...taskIds].sort()] as const,
   },
 
   // Progress keys

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -42,7 +42,7 @@ export const queryKeys = {
     details: () => [...queryKeys.logs.all, 'detail'] as const,
     detail: (id: string) => [...queryKeys.logs.details(), id] as const,
     byTask: (taskId: string) => [...queryKeys.logs.all, 'task', taskId] as const,
-    batch: (taskIds: string[]) => ['logs', 'batch', ...taskIds.sort()] as const,
+    batch: (taskIds: string[], skip = 0, limit = 50) => ['logs', 'batch', { skip, limit }, ...[...taskIds].sort()] as const,
   },
 
   // Progress keys


### PR DESCRIPTION
## Summary
- Fetch goal-detail task logs once with `useBatchLogsQuery(taskIds)` and reuse the grouped logs for actual-time cells and row memo panels.
- Stop mounting per-task log queries from `TaskLogsMemoPanel`; work sessions now fetch only after the panel is opened.
- Keep batch log caches fresh after log create/update/delete and preserve the previous 50-log default limit for batch reads.

## Impact
This removes the task-row log N+1 pattern described in #283. A goal with many tasks should now issue one batch log request for the visible task list instead of one log request per task, while session history requests are delayed until a user expands an individual task panel.

Closes #283

## Validation
- Passed: `export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; pnpm --filter @human-compiler/web exec jest src/hooks/__tests__/use-logs-query.test.ts --runInBand`.
- Passed: `git diff --check`.
- Attempted: `export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; pnpm --filter @human-compiler/web type-check`; it fails on existing environment/dependency issues unrelated to this change: missing `@dnd-kit/*`, `@tiptap/*`, `lowlight`, `@radix-ui/react-alert-dialog`, `@radix-ui/react-radio-group`, plus an existing `src/hooks/use-notifications.ts` BufferSource type error. pnpm also reports `Local package.json exists, but node_modules missing, did you mean to install?`.

## Environment note
`pnpm` is installed under nvm at `/home/masa10/.nvm/versions/node/v18.20.7/bin/pnpm` and reports version 9.0.0 after sourcing nvm. The default non-interactive Codex shell does not source nvm because `~/.bashrc` returns early for non-interactive shells, so it initially saw `/usr/bin/node` v12.22.9 and no `pnpm` on PATH.