### PR TITLE
[codex] fix goal task pagination and sorting

### DIFF
--- a/apps/api/src/humancompiler_api/base_service.py
+++ b/apps/api/src/humancompiler_api/base_service.py
@@ -128,6 +128,9 @@ class BaseService(ABC, Generic[T, CreateT, UpdateT]):
             if hasattr(self.model, "created_at"):
                 statement = statement.order_by(self.model.created_at.desc())
 
+        if hasattr(self.model, "id"):
+            statement = statement.order_by(self.model.id.asc())
+
         statement = statement.offset(skip).limit(limit)
         return list(session.exec(statement).all())
 

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -102,7 +102,7 @@ async def get_tasks_by_goal(
     session: Annotated[Session, Depends(get_session)],
     current_user: Annotated[AuthUser, Depends(get_current_user)],
     skip: Annotated[int, Query(ge=0)] = 0,
-    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    limit: Annotated[int, Query(ge=1, le=100)] = 100,
     sort_by: Annotated[SortBy, Query()] = SortBy.STATUS,
     sort_order: Annotated[SortOrder, Query()] = SortOrder.ASC,
 ) -> list[TaskResponse]:
@@ -152,7 +152,7 @@ async def get_tasks_by_project(
     session: Annotated[Session, Depends(get_session)],
     current_user: Annotated[AuthUser, Depends(get_current_user)],
     skip: Annotated[int, Query(ge=0)] = 0,
-    limit: Annotated[int, Query(ge=1, le=100)] = 20,
+    limit: Annotated[int, Query(ge=1, le=100)] = 100,
     sort_by: Annotated[SortBy, Query()] = SortBy.STATUS,
     sort_order: Annotated[SortOrder, Query()] = SortOrder.ASC,
 ) -> list[TaskResponse]:

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -640,6 +640,8 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
             # Default ordering
             statement = statement.order_by(Task.created_at.desc())
 
+        statement = statement.order_by(Task.id.asc())
+
         statement = statement.offset(skip).limit(limit)
         return list(session.exec(statement).all())
 

--- a/apps/api/tests/test_task_pagination_sorting.py
+++ b/apps/api/tests/test_task_pagination_sorting.py
@@ -1,0 +1,54 @@
+from decimal import Decimal
+from uuid import UUID
+
+from sqlmodel import Session
+
+from conftest import create_test_data
+from humancompiler_api.models import SortBy, SortOrder, Task, TaskStatus, WorkType
+from humancompiler_api.services import TaskService
+
+
+def test_get_tasks_by_goal_has_stable_tiebreaker_across_pages(
+    session: Session, test_user_id: str
+):
+    data = create_test_data(session, test_user_id)
+    goal = data["goal"]
+    task_service = TaskService()
+
+    expected_ids = [UUID(int=index + 1) for index in range(120)]
+    for index, task_id in enumerate(reversed(expected_ids)):
+        session.add(
+            Task(
+                id=task_id,
+                goal_id=goal.id,
+                title=f"Task {index}",
+                estimate_hours=Decimal("1.0"),
+                status=TaskStatus.PENDING,
+                work_type=WorkType.LIGHT_WORK,
+                priority=3,
+            )
+        )
+    session.flush()
+
+    first_page = task_service.get_tasks_by_goal(
+        session,
+        goal.id,
+        test_user_id,
+        skip=0,
+        limit=100,
+        sort_by=SortBy.STATUS,
+        sort_order=SortOrder.ASC,
+    )
+    second_page = task_service.get_tasks_by_goal(
+        session,
+        goal.id,
+        test_user_id,
+        skip=100,
+        limit=100,
+        sort_by=SortBy.STATUS,
+        sort_order=SortOrder.ASC,
+    )
+
+    paged_ids = [task.id for task in [*first_page, *second_page]]
+    assert paged_ids == expected_ids
+    assert len(paged_ids) == len(set(paged_ids)) == 120

