### PR TITLE
[codex] fix slot kind type safety

### DIFF
--- a/apps/api/src/humancompiler_api/models.py
+++ b/apps/api/src/humancompiler_api/models.py
@@ -66,6 +66,15 @@ class WorkType(StrEnum):
     FOCUSED_WORK = "focused_work"
 
 
+class SlotKind(StrEnum):
+    """Time slot kind for scheduling."""
+
+    LIGHT_WORK = "light_work"
+    STUDY = "study"
+    FOCUSED_WORK = "focused_work"
+    MEETING = "meeting"
+
+
 class SortBy(StrEnum):
     """Sort field options for list endpoints"""
 
@@ -2233,13 +2242,22 @@ class TimeSlotSchema(BaseModel):
 
     start: str = Field(..., pattern=r"^\d{2}:\d{2}$", description="Start time (HH:mm)")
     end: str = Field(..., pattern=r"^\d{2}:\d{2}$", description="End time (HH:mm)")
-    kind: str = Field(
+    kind: SlotKind = Field(
         ..., description="Slot kind (study, focused_work, light_work, meeting)"
     )
     capacity_hours: float | None = Field(
         None, ge=0, description="Slot capacity in hours"
     )
     assigned_project_id: str | None = Field(None, description="Assigned project ID")
+
+    @field_validator("start", "end")
+    @classmethod
+    def validate_time_value(cls, value: str) -> str:
+        """Validate HH:mm values are within a single calendar day."""
+        hour, minute = map(int, value.split(":"))
+        if not (0 <= hour <= 23 and 0 <= minute <= 59):
+            raise ValueError("Time must be between 00:00 and 23:59")
+        return value
 
     @model_validator(mode="after")
     def validate_start_before_end(self) -> "TimeSlotSchema":
@@ -2280,7 +2298,7 @@ class SlotTemplateResponse(BaseModel):
     user_id: UUID
     name: str
     day_of_week: int
-    slots: list[dict[str, Any]]
+    slots: list[TimeSlotSchema]
     is_default: bool
     created_at: datetime
     updated_at: datetime
@@ -2302,7 +2320,7 @@ class SlotTemplateResponse(BaseModel):
             user_id=template.user_id,
             name=template.name,
             day_of_week=template.day_of_week,
-            slots=template.slots_json,
+            slots=[TimeSlotSchema.model_validate(slot) for slot in template.slots_json],
             is_default=template.is_default,
             created_at=template.created_at,
             updated_at=template.updated_at,

--- a/apps/api/src/humancompiler_api/routers/scheduler.py
+++ b/apps/api/src/humancompiler_api/routers/scheduler.py
@@ -27,7 +27,7 @@ from humancompiler_optimizer.daily import (
     FixedAssignment,
     ScheduleResult,
     SchedulerTask,
-    SlotKind,
+    SlotKind as OptimizerSlotKind,
     TaskKind,
     TimeSlot,
 )
@@ -57,6 +57,7 @@ from humancompiler_api.models import (
     GoalDependency,
     TaskStatus,
     GoalStatus,
+    SlotKind,
     WorkType,
 )
 from humancompiler_api.services import goal_service, task_service, quick_task_service
@@ -514,7 +515,9 @@ def _coerce_human_solver_config(
     return human_daily_solver_config_from_dict({**defaults, **overrides})
 
 
-def _to_human_work_kind(kind: TaskKind | SlotKind | str) -> HumanWorkKind:
+def _to_human_work_kind(
+    kind: TaskKind | OptimizerSlotKind | SlotKind | str,
+) -> HumanWorkKind:
     raw_value = kind.value if isinstance(kind, Enum) else str(kind)
     mapping = {
         "light_work": HumanWorkKind.LIGHT_WORK,
@@ -1382,8 +1385,9 @@ class TimeSlotInput(BaseModel):
 
     start: str = Field(..., description="Start time in HH:MM format")
     end: str = Field(..., description="End time in HH:MM format")
-    kind: str = Field(
-        "light_work", description="Slot type: light_work, focused_work, study"
+    kind: SlotKind = Field(
+        SlotKind.LIGHT_WORK,
+        description="Slot type: light_work, focused_work, study, meeting",
     )
     capacity_hours: float | None = Field(
         None, description="Maximum hours for this slot"
@@ -1407,13 +1411,15 @@ class TimeSlotInput(BaseModel):
         except (ValueError, TypeError):
             raise ValueError("Time must be in HH:MM format")
 
-    @field_validator("kind")
-    @classmethod
-    def validate_kind(cls, v):
-        valid_kinds = ["light_work", "focused_work", "study"]
-        if v.lower() not in valid_kinds:
-            raise ValueError(f"Kind must be one of: {valid_kinds}")
-        return v.lower()
+    @model_validator(mode="after")
+    def validate_start_before_end(self) -> "TimeSlotInput":
+        start_parts = self.start.split(":")
+        end_parts = self.end.split(":")
+        start_minutes = int(start_parts[0]) * 60 + int(start_parts[1])
+        end_minutes = int(end_parts[0]) * 60 + int(end_parts[1])
+        if start_minutes >= end_minutes:
+            raise ValueError("Start time must be before end time")
+        return self
 
 
 class TaskSource(BaseModel):
@@ -1583,14 +1589,22 @@ def map_task_kind(status: str) -> TaskKind:
     return TaskKind.LIGHT_WORK  # Default
 
 
-def map_slot_kind(kind_str: str) -> SlotKind:
-    """Map input slot kind to scheduler SlotKind."""
+def map_slot_kind(kind: SlotKind | str) -> OptimizerSlotKind:
+    """Map API slot kind to optimizer slot kind."""
+    try:
+        slot_kind = kind if isinstance(kind, SlotKind) else SlotKind(str(kind))
+    except ValueError as exc:
+        raise ValueError(f"Unsupported slot kind: {kind}") from exc
+
+    if slot_kind == SlotKind.MEETING:
+        return OptimizerSlotKind.LIGHT_WORK
+
     mapping = {
-        "light_work": SlotKind.LIGHT_WORK,
-        "focused_work": SlotKind.FOCUSED_WORK,
-        "study": SlotKind.STUDY,
+        SlotKind.LIGHT_WORK: OptimizerSlotKind.LIGHT_WORK,
+        SlotKind.FOCUSED_WORK: OptimizerSlotKind.FOCUSED_WORK,
+        SlotKind.STUDY: OptimizerSlotKind.STUDY,
     }
-    return mapping.get(kind_str.lower(), SlotKind.LIGHT_WORK)
+    return mapping[slot_kind]
 
 
 def quick_task_to_scheduler_task(quick_task: QuickTask) -> SchedulerTask:
@@ -1828,6 +1842,12 @@ async def create_daily_schedule(
             logger.warning(f"Skipping ownership validation due to database error: {e}")
             pass
 
+        meeting_slot_indexes = {
+            index
+            for index, slot_input in enumerate(request.time_slots)
+            if slot_input.kind == SlotKind.MEETING
+        }
+
         # Convert time slots
         scheduler_slots = []
         for slot_input in request.time_slots:
@@ -1844,7 +1864,9 @@ async def create_daily_schedule(
                 start=start_time,
                 end=end_time,
                 kind=slot_kind,
-                capacity_hours=slot_input.capacity_hours,
+                capacity_hours=0.0
+                if slot_input.kind == SlotKind.MEETING
+                else slot_input.capacity_hours,
                 assigned_project_id=slot_input.assigned_project_id,
             )
             scheduler_slots.append(time_slot)
@@ -1852,6 +1874,11 @@ async def create_daily_schedule(
         # Convert fixed assignments
         scheduler_fixed_assignments = []
         for fa in request.fixed_assignments:
+            if fa.slot_index in meeting_slot_indexes:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Fixed assignments cannot target meeting slots",
+                )
             scheduler_fixed_assignments.append(
                 FixedAssignment(
                     task_id=fa.task_id,
@@ -1919,6 +1946,9 @@ async def create_daily_schedule(
         )
         return response
 
+    except HTTPException:
+        raise
+
     except ValidationError as e:
         logger.error(f"Validation error in schedule creation: {e}")
         raise HTTPException(
@@ -1977,13 +2007,13 @@ async def test_scheduler():
             TimeSlot(
                 start=time(9, 0),
                 end=time(11, 0),
-                kind=SlotKind.FOCUSED_WORK,
+                kind=OptimizerSlotKind.FOCUSED_WORK,
                 capacity_hours=2.0,
             ),
             TimeSlot(
                 start=time(14, 0),
                 end=time(15, 0),
-                kind=SlotKind.LIGHT_WORK,
+                kind=OptimizerSlotKind.LIGHT_WORK,
                 capacity_hours=1.0,
             ),
         ]

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -1781,7 +1781,7 @@ class SlotTemplateService(
             user_id=user_id,
             name=data.name,
             day_of_week=data.day_of_week,
-            slots_json=[slot.model_dump() for slot in data.slots],
+            slots_json=[slot.model_dump(mode="json") for slot in data.slots],
             is_default=data.is_default,
         )
 
@@ -1876,15 +1876,16 @@ class SlotTemplateService(
                 detail="Slot template not found",
             )
 
-        update_data = template_data.model_dump(exclude_unset=True)
+        update_data = template_data.model_dump(exclude_unset=True, exclude={"slots"})
 
         # Handle slots separately (convert to JSON)
-        if "slots" in update_data and update_data["slots"] is not None:
+        if (
+            "slots" in template_data.model_fields_set
+            and template_data.slots is not None
+        ):
             template.slots_json = [
-                slot.model_dump() if hasattr(slot, "model_dump") else slot
-                for slot in update_data["slots"]
+                slot.model_dump(mode="json") for slot in template_data.slots
             ]
-            del update_data["slots"]
 
         # Handle default template logic
         new_day_of_week = update_data.get("day_of_week")

--- a/apps/api/tests/test_scheduler.py
+++ b/apps/api/tests/test_scheduler.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 
 from humancompiler_api.auth import get_current_user_id
 from humancompiler_api.main import app
-from humancompiler_api.models import WorkType
+from humancompiler_api.models import SlotKind, WorkType
 from humancompiler_api.routers.scheduler import SCHEDULER_CONFIG_CONTROLS
 
 client = TestClient(app)
@@ -445,7 +445,10 @@ class TestSchedulerAPI:
         # Valid time slot
         valid_slot = TimeSlotInput(start="09:00", end="12:00", kind="focused_work")
         assert valid_slot.start == "09:00"
-        assert valid_slot.kind == "focused_work"
+        assert valid_slot.kind == SlotKind.FOCUSED_WORK
+
+        meeting_slot = TimeSlotInput(start="12:00", end="13:00", kind="meeting")
+        assert meeting_slot.kind == SlotKind.MEETING
 
         # Invalid time format
         with pytest.raises(ValueError):
@@ -458,6 +461,10 @@ class TestSchedulerAPI:
         # Invalid kind
         with pytest.raises(ValueError):
             TimeSlotInput(start="09:00", end="12:00", kind="invalid_kind")
+
+        # Invalid time range
+        with pytest.raises(ValueError):
+            TimeSlotInput(start="12:00", end="09:00", kind="focused_work")
 
     def test_task_kind_mapping(self):
         """Test task kind mapping function."""
@@ -472,13 +479,111 @@ class TestSchedulerAPI:
 
     def test_slot_kind_mapping(self):
         """Test slot kind mapping function."""
-        from humancompiler_api.routers.scheduler import SlotKind, map_slot_kind
+        from humancompiler_api.routers.scheduler import map_slot_kind
+        from humancompiler_optimizer.daily import SlotKind as OptimizerSlotKind
 
         # Test mapping
-        assert map_slot_kind("focused_work") == SlotKind.FOCUSED_WORK
-        assert map_slot_kind("light_work") == SlotKind.LIGHT_WORK  # Case insensitive
-        assert map_slot_kind("study") == SlotKind.STUDY
-        assert map_slot_kind("unknown") == SlotKind.LIGHT_WORK  # Default
+        assert map_slot_kind("focused_work") == OptimizerSlotKind.FOCUSED_WORK
+        assert map_slot_kind("light_work") == OptimizerSlotKind.LIGHT_WORK
+        assert map_slot_kind("study") == OptimizerSlotKind.STUDY
+        assert map_slot_kind("meeting") == OptimizerSlotKind.LIGHT_WORK
+        with pytest.raises(ValueError):
+            map_slot_kind("unknown")
+
+    def test_zero_capacity_slot_does_not_receive_assignments(self):
+        """Meeting slots are represented to the solver as zero-capacity slots."""
+        from datetime import time
+
+        from humancompiler_api.routers.scheduler import optimize_schedule
+        from humancompiler_optimizer.daily import (
+            SchedulerTask,
+            SlotKind as OptimizerSlotKind,
+            TaskKind,
+            TimeSlot,
+        )
+
+        result = optimize_schedule(
+            tasks=[
+                SchedulerTask(
+                    id="task-1",
+                    title="Task",
+                    estimate_hours=1.0,
+                    priority=1,
+                    kind=TaskKind.FOCUSED_WORK,
+                )
+            ],
+            time_slots=[
+                TimeSlot(
+                    start=time(12, 0),
+                    end=time(13, 0),
+                    kind=OptimizerSlotKind.LIGHT_WORK,
+                    capacity_hours=0.0,
+                )
+            ],
+            date=datetime(2025, 6, 23),
+        )
+
+        assert result.assignments == []
+        assert result.unscheduled_tasks == ["task-1"]
+
+    @patch("humancompiler_api.routers.scheduler._get_task_actual_hours")
+    @patch("humancompiler_api.routers.scheduler._get_tasks_by_source")
+    @patch(
+        "humancompiler_api.routers.scheduler.quick_task_service.get_active_quick_tasks"
+    )
+    def test_create_daily_schedule_rejects_fixed_assignment_to_meeting_slot(
+        self, mock_quick_tasks, mock_get_tasks_by_source, mock_actual_hours, mock_auth
+    ):
+        """Fixed assignments cannot target blocked meeting slots."""
+        from humancompiler_api.database import db
+
+        goal_id = str(uuid4())
+        project_id = str(uuid4())
+
+        mock_task = MagicMock()
+        mock_task.id = "task-1"
+        mock_task.title = "Pinned Task"
+        mock_task.estimate_hours = 1.0
+        mock_task.status = "pending"
+        mock_task.due_date = None
+        mock_task.goal_id = goal_id
+        mock_task.priority = 1
+        mock_task.work_type = WorkType.FOCUSED_WORK
+        mock_get_tasks_by_source.return_value = [mock_task]
+        mock_quick_tasks.return_value = []
+        mock_actual_hours.return_value = {}
+
+        mock_goal = MagicMock()
+        mock_goal.id = goal_id
+        mock_goal.project_id = project_id
+
+        mock_sess = MagicMock()
+        mock_exec_result = MagicMock()
+        mock_exec_result.all.return_value = [mock_goal]
+        mock_sess.exec.return_value = mock_exec_result
+
+        def mock_get_session():
+            yield mock_sess
+
+        app.dependency_overrides[db.get_session] = mock_get_session
+
+        try:
+            response = client.post(
+                "/api/schedule/daily",
+                json={
+                    "date": "2025-06-23",
+                    "time_slots": [
+                        {"start": "12:00", "end": "13:00", "kind": "meeting"}
+                    ],
+                    "fixed_assignments": [{"task_id": "task-1", "slot_index": 0}],
+                },
+            )
+        finally:
+            if db.get_session in app.dependency_overrides:
+                del app.dependency_overrides[db.get_session]
+
+        assert response.status_code == 400
+        assert "meeting slots" in response.json()["detail"]
 
     @patch("humancompiler_api.routers.scheduler.goal_service.get_goal")
     @patch("humancompiler_api.routers.scheduler.db.get_session")

--- a/apps/api/tests/test_slot_templates.py
+++ b/apps/api/tests/test_slot_templates.py
@@ -1,0 +1,123 @@
+"""Tests for slot template slot kind validation."""
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+from humancompiler_api.models import (
+    SlotKind,
+    SlotTemplateCreate,
+    SlotTemplateResponse,
+    SlotTemplateUpdate,
+    TimeSlotSchema,
+    User,
+)
+from humancompiler_api.services import slot_template_service
+
+
+@pytest.fixture
+def test_session():
+    """Create test database session."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+
+    try:
+        with Session(engine) as session:
+            yield session
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture
+def test_user(test_session):
+    """Create test user."""
+    user = User(id=uuid4(), email="slot-template-test@example.com")
+    test_session.add(user)
+    test_session.commit()
+    test_session.refresh(user)
+    return user
+
+
+def test_time_slot_schema_accepts_all_slot_kinds():
+    """TimeSlotSchema accepts every API slot kind."""
+    for kind in SlotKind:
+        slot = TimeSlotSchema(start="09:00", end="10:00", kind=kind)
+        assert slot.kind == kind
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "kind"),
+    [
+        ("25:00", "26:00", "focused_work"),
+        ("10:00", "09:00", "focused_work"),
+        ("09:00", "10:00", "invalid_kind"),
+    ],
+)
+def test_time_slot_schema_rejects_invalid_values(start, end, kind):
+    """TimeSlotSchema rejects invalid times, ranges, and slot kinds."""
+    with pytest.raises(ValidationError):
+        TimeSlotSchema(start=start, end=end, kind=kind)
+
+
+def test_slot_template_create_stores_slot_kind_as_json_string(test_session, test_user):
+    """Slot template creation stores enum values as plain JSON strings."""
+    template = slot_template_service.create_slot_template(
+        test_session,
+        SlotTemplateCreate(
+            name="Meeting template",
+            day_of_week=0,
+            slots=[TimeSlotSchema(start="12:00", end="13:00", kind=SlotKind.MEETING)],
+        ),
+        test_user.id,
+    )
+
+    assert template.slots_json == [
+        {
+            "start": "12:00",
+            "end": "13:00",
+            "kind": "meeting",
+            "capacity_hours": None,
+            "assigned_project_id": None,
+        }
+    ]
+
+    response = SlotTemplateResponse.from_db_model(template)
+    assert response.slots[0].kind == SlotKind.MEETING
+
+
+def test_slot_template_update_stores_slot_kind_as_json_string(test_session, test_user):
+    """Slot template updates also keep the stored JSON wire format stable."""
+    template = slot_template_service.create_slot_template(
+        test_session,
+        SlotTemplateCreate(
+            name="Work template",
+            day_of_week=1,
+            slots=[
+                TimeSlotSchema(
+                    start="09:00",
+                    end="10:00",
+                    kind=SlotKind.FOCUSED_WORK,
+                )
+            ],
+        ),
+        test_user.id,
+    )
+
+    updated = slot_template_service.update_slot_template(
+        test_session,
+        template.id,
+        test_user.id,
+        SlotTemplateUpdate(
+            slots=[TimeSlotSchema(start="11:00", end="12:00", kind="meeting")]
+        ),
+    )
+
+    assert updated.slots_json[0]["kind"] == "meeting"
+    assert not isinstance(updated.slots_json[0]["kind"], SlotKind)

--- a/apps/web/src/app/scheduling/daily/page.tsx
+++ b/apps/web/src/app/scheduling/daily/page.tsx
@@ -37,8 +37,9 @@ import {
 import { AppHeader } from '@/components/layout/app-header';
 import { toast } from '@/hooks/use-toast';
 import { schedulingApi, projectsApi, tasksApi, quickTasksApi, slotTemplatesApi } from '@/lib/api';
-import { getSlotKindLabel, getSlotKindColor } from '@/constants/schedule';
+import { getSlotKindLabel, getSlotKindColor, slotKinds } from '@/constants/schedule';
 import { DroppableSlot, TaskPool, DraggableTask } from '@/components/scheduling';
+import type { SlotKind } from '@/constants/schedule';
 import type {
   ScheduleRequest,
   ScheduleResult,
@@ -67,9 +68,9 @@ export default function SchedulingPage() {
   const [selectedDate, setSelectedDate] = useState(() => getJSTDateString());
 
   const [timeSlots, setTimeSlots] = useState<TimeSlot[]>([
-    { start: '09:00', end: '12:00', kind: 'focused_work' },
-    { start: '13:00', end: '17:00', kind: 'study' },
-    { start: '19:00', end: '21:00', kind: 'light_work' },
+    { start: '09:00', end: '12:00', kind: slotKinds.focused_work },
+    { start: '13:00', end: '17:00', kind: slotKinds.study },
+    { start: '19:00', end: '21:00', kind: slotKinds.light_work },
   ]);
 
   const [isOptimizing, setIsOptimizing] = useState(false);
@@ -337,6 +338,16 @@ export default function SchedulingPage() {
     // Dropping on a slot
     if (overId.startsWith('slot-')) {
       const slotIndex = parseInt(overId.replace('slot-', ''), 10);
+      const targetSlot = timeSlots[slotIndex];
+
+      if (targetSlot?.kind === 'meeting') {
+        toast({
+          title: '配置できません',
+          description: '会議枠にはタスクを配置できません',
+          variant: 'destructive',
+        });
+        return;
+      }
 
       // Remove from any previous slot
       setManualAssignments(prev => {
@@ -344,21 +355,25 @@ export default function SchedulingPage() {
         return [...filtered, { taskId, slotIndex }];
       });
     }
-  }, []);
+  }, [timeSlots]);
 
   // Slot management
   const addTimeSlot = () => {
     setTimeSlots(prev => [...prev, {
       start: '09:00',
       end: '12:00',
-      kind: 'light_work'
+      kind: slotKinds.light_work
     }]);
   };
 
   const updateTimeSlot = (index: number, field: keyof TimeSlot, value: string | number | undefined) => {
     setTimeSlots(prev => prev.map((slot, i) =>
-      i === index ? { ...slot, [field]: value } : slot
+      i === index ? { ...slot, [field]: field === 'kind' ? value as SlotKind : value } : slot
     ));
+    if (field === 'kind' && value === 'meeting') {
+      setManualAssignments(prev => prev.filter(a => a.slotIndex !== index));
+    }
+    setScheduleResult(null);
   };
 
   const removeTimeSlot = (index: number) => {

--- a/apps/web/src/app/scheduling/settings/page.tsx
+++ b/apps/web/src/app/scheduling/settings/page.tsx
@@ -48,8 +48,8 @@ import {
   getSlotKindColor,
   getDayOfWeekLabel,
   getDayOfWeekShortLabel,
-  type SlotKind,
 } from '@/constants/schedule';
+import type { SlotKind } from '@/constants/schedule';
 import type {
   SlotTemplate,
   SlotTemplateCreate,

--- a/apps/web/src/app/scheduling/tuning/page.tsx
+++ b/apps/web/src/app/scheduling/tuning/page.tsx
@@ -35,6 +35,8 @@ import {
   saveSchedulerSolverConfig,
 } from '@/lib/scheduler-config';
 import { cn } from '@/lib/utils';
+import { slotKinds } from '@/constants/schedule';
+import type { SlotKind } from '@/constants/schedule';
 import type {
   ScheduleResult,
   SchedulerSolverConfig,
@@ -42,7 +44,7 @@ import type {
   TimeSlot,
 } from '@/types/ai-planning';
 
-type SlotKind = 'focused_work' | 'study' | 'light_work';
+type SchedulableSlotKind = Exclude<SlotKind, 'meeting'>;
 
 type PreferenceState = {
   blockLength: 'short' | 'balanced' | 'long';
@@ -71,9 +73,9 @@ type PreferenceControl = {
 };
 
 const defaultSlots: TimeSlot[] = [
-  { start: '09:00', end: '12:00', kind: 'focused_work' },
-  { start: '13:00', end: '17:00', kind: 'study' },
-  { start: '19:00', end: '21:00', kind: 'light_work' },
+  { start: '09:00', end: '12:00', kind: slotKinds.focused_work },
+  { start: '13:00', end: '17:00', kind: slotKinds.study },
+  { start: '19:00', end: '21:00', kind: slotKinds.light_work },
 ];
 
 const defaultPreferences: PreferenceState = {
@@ -144,7 +146,7 @@ const preferenceControls: PreferenceControl[] = [
   },
 ];
 
-const slotKindOptions: Array<{ value: SlotKind; label: string }> = [
+const slotKindOptions: Array<{ value: SchedulableSlotKind; label: string }> = [
   { value: 'focused_work', label: '集中作業' },
   { value: 'study', label: '学習' },
   { value: 'light_work', label: '軽作業' },
@@ -580,7 +582,7 @@ export default function SchedulerTuningPage() {
                       />
                       <Select
                         value={slot.kind}
-                        onValueChange={(value) => updateSlot(index, { kind: value as SlotKind })}
+                        onValueChange={(value) => updateSlot(index, { kind: value as SchedulableSlotKind })}
                       >
                         <SelectTrigger aria-label={`${index + 1}枠目の作業種別`}>
                           <SelectValue />

--- a/apps/web/src/components/scheduling/DroppableSlot.tsx
+++ b/apps/web/src/components/scheduling/DroppableSlot.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Clock, Trash2, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { DraggableTask } from './DraggableTask';
+import { getSlotKindLabel, getSlotKindPanelStyle, slotKindLabels } from '@/constants/schedule';
 import type { TimeSlot, TaskInfo } from '@/types/ai-planning';
 import type { Project } from '@/types/project';
 
@@ -57,28 +58,20 @@ export function DroppableSlot({
   );
   const remainingHours = duration - assignedHours;
 
-  const kindColors: Record<string, { bg: string; border: string; text: string }> = {
-    study: { bg: 'bg-blue-50', border: 'border-blue-300', text: 'text-blue-700' },
-    focused_work: { bg: 'bg-purple-50', border: 'border-purple-300', text: 'text-purple-700' },
-    light_work: { bg: 'bg-green-50', border: 'border-green-300', text: 'text-green-700' },
-  };
-
-  const kindLabels: Record<string, string> = {
-    study: '学習',
-    focused_work: '集中作業',
-    light_work: '軽作業',
-  };
-
-  const colors = kindColors[slot.kind] || { bg: 'bg-gray-50', border: 'border-gray-300', text: 'text-gray-700' };
+  const isMeetingSlot = slot.kind === 'meeting';
+  const colors = getSlotKindPanelStyle(slot.kind);
 
   // Check if the dragged task can be dropped here (kind matching)
-  const canDrop = active?.data?.current?.task?.kind === slot.kind ||
-                  !active?.data?.current?.task?.kind ||
-                  remainingHours >= (active?.data?.current?.task?.estimate_hours ?? 0);
+  const canDrop = !isMeetingSlot && (
+    active?.data?.current?.task?.kind === slot.kind ||
+    !active?.data?.current?.task?.kind ||
+    remainingHours >= (active?.data?.current?.task?.estimate_hours ?? 0)
+  );
 
   return (
     <div
       ref={setNodeRef}
+      aria-disabled={isMeetingSlot}
       className={cn(
         'rounded-xl border-2 transition-all duration-200 overflow-hidden',
         colors.border,
@@ -94,7 +87,7 @@ export function DroppableSlot({
               スロット {slotIndex + 1}
             </span>
             <Badge variant="outline" className={cn('text-xs', colors.text)}>
-              {kindLabels[slot.kind]}
+              {getSlotKindLabel(slot.kind)}
             </Badge>
           </div>
           <Button
@@ -137,9 +130,11 @@ export function DroppableSlot({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="study">学習</SelectItem>
-                <SelectItem value="focused_work">集中作業</SelectItem>
-                <SelectItem value="light_work">軽作業</SelectItem>
+                {Object.entries(slotKindLabels).map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/apps/web/src/constants/schedule.ts
+++ b/apps/web/src/constants/schedule.ts
@@ -6,6 +6,13 @@ import { logger } from '@/lib/logger'
 
 export type SlotKind = 'study' | 'focused_work' | 'light_work' | 'meeting';
 
+export const slotKinds: Record<SlotKind, SlotKind> = {
+  study: 'study',
+  focused_work: 'focused_work',
+  light_work: 'light_work',
+  meeting: 'meeting',
+} as const;
+
 export const slotKindLabels: Record<SlotKind, string> = {
   study: '学習',
   focused_work: '集中作業',
@@ -18,6 +25,13 @@ export const slotKindColors: Record<SlotKind, string> = {
   focused_work: 'bg-purple-100 text-purple-800',
   light_work: 'bg-green-100 text-green-800',
   meeting: 'bg-orange-100 text-orange-800',
+} as const;
+
+export const slotKindPanelStyles: Record<SlotKind, { bg: string; border: string; text: string }> = {
+  study: { bg: 'bg-blue-50', border: 'border-blue-300', text: 'text-blue-700' },
+  focused_work: { bg: 'bg-purple-50', border: 'border-purple-300', text: 'text-purple-700' },
+  light_work: { bg: 'bg-green-50', border: 'border-green-300', text: 'text-green-700' },
+  meeting: { bg: 'bg-orange-50', border: 'border-orange-300', text: 'text-orange-700' },
 } as const;
 
 /**
@@ -50,6 +64,19 @@ export const getSlotKindColor = (slotKind: string): string => {
   }
 
   return slotKindColors[typedSlotKind];
+};
+
+export const getSlotKindPanelStyle = (
+  slotKind: string,
+): { bg: string; border: string; text: string } => {
+  const typedSlotKind = slotKind as SlotKind;
+
+  if (!(slotKind in slotKindPanelStyles)) {
+    logger.warn('Unknown slot kind, using fallback to meeting', { slotKind }, { component: 'schedule' });
+    return slotKindPanelStyles.meeting;
+  }
+
+  return slotKindPanelStyles[typedSlotKind];
 };
 
 /**

--- a/apps/web/src/types/ai-planning.ts
+++ b/apps/web/src/types/ai-planning.ts
@@ -3,6 +3,9 @@
  * @description AI支援による週次計画・スケジュール最適化に使用する型を定義
  */
 
+import type { SlotKind } from '@/constants/schedule';
+import type { WorkType } from './task';
+
 /**
  * 週次計画リクエスト
  * @description AI週次計画生成時のパラメータ
@@ -187,7 +190,7 @@ export interface TimeSlot {
   /** 終了時刻 (HH:mm形式) */
   end: string;
   /** スロット種別（作業タイプ） */
-  kind: 'study' | 'focused_work' | 'light_work' | 'meeting';
+  kind: SlotKind;
   /** スロットのキャパシティ（時間単位） */
   capacity_hours?: number;
   /** 割り当てプロジェクトID（スロット単位での割り当て） */
@@ -291,7 +294,7 @@ export interface TaskAssignment {
   /** スロット終了時刻 */
   slot_end: string;
   /** スロット種別 */
-  slot_kind: string;
+  slot_kind: SlotKind;
   /** ユーザーによる固定割り当てかどうか */
   is_fixed?: boolean;
 }
@@ -310,7 +313,7 @@ export interface TaskInfo {
   /** 優先度 */
   priority: number;
   /** 作業種別 */
-  kind: string;
+  kind: WorkType;
   /** 期限日 */
   due_date?: string;
   /** 所属ゴールID */


### PR DESCRIPTION
## Summary

- Add a backend `SlotKind` enum for scheduling slots, including `meeting`.
- Keep task `WorkType` limited to task work types, while sharing the frontend `SlotKind` definition from `constants/schedule.ts`.
- Treat `meeting` slots as blocked schedule windows: accepted by APIs and UI, rendered in daily scheduling, but unavailable for task assignment.

## Why

Issue #267 identified that slot kind and work type definitions were scattered across backend and frontend code. The biggest mismatch was that `meeting` existed for slot templates/UI but not in task work types or daily scheduler validation.

## Impact

- Slot templates can persist `meeting` as plain JSON strings while exposing typed API models.
- Daily scheduling accepts meeting slots without passing a new work kind into `humancompiler-scheduler`.
- Fixed assignments targeting meeting slots are rejected with `400`.
- The daily scheduling UI displays meeting slots and prevents dropping tasks into them.

## Validation

- `cd apps/api && uv run pytest -s tests/test_scheduler.py tests/test_scheduler_remaining_hours.py tests/test_slot_templates.py`
- `cd apps/api && uv run ruff check src/humancompiler_api/models.py src/humancompiler_api/services.py src/humancompiler_api/routers/scheduler.py tests/test_scheduler.py tests/test_slot_templates.py`
- `pnpm --filter @human-compiler/web type-check`
- `git diff --check --cached`