### PR TITLE
[codex] Normalize task estimate hours at API boundary

### DIFF
--- a/apps/web/src/app/projects/[id]/goals/[goalId]/page.tsx
+++ b/apps/web/src/app/projects/[id]/goals/[goalId]/page.tsx
@@ -146,6 +146,28 @@ export default function GoalDetailPage() {
     );
   }, [taskIds, logsByTask]);
 
+  const { completedTasks, totalEstimateHours, completedEstimateHours } = useMemo(() => {
+    return tasks.reduce(
+      (totals, task) => {
+        const estimateHours = task.estimate_hours || 0;
+
+        totals.totalEstimateHours += estimateHours;
+
+        if (task.status === 'completed') {
+          totals.completedTasks += 1;
+          totals.completedEstimateHours += estimateHours;
+        }
+
+        return totals;
+      },
+      {
+        completedTasks: 0,
+        totalEstimateHours: 0,
+        completedEstimateHours: 0,
+      }
+    );
+  }, [tasks]);
+
   useEffect(() => {
     if (!authLoading && !user) {
       router.push('/login');
@@ -190,51 +212,8 @@ export default function GoalDetailPage() {
   // Return early if data is not loaded yet
   if (!goal || !project) return null;
 
-  const completedTasks = tasks.filter(task => task.status === 'completed').length;
-
-  // Debug: Log tasks data to understand the structure
-  log.debug('Tasks data for goal detail', {
-    goalId: goalId,
-    tasksData: tasks.map(t => ({
-      id: t.id,
-      title: t.title,
-      estimate_hours: t.estimate_hours,
-      type: typeof t.estimate_hours
-    }))
-  });
-
-  // Ensure estimate_hours is treated as number and fix potential string concatenation issues
-  const totalEstimateHours = tasks.reduce((sum, task) => {
-    const hours = typeof task.estimate_hours === 'string'
-      ? parseFloat(task.estimate_hours)
-      : task.estimate_hours || 0;
-    log.debug('Task hours calculation', {
-      taskTitle: task.title,
-      hours,
-      originalType: typeof task.estimate_hours,
-      goalId: goalId
-    });
-    return sum + hours;
-  }, 0);
-
-  const completedEstimateHours = tasks
-    .filter(task => task.status === 'completed')
-    .reduce((sum, task) => {
-      const hours = typeof task.estimate_hours === 'string'
-        ? parseFloat(task.estimate_hours)
-        : task.estimate_hours || 0;
-      return sum + hours;
-    }, 0);
-
   // Get actual hours from goal progress API
   const totalActualHours = goalProgress ? goalProgress.actual_minutes / 60 : 0;
-
-  log.debug('Goal detail calculated values', {
-    goalId: goalId,
-    totalEstimateHours,
-    completedEstimateHours,
-    totalActualHours
-  });
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
@@ -284,7 +263,7 @@ export default function GoalDetailPage() {
                 <div className="h-4 w-4 bg-green-600 rounded-full" />
                 <div>
                   <div className="text-2xl font-bold">{completedTasks}</div>
-                  <div className="text-xs text-gray-500">完了タスク</div>
+                  <div className="text-xs text-gray-500">完了タスク ({completedEstimateHours.toFixed(1)}h)</div>
                 </div>
               </div>
             </CardContent>

--- a/apps/web/src/components/tasks/task-edit-dialog.tsx
+++ b/apps/web/src/components/tasks/task-edit-dialog.tsx
@@ -73,7 +73,7 @@ export function TaskEditDialog({ task, availableTasks = [], children }: TaskEdit
     defaultValues: {
       title: task.title,
       description: task.description || '',
-      estimate_hours: typeof task.estimate_hours === 'string' ? parseFloat(task.estimate_hours) : task.estimate_hours,
+      estimate_hours: task.estimate_hours,
       due_date: task.due_date?.split('T')[0] || '',
       status: task.status,
       work_type: task.work_type || 'light_work',
@@ -86,7 +86,7 @@ export function TaskEditDialog({ task, availableTasks = [], children }: TaskEdit
     form.reset({
       title: task.title,
       description: task.description || '',
-      estimate_hours: typeof task.estimate_hours === 'string' ? parseFloat(task.estimate_hours) : task.estimate_hours,
+      estimate_hours: task.estimate_hours,
       due_date: task.due_date?.split('T')[0] || '',
       status: task.status,
       work_type: task.work_type || 'light_work',

--- a/apps/web/src/lib/__tests__/tasks-api.test.ts
+++ b/apps/web/src/lib/__tests__/tasks-api.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const mockGetSession = jest.fn()
+const mockRefreshSession = jest.fn()
+const mockFetchWithFallback = jest.fn()
+
+jest.mock('../supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: () => mockGetSession(),
+      refreshSession: () => mockRefreshSession(),
+    },
+  },
+}))
+
+jest.mock('../fetch-with-fallback', () => ({
+  fetchWithFallback: (...args: unknown[]) => mockFetchWithFallback(...args),
+}))
+
+jest.mock('../config', () => ({
+  getApiEndpoint: jest.fn(() => ''),
+  appConfig: {
+    api: {
+      timeout: 30000,
+      retryAttempts: 0,
+      retryDelay: 0,
+    },
+    security: {
+      enforceHttps: false,
+    },
+  },
+  safeLog: jest.fn(),
+}))
+
+jest.mock('../errors', () => {
+  const actual = jest.requireActual('../errors')
+  return {
+    ...actual,
+    logError: jest.fn(),
+  }
+})
+
+import { tasksApi } from '../api'
+
+const rawTask = (overrides: Record<string, unknown> = {}) => ({
+  id: 'task-1',
+  title: 'Task 1',
+  description: null,
+  memo: null,
+  estimate_hours: 2,
+  due_date: null,
+  status: 'pending',
+  work_type: 'light_work',
+  priority: 3,
+  goal_id: 'goal-1',
+  created_at: '2026-06-27T00:00:00Z',
+  updated_at: '2026-06-27T00:00:00Z',
+  dependencies: [],
+  ...overrides,
+})
+
+const mockJsonResponse = (data: unknown) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  json: jest.fn().mockResolvedValue(data),
+})
+
+describe('tasksApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: 'test-token',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+        },
+      },
+      error: null,
+    })
+  })
+
+  it('normalizes string estimate_hours from task list responses', async () => {
+    mockFetchWithFallback.mockResolvedValueOnce(
+      mockJsonResponse([
+        rawTask({ id: 'task-1', estimate_hours: '2.50' }),
+        rawTask({ id: 'task-2', estimate_hours: 1.25 }),
+      ])
+    )
+
+    const tasks = await tasksApi.getByGoal('goal-1')
+
+    expect(tasks).toEqual([
+      expect.objectContaining({ id: 'task-1', estimate_hours: 2.5 }),
+      expect.objectContaining({ id: 'task-2', estimate_hours: 1.25 }),
+    ])
+  })
+
+  it('normalizes string estimate_hours from single task responses', async () => {
+    mockFetchWithFallback.mockResolvedValueOnce(
+      mockJsonResponse(rawTask({ estimate_hours: '3.75' }))
+    )
+
+    const task = await tasksApi.getById('task-1')
+
+    expect(task.estimate_hours).toBe(3.75)
+  })
+
+  it('normalizes invalid estimate_hours values to zero at the API boundary', async () => {
+    mockFetchWithFallback.mockResolvedValueOnce(
+      mockJsonResponse(rawTask({ estimate_hours: 'not-a-number' }))
+    )
+
+    const task = await tasksApi.update('task-1', { title: 'Updated' })
+
+    expect(task.estimate_hours).toBe(0)
+  })
+})

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -97,6 +97,30 @@ import type { TaskStatus } from '@/types/task';
 
 export const DEFAULT_TASK_PAGE_LIMIT = 100;
 