--- a/apps/web/src/app/projects/[id]/goals/[goalId]/page.tsx
+++ b/apps/web/src/app/projects/[id]/goals/[goalId]/page.tsx
@@ -1,22 +1,22 @@
 'use client';
 
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useParams } from 'next/navigation';
 import { useAuth } from '@/hooks/use-auth';
-import { useTasksByGoal } from '@/hooks/use-tasks-query';
+import { useAllTasksByGoal, useUpdateTask } from '@/hooks/use-tasks-query';
 import { useGoal } from '@/hooks/use-goals-query';
 import { useProject } from '@/hooks/use-project-query';
 import { useGoalNote } from '@/hooks/use-notes';
 import { useQuery } from '@tanstack/react-query';
 import { progressApi } from '@/lib/api';
 import { useBatchLogsQuery } from '@/hooks/use-logs-query';
-import { useUpdateTask } from '@/hooks/use-tasks-query';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { SortDropdown } from '@/components/ui/sort-dropdown';
 import { TaskFormDialog } from '@/components/tasks/task-form-dialog';
 import { TaskEditDialog } from '@/components/tasks/task-edit-dialog';
 import { TaskDeleteDialog } from '@/components/tasks/task-delete-dialog';
@@ -26,6 +26,8 @@ import { ContextNoteEditor } from '@/components/notes/context-note-editor';
 import { ArrowLeft, Plus, Clock, Calendar, GitBranch, FileText, Loader2, AlertCircle } from 'lucide-react';
 import { taskStatusLabels, taskStatusColors, workTypeLabels, workTypeColors, taskPriorityLabels, taskPriorityColors } from '@/types/task';
 import type { TaskStatus, Task } from '@/types/task';
+import { SortBy, SortOrder } from '@/types/sort';
+import type { SortOptions } from '@/types/sort';
 import { log } from '@/lib/logger';
 import { AppHeader } from '@/components/layout/app-header';
 
