### PR TITLE
[codex] fix task query cache invalidation

### DIFF
--- a/apps/web/src/components/tasks/task-dependencies-manager.tsx
+++ b/apps/web/src/components/tasks/task-dependencies-manager.tsx
@@ -12,9 +12,9 @@ import {
 } from '@/components/ui/select';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { tasksApi } from '@/lib/api';
 import { toast } from '@/hooks/use-toast';
-import type { Task, TaskDependency } from '@/types/task';
+import { useAddTaskDependency, useDeleteTaskDependency } from '@/hooks/use-tasks-query';
+import type { Task } from '@/types/task';
 
 interface TaskDependenciesManagerProps {
   task: Task;
@@ -29,10 +29,10 @@ export function TaskDependenciesManager({
   onDependencyAdded,
   onDependencyRemoved,
 }: TaskDependenciesManagerProps) {
-  const [dependencies, setDependencies] = useState<TaskDependency[]>(task.dependencies || []);
   const [selectedTaskId, setSelectedTaskId] = useState<string>('');
-  const [isAdding, setIsAdding] = useState(false);
-  const [isRemoving, setIsRemoving] = useState<string | null>(null);
+  const dependencies = task.dependencies || [];
+  const addDependencyMutation = useAddTaskDependency(task, availableTasks);
+  const deleteDependencyMutation = useDeleteTaskDependency(task);
 
   // Filter out tasks that cannot be dependencies
   const selectableTasks = availableTasks.filter(t => {
@@ -46,17 +46,9 @@ export function TaskDependenciesManager({
   const handleAddDependency = async () => {
     if (!selectedTaskId) return;
 
-    setIsAdding(true);
+    const dependsOnTask = availableTasks.find(t => t.id === selectedTaskId);
     try {
-      const newDependency = await tasksApi.addDependency(task.id, selectedTaskId);
-
-      // Find the task details for the new dependency
-      const dependsOnTask = availableTasks.find(t => t.id === selectedTaskId);
-      if (dependsOnTask) {
-        newDependency.depends_on_task = dependsOnTask;
-      }
-
-      setDependencies([...dependencies, newDependency]);
+      await addDependencyMutation.mutateAsync(selectedTaskId);
       setSelectedTaskId('');
       toast({
         title: '依存関係を追加しました',
@@ -69,16 +61,12 @@ export function TaskDependenciesManager({
         description: '依存関係の追加に失敗しました。',
         variant: 'destructive',
       });
-    } finally {
-      setIsAdding(false);
     }
   };
 
   const handleRemoveDependency = async (dependencyId: string) => {
-    setIsRemoving(dependencyId);
     try {
-      await tasksApi.deleteDependency(task.id, dependencyId);
-      setDependencies(dependencies.filter(d => d.id !== dependencyId));
+      await deleteDependencyMutation.mutateAsync(dependencyId);
       toast({
         title: '依存関係を削除しました',
       });
@@ -89,8 +77,6 @@ export function TaskDependenciesManager({
         description: '依存関係の削除に失敗しました。',
         variant: 'destructive',
       });
-    } finally {
-      setIsRemoving(null);
     }
   };
 
@@ -126,7 +112,10 @@ export function TaskDependenciesManager({
                   size="sm"
                   variant="ghost"
                   onClick={() => handleRemoveDependency(dep.id)}
-                  disabled={isRemoving === dep.id}
+                  disabled={
+                    deleteDependencyMutation.isPending &&
+                    deleteDependencyMutation.variables === dep.id
+                  }
                 >
                   <X className="h-4 w-4" />
                 </Button>
@@ -140,7 +129,7 @@ export function TaskDependenciesManager({
         <Select
           value={selectedTaskId}
           onValueChange={setSelectedTaskId}
-          disabled={isAdding || selectableTasks.length === 0}
+          disabled={addDependencyMutation.isPending || selectableTasks.length === 0}
         >
           <SelectTrigger className="flex-1">
             <SelectValue placeholder="依存タスクを選択..." />
@@ -156,7 +145,7 @@ export function TaskDependenciesManager({
         <Button
           size="sm"
           onClick={handleAddDependency}
-          disabled={!selectedTaskId || isAdding}
+          disabled={!selectedTaskId || addDependencyMutation.isPending}
         >
           <Plus className="h-4 w-4 mr-1" />
           追加

--- a/apps/web/src/components/tasks/task-edit-dialog.tsx
+++ b/apps/web/src/components/tasks/task-edit-dialog.tsx
@@ -311,12 +311,6 @@ export function TaskEditDialog({ task, availableTasks = [], children }: TaskEdit
             <TaskDependenciesManager
               task={task}
               availableTasks={availableTasks}
-              onDependencyAdded={() => {
-                // Optionally refresh task data
-              }}
-              onDependencyRemoved={() => {
-                // Optionally refresh task data
-              }}
             />
           </TabsContent>
 

--- a/apps/web/src/hooks/__tests__/use-tasks-query.test.ts
+++ b/apps/web/src/hooks/__tests__/use-tasks-query.test.ts
@@ -2,9 +2,10 @@
  * @jest-environment jsdom
  */
 import { act, waitFor } from '@testing-library/react'
+import { QueryClient } from '@tanstack/react-query'
 import { createMockTask, createMockTasks, resetIdCounter } from './helpers/mock-factories'
 import { renderHookWithClient } from './helpers/test-utils'
-import type { Task, TaskCreate, TaskUpdate } from '@/types/task'
+import type { Task, TaskCreate, TaskDependency, TaskUpdate } from '@/types/task'
 import { SortBy, SortOrder } from '@/types/sort'
 import type { SortOptions } from '@/types/sort'
 
@@ -15,6 +16,22 @@ const mockGetById = jest.fn<Promise<Task>, [string]>()
 const mockCreate = jest.fn<Promise<Task>, [TaskCreate]>()
 const mockUpdate = jest.fn<Promise<Task>, [string, TaskUpdate]>()
 const mockDelete = jest.fn<Promise<void>, [string]>()
+const mockAddDependency = jest.fn<Promise<TaskDependency>, [string, string]>()
+const mockDeleteDependency = jest.fn<Promise<void>, [string, string]>()
+
+const createPersistentQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Infinity,
+        staleTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  })
 
 jest.mock('@/lib/api', () => ({
   DEFAULT_TASK_PAGE_LIMIT: 100,
@@ -25,6 +42,8 @@ jest.mock('@/lib/api', () => ({
     create: (data: TaskCreate) => mockCreate(data),
     update: (id: string, data: TaskUpdate) => mockUpdate(id, data),
     delete: (id: string) => mockDelete(id),
+    addDependency: (taskId: string, dependsOnTaskId: string) => mockAddDependency(taskId, dependsOnTaskId),
+    deleteDependency: (taskId: string, dependencyId: string) => mockDeleteDependency(taskId, dependencyId),
   },
 }))
 
@@ -37,6 +56,8 @@ import {
   useCreateTask,
   useUpdateTask,
   useDeleteTask,
+  useAddTaskDependency,
+  useDeleteTaskDependency,
   taskKeys,
 } from '../use-tasks-query'
 
@@ -51,7 +72,6 @@ describe('taskKeys', () => {
 
   it('should generate correct keys for details', () => {
     expect(taskKeys.all).toEqual(['tasks'])
-    expect(taskKeys.lists()).toEqual(['tasks', 'list'])
     expect(taskKeys.details()).toEqual(['tasks', 'detail'])
     expect(taskKeys.detail('task-1')).toEqual(['tasks', 'detail', 'task-1'])
   })
@@ -234,7 +254,7 @@ describe('useCreateTask', () => {
     })
   })
 
-  it('should invalidate task lists', async () => {
+  it('should invalidate project task queries', async () => {
     const newTask = createMockTask({ id: 'new-task', goal_id: 'goal-1' })
     mockCreate.mockResolvedValue(newTask)
 
@@ -250,7 +270,7 @@ describe('useCreateTask', () => {
       })
     })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: taskKeys.lists() })
+    expect(invalidateSpy).toHaveBeenCalledWith({ predicate: expect.any(Function) })
   })
 
   it('should add task to cache', async () => {
@@ -283,7 +303,7 @@ describe('useUpdateTask', () => {
     resetIdCounter()
   })
 
-  it('should update cache and invalidate lists', async () => {
+  it('should update cache and invalidate goal and project task queries', async () => {
     const updatedTask = createMockTask({ id: 'task-1', title: 'Updated', goal_id: 'goal-1' })
     mockUpdate.mockResolvedValue(updatedTask)
 
@@ -314,7 +334,7 @@ describe('useUpdateTask', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: taskKeys.byGoal('goal-1'),
     })
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: taskKeys.lists() })
+    expect(invalidateSpy).toHaveBeenCalledWith({ predicate: expect.any(Function) })
   })
 })
 
@@ -376,7 +396,7 @@ describe('useDeleteTask', () => {
     })
   })
 
-  it('should fallback to invalidate all lists if goalId unknown', async () => {
+  it('should fallback to invalidate all goal and project task queries if goalId unknown', async () => {
     mockDelete.mockResolvedValue(undefined)
 
     const { result, queryClient } = renderHookWithClient(() => useDeleteTask())
@@ -392,8 +412,106 @@ describe('useDeleteTask', () => {
       jest.advanceTimersByTime(300)
     })
 
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: taskKeys.lists(),
+    expect(invalidateSpy).toHaveBeenCalledWith({ predicate: expect.any(Function) })
+  })
+})
+
+describe('useAddTaskDependency', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIdCounter()
+  })
+
+  it('should add dependency to task caches and invalidate task collections', async () => {
+    const task = createMockTask({ id: 'task-1', goal_id: 'goal-1', dependencies: [] })
+    const dependsOnTask = createMockTask({ id: 'task-2', title: 'Dependency task', status: 'pending' })
+    const dependency: TaskDependency = {
+      id: 'dep-1',
+      task_id: 'task-1',
+      depends_on_task_id: 'task-2',
+      created_at: '2025-01-01T00:00:00Z',
+      depends_on_task: null,
+    }
+    mockAddDependency.mockResolvedValue(dependency)
+
+    const queryClient = createPersistentQueryClient()
+    const { result } = renderHookWithClient(
+      () => useAddTaskDependency(task, [dependsOnTask]),
+      { queryClient }
+    )
+
+    queryClient.setQueryData(taskKeys.detail('task-1'), task)
+    queryClient.setQueryData([...taskKeys.byGoal('goal-1'), 'page', 0, 100, 'default'], [task])
+    queryClient.setQueryData([...taskKeys.byProject('project-1'), 'page', 0, 100, 'default'], [task])
+
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries')
+
+    await act(async () => {
+      await result.current.mutateAsync('task-2')
     })
+
+    expect(mockAddDependency).toHaveBeenCalledWith('task-1', 'task-2')
+    expect(queryClient.getQueryData<Task>(taskKeys.detail('task-1'))?.dependencies).toEqual([
+      {
+        ...dependency,
+        depends_on_task: {
+          id: 'task-2',
+          title: 'Dependency task',
+          status: 'pending',
+        },
+      },
+    ])
+    expect(queryClient.getQueryData<Task[]>([...taskKeys.byGoal('goal-1'), 'page', 0, 100, 'default'])?.[0].dependencies).toHaveLength(1)
+    expect(queryClient.getQueryData<Task[]>([...taskKeys.byProject('project-1'), 'page', 0, 100, 'default'])?.[0].dependencies).toHaveLength(1)
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: taskKeys.detail('task-1') })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: taskKeys.byGoal('goal-1') })
+    expect(invalidateSpy).toHaveBeenCalledWith({ predicate: expect.any(Function) })
+  })
+})
+
+describe('useDeleteTaskDependency', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetIdCounter()
+  })
+
+  it('should remove dependency from task caches and invalidate task collections', async () => {
+    const dependency: TaskDependency = {
+      id: 'dep-1',
+      task_id: 'task-1',
+      depends_on_task_id: 'task-2',
+      created_at: '2025-01-01T00:00:00Z',
+      depends_on_task: {
+        id: 'task-2',
+        title: 'Dependency task',
+        status: 'pending',
+      },
+    }
+    const task = createMockTask({ id: 'task-1', goal_id: 'goal-1', dependencies: [dependency] })
+    mockDeleteDependency.mockResolvedValue(undefined)
+
+    const queryClient = createPersistentQueryClient()
+    const { result } = renderHookWithClient(
+      () => useDeleteTaskDependency(task),
+      { queryClient }
+    )
+
+    queryClient.setQueryData(taskKeys.detail('task-1'), task)
+    queryClient.setQueryData([...taskKeys.byGoal('goal-1'), 'page', 0, 100, 'default'], [task])
+    queryClient.setQueryData([...taskKeys.byProject('project-1'), 'page', 0, 100, 'default'], [task])
+
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries')
+
+    await act(async () => {
+      await result.current.mutateAsync('dep-1')
+    })
+
+    expect(mockDeleteDependency).toHaveBeenCalledWith('task-1', 'dep-1')
+    expect(queryClient.getQueryData<Task>(taskKeys.detail('task-1'))?.dependencies).toEqual([])
+    expect(queryClient.getQueryData<Task[]>([...taskKeys.byGoal('goal-1'), 'page', 0, 100, 'default'])?.[0].dependencies).toEqual([])
+    expect(queryClient.getQueryData<Task[]>([...taskKeys.byProject('project-1'), 'page', 0, 100, 'default'])?.[0].dependencies).toEqual([])
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: taskKeys.detail('task-1') })
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: taskKeys.byGoal('goal-1') })
+    expect(invalidateSpy).toHaveBeenCalledWith({ predicate: expect.any(Function) })
   })
 })