+type RawTask = Omit<Task, 'estimate_hours'> & {
+  estimate_hours: number | string | null | undefined;
+};
+
+const normalizeEstimateHours = (estimateHours: RawTask['estimate_hours']): number => {
+  if (typeof estimateHours === 'number') {
+    return Number.isFinite(estimateHours) ? estimateHours : 0;
+  }
+
+  if (typeof estimateHours === 'string') {
+    const parsed = Number.parseFloat(estimateHours);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+};
+
+const normalizeTask = (task: RawTask): Task => ({
+  ...task,
+  estimate_hours: normalizeEstimateHours(task.estimate_hours),
+});
+
+const normalizeTasks = (tasks: RawTask[]): Task[] => tasks.map(normalizeTask);
+
 // Helper function to ensure HTTPS protocol
 const ensureHttps = (url: string): string => {
   if (!url) return url;
@@ -404,7 +428,8 @@ class ApiClient {
       params.set('sort_order', sortOptions.sortOrder);
     }
 
-    return this.request<Task[]>(`/api/tasks/goal/${goalId}?${params.toString()}`);
+    const tasks = await this.request<RawTask[]>(`/api/tasks/goal/${goalId}?${params.toString()}`);
+    return normalizeTasks(tasks);
   }
 
   async getTasksByProject(projectId: string, skip: number = 0, limit: number = DEFAULT_TASK_PAGE_LIMIT, sortOptions?: SortOptions): Promise<Task[]> {
@@ -420,25 +445,29 @@ class ApiClient {
       params.set('sort_order', sortOptions.sortOrder);
     }
 
-    return this.request<Task[]>(`/api/tasks/project/${projectId}?${params.toString()}`);
+    const tasks = await this.request<RawTask[]>(`/api/tasks/project/${projectId}?${params.toString()}`);
+    return normalizeTasks(tasks);
   }
 
   async getTask(taskId: string): Promise<Task> {
-    return this.request<Task>(`/api/tasks/${taskId}/`);
+    const task = await this.request<RawTask>(`/api/tasks/${taskId}/`);
+    return normalizeTask(task);
   }
 
   async createTask(taskData: TaskCreate): Promise<Task> {
-    return this.request<Task>('/api/tasks/', {
+    const task = await this.request<RawTask>('/api/tasks/', {
       method: 'POST',
       body: JSON.stringify(taskData),
     });
+    return normalizeTask(task);
   }
 
   async updateTask(taskId: string, taskData: TaskUpdate): Promise<Task> {
-    return this.request<Task>(`/api/tasks/${taskId}/`, {
+    const task = await this.request<RawTask>(`/api/tasks/${taskId}/`, {
       method: 'PUT',
       body: JSON.stringify(taskData),
     });
+    return normalizeTask(task);
   }
 
   async deleteTask(taskId: string): Promise<void> {
@@ -1211,10 +1240,11 @@ class ApiClient {
    */
   async convertQuickTaskToTask(taskId: string, goalId: string): Promise<Task> {
     const convertData: QuickTaskConvertRequest = { goal_id: goalId };
-    return this.request<Task>(`/api/quick-tasks/${taskId}/convert`, {
+    const task = await this.request<RawTask>(`/api/quick-tasks/${taskId}/convert`, {
       method: 'POST',
       body: JSON.stringify(convertData),
     });
+    return normalizeTask(task);
   }
 
   // === Slot Template Methods ===


### PR DESCRIPTION
## Summary

- Normalize `Task.estimate_hours` once in `apps/web/src/lib/api.ts` for all task-returning API client methods, including quick-task conversion.
- Remove component-level string parsing in the goal detail page and task edit dialog.
- Remove render-time debug logging from the goal detail page and memoize task estimate aggregates.
- Add regression tests covering string and invalid `estimate_hours` payloads at the task API boundary.

## Impact

Task consumers can continue treating `estimate_hours` as a `number`, matching the TypeScript contract. The goal detail page no longer pays per-render debug/log payload costs, and estimate totals are derived once per task list change.

Closes #288

## Validation

- `pnpm --filter @human-compiler/web test -- src/lib/__tests__/tasks-api.test.ts --runInBand`
- `pnpm --filter @human-compiler/web type-check`
- `pnpm --filter @human-compiler/web lint`