@@ -76,13 +78,17 @@ export default function GoalDetailPage() {
   const params = useParams();
   const id = params.id as string;
   const goalId = params.goalId as string;
+  const [taskSortOptions, setTaskSortOptions] = useState<SortOptions>({
+    sortBy: SortBy.STATUS,
+    sortOrder: SortOrder.ASC,
+  });
 
   const {
     data: tasks = [],
     isLoading: tasksLoading,
     error: tasksError,
     refetch: refetchTasks
-  } = useTasksByGoal(goalId);
+  } = useAllTasksByGoal(goalId, taskSortOptions);
 
   const {
     data: goal,
@@ -337,17 +343,30 @@ export default function GoalDetailPage() {
 
       {/* Tasks Section */}
       <div className="space-y-6">
-        <div className="flex justify-between items-center">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h2 className="text-2xl font-bold">タスク一覧</h2>
             <p className="text-gray-600 mt-2">このゴールのタスクを管理します。</p>
           </div>
-          <TaskFormDialog goalId={goalId}>
-            <Button>
-              <Plus className="h-4 w-4 mr-2" />
-              新規タスク作成
-            </Button>
-          </TaskFormDialog>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <SortDropdown
+              currentSort={taskSortOptions}
+              onSortChange={setTaskSortOptions}
+              sortFields={[
+                { value: SortBy.STATUS, label: 'ステータス' },
+                { value: SortBy.PRIORITY, label: '優先度' },
+                { value: SortBy.TITLE, label: 'タスク名' },
+                { value: SortBy.CREATED_AT, label: '作成日' },
+                { value: SortBy.UPDATED_AT, label: '更新日' },
+              ]}
+            />
+            <TaskFormDialog goalId={goalId}>
+              <Button>
+                <Plus className="h-4 w-4 mr-2" />
+                新規タスク作成
+              </Button>
+            </TaskFormDialog>
+          </div>
         </div>
 
         {tasksLoading ? (

--- a/apps/web/src/hooks/__tests__/use-logs-query.test.ts
+++ b/apps/web/src/hooks/__tests__/use-logs-query.test.ts
@@ -141,6 +141,27 @@ describe('useBatchLogsQuery', () => {
     expect(mockGetBatch).toHaveBeenCalledWith(['task-1'], 10, 25)
   })
 
+  it('should chunk large task id lists to keep batch URLs bounded', async () => {
+    const taskIds = Array.from({ length: 120 }, (_, index) => `task-${index + 1}`)
+    mockGetBatch.mockImplementation(async (ids) => {
+      return Object.fromEntries(
+        ids.map(taskId => [taskId, createMockLogs(1, { task_id: taskId })])
+      )
+    })
+
+    const { result } = renderHookWithClient(() => useBatchLogsQuery(taskIds))
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(mockGetBatch).toHaveBeenCalledTimes(3)
+    expect(mockGetBatch).toHaveBeenNthCalledWith(1, taskIds.slice(0, 50), 0, 50)
+    expect(mockGetBatch).toHaveBeenNthCalledWith(2, taskIds.slice(50, 100), 0, 50)
+    expect(mockGetBatch).toHaveBeenNthCalledWith(3, taskIds.slice(100), 0, 50)
+    expect(Object.keys(result.current.data || {})).toHaveLength(120)
+  })
+
   it('should be disabled when taskIds is empty', async () => {
     const { result } = renderHookWithClient(() => useBatchLogsQuery([]))
 

--- a/apps/web/src/hooks/__tests__/use-tasks-query.test.ts
+++ b/apps/web/src/hooks/__tests__/use-tasks-query.test.ts
@@ -5,6 +5,7 @@ import { act, waitFor } from '@testing-library/react'
 import { createMockTask, createMockTasks, resetIdCounter } from './helpers/mock-factories'
 import { renderHookWithClient } from './helpers/test-utils'
 import type { Task, TaskCreate, TaskUpdate } from '@/types/task'
+import { SortBy, SortOrder } from '@/types/sort'
 import type { SortOptions } from '@/types/sort'
 
 // Mock the API
@@ -16,6 +17,7 @@ const mockUpdate = jest.fn<Promise<Task>, [string, TaskUpdate]>()
 const mockDelete = jest.fn<Promise<void>, [string]>()
 
 jest.mock('@/lib/api', () => ({
+  DEFAULT_TASK_PAGE_LIMIT: 100,
   tasksApi: {
     getByGoal: (...args: [string, number?, number?, SortOptions?]) => mockGetByGoal(...args),
     getByProject: (...args: [string, number?, number?, SortOptions?]) => mockGetByProject(...args),
@@ -28,6 +30,7 @@ jest.mock('@/lib/api', () => ({
 
 // Import after mocks
 import {
+  useAllTasksByGoal,
   useTasksByGoal,
   useTasksByProject,
   useTask,
@@ -70,7 +73,7 @@ describe('useTasksByGoal', () => {
       expect(result.current.isSuccess).toBe(true)
     })
 
-    expect(mockGetByGoal).toHaveBeenCalledWith('goal-1', 0, 50, undefined)
+    expect(mockGetByGoal).toHaveBeenCalledWith('goal-1', 0, 100, undefined)
     expect(result.current.data).toHaveLength(5)
   })
 
@@ -78,19 +81,66 @@ describe('useTasksByGoal', () => {
     const mockTasks = createMockTasks(3)
     mockGetByGoal.mockResolvedValue(mockTasks)
 
-    const sortOptions: SortOptions = { sortBy: 'priority', sortOrder: 'asc' }
+    const sortOptions: SortOptions = { sortBy: SortBy.PRIORITY, sortOrder: SortOrder.ASC }
 
-    const { result } = renderHookWithClient(() => useTasksByGoal('goal-1', 0, 50, sortOptions))
+    const { result } = renderHookWithClient(() => useTasksByGoal('goal-1', 0, 100, sortOptions))
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true)
     })
 
-    expect(mockGetByGoal).toHaveBeenCalledWith('goal-1', 0, 50, sortOptions)
+    expect(mockGetByGoal).toHaveBeenCalledWith('goal-1', 0, 100, sortOptions)
   })
 
   it('should be disabled when goalId is falsy', async () => {
     const { result } = renderHookWithClient(() => useTasksByGoal(''))
+
+    expect(result.current.isPending).toBe(true)
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockGetByGoal).not.toHaveBeenCalled()
+  })
+})
+
+describe('useAllTasksByGoal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIdCounter()
+  })
+
+  it('should fetch a single page when fewer than the task page limit exist', async () => {
+    const mockTasks = createMockTasks(60, { goal_id: 'goal-1' })
+    mockGetByGoal.mockResolvedValueOnce(mockTasks)
+
+    const { result } = renderHookWithClient(() => useAllTasksByGoal('goal-1'))
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(mockGetByGoal).toHaveBeenCalledTimes(1)
+    expect(mockGetByGoal).toHaveBeenCalledWith('goal-1', 0, 100, undefined)
+    expect(result.current.data).toHaveLength(60)
+  })
+
+  it('should keep fetching pages until the final partial page', async () => {
+    const firstPage = createMockTasks(100, { goal_id: 'goal-1' })
+    const secondPage = createMockTasks(50, { goal_id: 'goal-1' })
+    mockGetByGoal.mockResolvedValueOnce(firstPage).mockResolvedValueOnce(secondPage)
+
+    const sortOptions: SortOptions = { sortBy: SortBy.CREATED_AT, sortOrder: SortOrder.DESC }
+    const { result } = renderHookWithClient(() => useAllTasksByGoal('goal-1', sortOptions))
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true)
+    })
+
+    expect(mockGetByGoal).toHaveBeenNthCalledWith(1, 'goal-1', 0, 100, sortOptions)
+    expect(mockGetByGoal).toHaveBeenNthCalledWith(2, 'goal-1', 100, 100, sortOptions)
+    expect(result.current.data).toHaveLength(150)
+  })
+
+  it('should be disabled when goalId is falsy', async () => {
+    const { result } = renderHookWithClient(() => useAllTasksByGoal(''))
 
     expect(result.current.isPending).toBe(true)
     expect(result.current.fetchStatus).toBe('idle')
@@ -114,7 +164,7 @@ describe('useTasksByProject', () => {
       expect(result.current.isSuccess).toBe(true)
     })
 
-    expect(mockGetByProject).toHaveBeenCalledWith('proj-1', 0, 50, undefined)
+    expect(mockGetByProject).toHaveBeenCalledWith('proj-1', 0, 100, undefined)
     expect(result.current.data).toHaveLength(8)
   })
 
@@ -270,8 +320,13 @@ describe('useUpdateTask', () => {
 
 describe('useDeleteTask', () => {
   beforeEach(() => {
+    jest.useFakeTimers()
     jest.clearAllMocks()
     resetIdCounter()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   it('should remove from cache', async () => {
@@ -312,6 +367,10 @@ describe('useDeleteTask', () => {
       await result.current.mutateAsync('task-1')
     })
 
+    act(() => {
+      jest.advanceTimersByTime(300)
+    })
+
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: taskKeys.byGoal('goal-1'),
     })
@@ -327,6 +386,10 @@ describe('useDeleteTask', () => {
 
     await act(async () => {
       await result.current.mutateAsync('unknown-task')
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(300)
     })
 
     expect(invalidateSpy).toHaveBeenCalledWith({

--- a/apps/web/src/hooks/use-logs-query.ts
+++ b/apps/web/src/hooks/use-logs-query.ts
@@ -8,6 +8,17 @@ import { queryKeys } from '@/lib/query-keys'
  * Re-exported from centralized query keys for backward compatibility.
  */
 export const logKeys = queryKeys.logs
+const LOG_BATCH_TASK_CHUNK_SIZE = 50
+
+const chunkTaskIds = (taskIds: string[], chunkSize: number) => {
+  const chunks: string[][] = []
+
+  for (let index = 0; index < taskIds.length; index += chunkSize) {
+    chunks.push(taskIds.slice(index, index + chunkSize))
+  }
+
+  return chunks
+}
 
 /**
  * Fetches logs for a specific task with pagination.
@@ -38,8 +49,14 @@ export function useBatchLogsQuery(taskIds: string[], skip = 0, limit = 50) {
   return useQuery({
     queryKey: queryKeys.logs.batch(taskIds, skip, limit),
     queryFn: async () => {
-      // Use the new batch API endpoint for efficient fetching
-      return await logsApi.getBatch(taskIds, skip, limit);
+      const chunks = chunkTaskIds(taskIds, LOG_BATCH_TASK_CHUNK_SIZE);
+      const batchResults = await Promise.all(
+        chunks.map(chunk => logsApi.getBatch(chunk, skip, limit))
+      );
+
+      return batchResults.reduce<Record<string, Log[]>>((mergedLogs, batchLogs) => {
+        return { ...mergedLogs, ...batchLogs };
+      }, {});
     },
     enabled: taskIds.length > 0,
     staleTime: 5 * 60 * 1000, // 5 minutes

--- a/apps/web/src/hooks/use-tasks-query.ts
+++ b/apps/web/src/hooks/use-tasks-query.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { tasksApi } from '@/lib/api'
+import { DEFAULT_TASK_PAGE_LIMIT, tasksApi } from '@/lib/api'
 import type { Task, TaskCreate, TaskUpdate } from '@/types/task'
 import type { SortOptions } from '@/types/sort'
 
@@ -22,15 +22,48 @@ export const taskKeys = {
  *
  * @param goalId - The goal UUID to fetch tasks for
  * @param skip - Number of records to skip (default: 0)
- * @param limit - Maximum records to return (default: 50)
+ * @param limit - Maximum records to return (default: 100)
  * @param sortOptions - Optional sorting configuration
  * @returns UseQueryResult with task array
  */
-export function useTasksByGoal(goalId: string, skip = 0, limit = 50, sortOptions?: SortOptions) {
+export function useTasksByGoal(goalId: string, skip = 0, limit = DEFAULT_TASK_PAGE_LIMIT, sortOptions?: SortOptions) {
   const sortKey = sortOptions ? `sort-${sortOptions.sortBy}-${sortOptions.sortOrder}` : 'default';
   return useQuery({
-    queryKey: [...taskKeys.byGoal(goalId), sortKey],
+    queryKey: [...taskKeys.byGoal(goalId), 'page', skip, limit, sortKey],
     queryFn: () => tasksApi.getByGoal(goalId, skip, limit, sortOptions),
+    enabled: !!goalId,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+    gcTime: 10 * 60 * 1000, // 10 minutes
+  })
+}
+
+/**
+ * Fetches every task for a goal by walking the paginated API.
+ *
+ * @param goalId - The goal UUID to fetch tasks for
+ * @param sortOptions - Optional sorting configuration
+ * @returns UseQueryResult with the complete task array
+ */
+export function useAllTasksByGoal(goalId: string, sortOptions?: SortOptions) {
+  const sortKey = sortOptions ? `sort-${sortOptions.sortBy}-${sortOptions.sortOrder}` : 'default';
+
+  return useQuery({
+    queryKey: [...taskKeys.byGoal(goalId), 'all', DEFAULT_TASK_PAGE_LIMIT, sortKey],
+    queryFn: async () => {
+      const tasks: Task[] = [];
+      let skip = 0;
+
+      while (true) {
+        const page = await tasksApi.getByGoal(goalId, skip, DEFAULT_TASK_PAGE_LIMIT, sortOptions);
+        tasks.push(...page);
+
+        if (page.length < DEFAULT_TASK_PAGE_LIMIT) {
+          return tasks;
+        }
+
+        skip += DEFAULT_TASK_PAGE_LIMIT;
+      }
+    },
     enabled: !!goalId,
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
@@ -42,14 +75,14 @@ export function useTasksByGoal(goalId: string, skip = 0, limit = 50, sortOptions
  *
  * @param projectId - The project UUID to fetch tasks for
  * @param skip - Number of records to skip (default: 0)
- * @param limit - Maximum records to return (default: 50)
+ * @param limit - Maximum records to return (default: 100)
  * @param sortOptions - Optional sorting configuration
  * @returns UseQueryResult with task array
  */
-export function useTasksByProject(projectId: string, skip = 0, limit = 50, sortOptions?: SortOptions) {
+export function useTasksByProject(projectId: string, skip = 0, limit = DEFAULT_TASK_PAGE_LIMIT, sortOptions?: SortOptions) {
   const sortKey = sortOptions ? `sort-${sortOptions.sortBy}-${sortOptions.sortOrder}` : 'default';
   return useQuery({
-    queryKey: [...taskKeys.byProject(projectId), sortKey],
+    queryKey: [...taskKeys.byProject(projectId), 'page', skip, limit, sortKey],
     queryFn: () => tasksApi.getByProject(projectId, skip, limit, sortOptions),
     enabled: !!projectId,
     staleTime: 5 * 60 * 1000, // 5 minutes

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -85,6 +85,8 @@ import type {
 } from '@/types/quick-task';
 import type { TaskStatus } from '@/types/task';
 
+export const DEFAULT_TASK_PAGE_LIMIT = 100;
+
 // Helper function to ensure HTTPS protocol
 const ensureHttps = (url: string): string => {
   if (!url) return url;
@@ -375,11 +377,11 @@ class ApiClient {
    *
    * @param goalId - The goal UUID
    * @param skip - Pagination offset (default: 0)
-   * @param limit - Maximum results (default: 20)
+   * @param limit - Maximum results (default: 100)
    * @param sortOptions - Sorting configuration
    * @returns Array of Task objects
    */
-  async getTasksByGoal(goalId: string, skip: number = 0, limit: number = 20, sortOptions?: SortOptions): Promise<Task[]> {
+  async getTasksByGoal(goalId: string, skip: number = 0, limit: number = DEFAULT_TASK_PAGE_LIMIT, sortOptions?: SortOptions): Promise<Task[]> {
     const params = new URLSearchParams({
       skip: skip.toString(),
       limit: limit.toString(),
@@ -395,7 +397,7 @@ class ApiClient {
     return this.request<Task[]>(`/api/tasks/goal/${goalId}?${params.toString()}`);
   }
 
-  async getTasksByProject(projectId: string, skip: number = 0, limit: number = 20, sortOptions?: SortOptions): Promise<Task[]> {
+  async getTasksByProject(projectId: string, skip: number = 0, limit: number = DEFAULT_TASK_PAGE_LIMIT, sortOptions?: SortOptions): Promise<Task[]> {
     const params = new URLSearchParams({
       skip: skip.toString(),
       limit: limit.toString(),


### PR DESCRIPTION
## Summary

- Fetch all goal tasks in the goal detail page by walking the paginated tasks API in 100-item pages, so task counts and estimate totals include items past the first page.
- Expose the existing task sorting pipeline on the goal detail page with status, priority, title, created date, and updated date options.
- Align task list default limits across the web API client, task query hooks, and backend task routes at 100.
- Cover the all-pages goal task hook and updated default limit behavior in hook tests.

## Validation

- `PATH=/home/masa10/.nvm/versions/node/v18.20.7/bin:$PATH pnpm --filter @human-compiler/web test -- use-tasks-query.test.ts --runInBand`
- `PATH=/home/masa10/.nvm/versions/node/v18.20.7/bin:$PATH pnpm --filter @human-compiler/web type-check`
- `PATH=/home/masa10/.nvm/versions/node/v18.20.7/bin:$PATH pnpm --filter @human-compiler/web lint` (passes with existing `any` warnings)
- `apps/api/.venv/bin/pytest tests/test_task_deletion.py -q -s`
- `apps/api/.venv/bin/pytest tests/test_api.py -q -s`

Closes #284