--- a/apps/web/src/hooks/use-tasks-query.ts
+++ b/apps/web/src/hooks/use-tasks-query.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { DEFAULT_TASK_PAGE_LIMIT, tasksApi } from '@/lib/api'
-import type { Task, TaskCreate, TaskUpdate } from '@/types/task'
+import type { QueryClient, Query } from '@tanstack/react-query'
+import type { Task, TaskCreate, TaskUpdate, TaskDependency } from '@/types/task'
 import type { SortOptions } from '@/types/sort'
 
 /**
@@ -9,12 +10,64 @@ import type { SortOptions } from '@/types/sort'
  */
 export const taskKeys = {
   all: ['tasks'] as const,
-  lists: () => [...taskKeys.all, 'list'] as const,
-  list: (filters: string) => [...taskKeys.lists(), { filters }] as const,
   details: () => [...taskKeys.all, 'detail'] as const,
   detail: (id: string) => [...taskKeys.details(), id] as const,
   byGoal: (goalId: string) => [...taskKeys.all, 'goal', goalId] as const,
   byProject: (projectId: string) => [...taskKeys.all, 'project', projectId] as const,
+}
+
+const isTaskGoalQuery = (query: Query) =>
+  query.queryKey[0] === taskKeys.all[0] && query.queryKey[1] === 'goal'
+
+const isTaskProjectQuery = (query: Query) =>
+  query.queryKey[0] === taskKeys.all[0] && query.queryKey[1] === 'project'
+
+const invalidateTaskCollections = (queryClient: QueryClient, goalId?: string) => {
+  if (goalId) {
+    queryClient.invalidateQueries({ queryKey: taskKeys.byGoal(goalId) })
+  } else {
+    queryClient.invalidateQueries({ predicate: isTaskGoalQuery })
+  }
+
+  queryClient.invalidateQueries({ predicate: isTaskProjectQuery })
+}
+
+const updateTaskInList = (
+  data: unknown,
+  taskId: string,
+  updateTask: (task: Task) => Task
+) => {
+  if (!Array.isArray(data)) {
+    return data
+  }
+
+  return data.map((task) => {
+    if (!task || typeof task !== 'object' || (task as Task).id !== taskId) {
+      return task
+    }
+
+    return updateTask(task as Task)
+  })
+}
+
+const updateTaskCaches = (
+  queryClient: QueryClient,
+  task: Task,
+  updateTask: (task: Task) => Task
+) => {
+  queryClient.setQueryData<Task>(taskKeys.detail(task.id), (cachedTask) =>
+    updateTask(cachedTask ?? task)
+  )
+
+  queryClient.setQueriesData(
+    { queryKey: taskKeys.byGoal(task.goal_id) },
+    (data) => updateTaskInList(data, task.id, updateTask)
+  )
+
+  queryClient.setQueriesData(
+    { predicate: isTaskProjectQuery },
+    (data) => updateTaskInList(data, task.id, updateTask)
+  )
 }
 
 /**
@@ -118,14 +171,7 @@ export function useCreateTask() {
   return useMutation({
     mutationFn: (taskData: TaskCreate) => tasksApi.create(taskData),
     onSuccess: (newTask: Task) => {
-      // Invalidate tasks for the specific goal
-      queryClient.invalidateQueries({
-        queryKey: taskKeys.byGoal(newTask.goal_id)
-      })
-
-      // Invalidate tasks for the project if we have project_id
-      // Note: We need to get the goal to know the project_id
-      queryClient.invalidateQueries({ queryKey: taskKeys.lists() })
+      invalidateTaskCollections(queryClient, newTask.goal_id)
 
       // Add the new task to cache
       queryClient.setQueryData(
@@ -138,7 +184,7 @@ export function useCreateTask() {
 
 /**
  * Mutation hook for updating a task.
- * Updates cache and invalidates task lists on success.
+ * Updates cache and invalidates task collections on success.
  *
  * @returns UseMutationResult with mutateAsync function
  */
