### PR TITLE
[codex] fix task edit optional field clearing

### DIFF
--- a/apps/api/tests/test_task_update_clears_optional_fields.py
+++ b/apps/api/tests/test_task_update_clears_optional_fields.py
@@ -1,0 +1,41 @@
+from datetime import UTC, datetime
+
+from sqlmodel import Session
+
+from conftest import create_test_data
+from humancompiler_api.models import TaskCreate, TaskUpdate
+from humancompiler_api.services import TaskService
+
+
+def test_update_task_with_explicit_null_clears_description_and_due_date(
+    session: Session, test_user_id: str
+):
+    data = create_test_data(session, test_user_id)
+    task_service = TaskService()
+    due_date = datetime(2026, 1, 15, tzinfo=UTC)
+    task = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Task with optional fields",
+            description="Clear me",
+            estimate_hours=2,
+            due_date=due_date,
+        ),
+        test_user_id,
+    )
+
+    updated_task = task_service.update_task(
+        session,
+        task.id,
+        test_user_id,
+        TaskUpdate(description=None, due_date=None),
+    )
+
+    assert updated_task.description is None
+    assert updated_task.due_date is None
+
+    session.expire_all()
+    persisted_task = task_service.get_task(session, task.id, test_user_id)
+    assert persisted_task.description is None
+    assert persisted_task.due_date is None

--- a/apps/web/src/components/tasks/__tests__/task-edit-payload.test.ts
+++ b/apps/web/src/components/tasks/__tests__/task-edit-payload.test.ts
@@ -1,0 +1,37 @@
+import { buildTaskEditUpdatePayload } from '../task-edit-payload';
+
+describe('buildTaskEditUpdatePayload', () => {
+  it('keeps cleared optional fields in JSON by sending explicit nulls', () => {
+    const payload = buildTaskEditUpdatePayload({
+      title: 'Updated task',
+      description: '',
+      estimate_hours: 2,
+      due_date: '',
+      status: 'pending',
+      work_type: 'focused_work',
+      priority: 2,
+    });
+
+    expect(payload.description).toBeNull();
+    expect(payload.due_date).toBeNull();
+    expect(JSON.parse(JSON.stringify(payload))).toMatchObject({
+      description: null,
+      due_date: null,
+    });
+  });
+
+  it('preserves non-empty optional fields', () => {
+    const payload = buildTaskEditUpdatePayload({
+      title: 'Updated task',
+      description: 'Keep this',
+      estimate_hours: 2,
+      due_date: '2026-01-15',
+      status: 'in_progress',
+      work_type: 'study',
+      priority: 1,
+    });
+
+    expect(payload.description).toBe('Keep this');
+    expect(payload.due_date).toBe('2026-01-15');
+  });
+});

--- a/apps/web/src/components/tasks/task-edit-dialog.tsx
+++ b/apps/web/src/components/tasks/task-edit-dialog.tsx
@@ -39,6 +39,7 @@ import { TaskDependenciesManager } from './task-dependencies-manager';
 import { SessionHistory } from '@/components/runner/session-history';
 import type { Task } from '@/types/task';
 import { roundToDecimals, parseFloatSafe } from '@/lib/number-utils';
+import { buildTaskEditUpdatePayload } from './task-edit-payload';
 
 const taskFormSchema = z.object({
   title: z.string().min(1, '必須項目です').max(100, '100文字以内で入力してください'),
@@ -97,15 +98,7 @@ export function TaskEditDialog({ task, availableTasks = [], children }: TaskEdit
     try {
       await updateTaskMutation.mutateAsync({
         id: task.id,
-        data: {
-          title: data.title,
-          description: data.description || undefined,
-          estimate_hours: data.estimate_hours,
-          due_date: data.due_date || undefined,
-          status: data.status,
-          work_type: data.work_type || 'light_work',
-          priority: data.priority || 3,
-        }
+        data: buildTaskEditUpdatePayload(data),
       });
 
       toast({

--- a/apps/web/src/components/tasks/task-edit-payload.ts
+++ b/apps/web/src/components/tasks/task-edit-payload.ts
@@ -1,0 +1,23 @@
+import type { TaskStatus, TaskUpdate, WorkType } from '@/types/task';
+
+interface TaskEditPayloadInput {
+  title: string;
+  description?: string;
+  estimate_hours: number;
+  due_date?: string;
+  status: TaskStatus;
+  work_type?: WorkType;
+  priority?: number;
+}
+
+export function buildTaskEditUpdatePayload(data: TaskEditPayloadInput): TaskUpdate {
+  return {
+    title: data.title,
+    description: data.description === '' ? null : data.description,
+    estimate_hours: data.estimate_hours,
+    due_date: data.due_date === '' ? null : data.due_date,
+    status: data.status,
+    work_type: data.work_type || 'light_work',
+    priority: data.priority || 3,
+  };
+}

--- a/apps/web/src/types/task.ts
+++ b/apps/web/src/types/task.ts
@@ -110,13 +110,13 @@ export interface TaskUpdate {
   /** タスクタイトル */
   title?: string;
   /** タスク説明 */
-  description?: string;
+  description?: string | null;
   /** メモ */
-  memo?: string;
+  memo?: string | null;
   /** 見積もり時間（時間単位） */
   estimate_hours?: number;
   /** 期限日 (ISO 8601形式) */
-  due_date?: string;
+  due_date?: string | null;
   /** ステータス */
   status?: TaskStatus;
   /** 作業種別 */


### PR DESCRIPTION
## Summary

- タスク編集の送信payloadで、空欄にした`description`と`due_date`を`undefined`ではなく明示的な`null`として送るようにしました。
- frontendの`TaskUpdate`型をAPIのnullable update schemaに合わせました。
- frontend payloadテストとbackend serviceテストを追加し、明示`null`で説明・締切日がクリアされることを確認しました。

## Root Cause

`TaskEditDialog`が空欄を`undefined`に変換していたため、`JSON.stringify`で該当フィールドが欠落していました。backendの更新処理は`model_dump(exclude_unset=True)`を使うため、未送信フィールドは更新対象にならず、既存の説明・締切日が残っていました。

## Validation

- `pnpm --filter @human-compiler/web test -- task-edit-payload.test.ts`
- `pnpm --filter @human-compiler/web type-check`
- `cd apps/api && ./.venv/bin/python -m pytest -s tests/test_task_update_clears_optional_fields.py`
- `cd apps/api && ./.venv/bin/ruff check tests/test_task_update_clears_optional_fields.py`

Closes #282