@@ -155,20 +201,15 @@ export function useUpdateTask() {
         updatedTask
       )
 
-      // Invalidate tasks for the goal to reflect changes in list view
-      queryClient.invalidateQueries({
-        queryKey: taskKeys.byGoal(updatedTask.goal_id)
-      })
-
-      // Invalidate task lists as well
-      queryClient.invalidateQueries({ queryKey: taskKeys.lists() })
+      // Invalidate task collections to reflect changes in goal and project views.
+      invalidateTaskCollections(queryClient, updatedTask.goal_id)
     },
   })
 }
 
 /**
  * Mutation hook for deleting a task.
- * Removes from cache and invalidates task lists on success.
+ * Removes from cache and invalidates task collections on success.
  * Cache invalidation is delayed to allow dialog close animation to complete,
  * preventing UI freeze from Radix UI cleanup issues.
  *
@@ -196,15 +237,69 @@ export function useDeleteTask() {
           document.body.style.overflow = ''
         }
 
-        if (goalId) {
-          queryClient.invalidateQueries({
-            queryKey: taskKeys.byGoal(goalId)
-          })
-        } else {
-          // Fallback: invalidate all task lists
-          queryClient.invalidateQueries({ queryKey: taskKeys.lists() })
-        }
+        invalidateTaskCollections(queryClient, goalId)
       }, 300)
+    },
+  })
+}
+
+/**
+ * Mutation hook for adding a dependency to a task.
+ * Keeps task detail/collection caches fresh and invalidates goal/project task views.
+ */
+export function useAddTaskDependency(task: Task, availableTasks: Task[] = []) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (dependsOnTaskId: string) => tasksApi.addDependency(task.id, dependsOnTaskId),
+    onSuccess: (dependency: TaskDependency, dependsOnTaskId) => {
+      const dependsOnTask = availableTasks.find((availableTask) => availableTask.id === dependsOnTaskId)
+      const hydratedDependency: TaskDependency = {
+        ...dependency,
+        depends_on_task: dependency.depends_on_task ?? (dependsOnTask
+          ? {
+              id: dependsOnTask.id,
+              title: dependsOnTask.title,
+              status: dependsOnTask.status,
+            }
+          : null),
+      }
+
+      updateTaskCaches(queryClient, task, (cachedTask) => ({
+        ...cachedTask,
+        dependencies: [
+          ...(cachedTask.dependencies ?? []).filter(
+            (existingDependency) => existingDependency.id !== hydratedDependency.id
+          ),
+          hydratedDependency,
+        ],
+      }))
+
+      queryClient.invalidateQueries({ queryKey: taskKeys.detail(task.id) })
+      invalidateTaskCollections(queryClient, task.goal_id)
+    },
+  })
+}
+
+/**
+ * Mutation hook for deleting a dependency from a task.
+ * Keeps task detail/collection caches fresh and invalidates goal/project task views.
+ */
+export function useDeleteTaskDependency(task: Task) {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (dependencyId: string) => tasksApi.deleteDependency(task.id, dependencyId),
+    onSuccess: (_, dependencyId) => {
+      updateTaskCaches(queryClient, task, (cachedTask) => ({
+        ...cachedTask,
+        dependencies: (cachedTask.dependencies ?? []).filter(
+          (dependency) => dependency.id !== dependencyId
+        ),
+      }))
+
+      queryClient.invalidateQueries({ queryKey: taskKeys.detail(task.id) })
+      invalidateTaskCollections(queryClient, task.goal_id)
     },
   })
 }


### PR DESCRIPTION
## Summary
- Replace dead task list invalidations with real goal/project task collection invalidation.
- Move task dependency add/delete operations into React Query mutations that update detail and collection caches, then invalidate detail, goal, and project queries.
- Remove the empty dependency refresh callbacks from `TaskEditDialog` and cover the new cache behavior in hook tests.

## Root Cause
Task mutations invalidated `taskKeys.lists()`, but no active task queries used the `['tasks', 'list']` prefix. Dependency add/delete also updated only local component state, so cached goal/project/detail task data could remain stale until the 5 minute stale window expired.

## Validation
- `pnpm --filter web test -- use-tasks-query.test.ts --runInBand`
- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing `no-explicit-any` warnings in unrelated files)

Closes #285