### PR TITLE
[codex] fix task validation constraints

### DIFF
--- a/apps/api/src/humancompiler_api/models.py
+++ b/apps/api/src/humancompiler_api/models.py
@@ -1010,7 +1010,7 @@ class TaskUpdate(BaseModel):
     title: str | None = Field(None, min_length=1, max_length=200)
     description: str | None = Field(None, max_length=1000)
     memo: str | None = Field(None, max_length=2000)
-    estimate_hours: Decimal | None = Field(None, gt=0)
+    estimate_hours: Decimal | None = Field(None, gt=0, max_digits=5, decimal_places=2)
     due_date: datetime | None = None
     status: TaskStatus | None = None
     work_type: WorkType | None = None

--- a/apps/api/tests/test_task_update_clears_optional_fields.py
+++ b/apps/api/tests/test_task_update_clears_optional_fields.py
@@ -1,5 +1,8 @@
 from datetime import UTC, datetime
+from decimal import Decimal
 
+import pytest
+from pydantic import ValidationError
 from sqlmodel import Session
 
 from conftest import create_test_data
@@ -39,3 +42,24 @@ def test_update_task_with_explicit_null_clears_description_and_due_date(
     persisted_task = task_service.get_task(session, task.id, test_user_id)
     assert persisted_task.description is None
     assert persisted_task.due_date is None
+
+
+def test_task_update_validation_matches_task_database_constraints():
+    TaskUpdate(
+        title="a" * 200,
+        description="b" * 1000,
+        memo="c" * 2000,
+        estimate_hours=Decimal("999.99"),
+    )
+
+    invalid_inputs = [
+        {"title": "a" * 201},
+        {"description": "b" * 1001},
+        {"memo": "c" * 2001},
+        {"estimate_hours": Decimal("1000.00")},
+        {"estimate_hours": Decimal("1.234")},
+    ]
+
+    for invalid_input in invalid_inputs:
+        with pytest.raises(ValidationError):
+            TaskUpdate(**invalid_input)

--- a/apps/web/src/components/tasks/task-edit-dialog.tsx
+++ b/apps/web/src/components/tasks/task-edit-dialog.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from 'react';
 import { log } from '@/lib/logger';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import * as z from 'zod';
 import {
   Dialog,
   DialogContent,
@@ -40,23 +39,12 @@ import { SessionHistory } from '@/components/runner/session-history';
 import type { Task } from '@/types/task';
 import { roundToDecimals, parseFloatSafe } from '@/lib/number-utils';
 import { buildTaskEditUpdatePayload } from './task-edit-payload';
-
-const taskFormSchema = z.object({
-  title: z.string().min(1, '必須項目です').max(100, '100文字以内で入力してください'),
-  description: z.string().max(500, '500文字以内で入力してください').optional(),
-  estimate_hours: z.number()
-    .min(0.01, '0.01時間以上で入力してください')
-    .max(999.99, '999.99時間以内で入力してください')
-    .refine((val) => Number((val * 100).toFixed()) / 100 === val, {
-      message: '小数点以下は2桁以内で入力してください'
-    }),
-  due_date: z.string().optional(),
-  status: z.enum(['pending', 'in_progress', 'completed', 'cancelled']),
-  work_type: z.enum(['light_work', 'study', 'focused_work']).optional(),
-  priority: z.number().int().min(1, '1以上で入力してください').max(5, '5以下で入力してください').optional(),
-});
-
-type TaskFormData = z.infer<typeof taskFormSchema>;
+import {
+  TASK_ESTIMATE_HOURS_MAX,
+  TASK_ESTIMATE_HOURS_MIN,
+  taskEditFormSchema,
+  type TaskEditFormData,
+} from '@/lib/validations/task';
 
 interface TaskEditDialogProps {
   task: Task;
@@ -68,8 +56,8 @@ export function TaskEditDialog({ task, availableTasks = [], children }: TaskEdit
   const [open, setOpen] = useState(false);
   const updateTaskMutation = useUpdateTask();
 
-  const form = useForm<TaskFormData>({
-    resolver: zodResolver(taskFormSchema),
+  const form = useForm<TaskEditFormData>({
+    resolver: zodResolver(taskEditFormSchema),
     defaultValues: {
       title: task.title,
       description: task.description || '',
@@ -94,7 +82,7 @@ export function TaskEditDialog({ task, availableTasks = [], children }: TaskEdit
     });
   }, [task, form]);
 
-  const onSubmit = async (data: TaskFormData) => {
+  const onSubmit = async (data: TaskEditFormData) => {
     try {
       await updateTaskMutation.mutateAsync({
         id: task.id,
@@ -183,8 +171,8 @@ export function TaskEditDialog({ task, availableTasks = [], children }: TaskEdit
                     <Input
                       type="number"
                       step="0.01"
-                      min="0.01"
-                      max="999.99"
+                      min={TASK_ESTIMATE_HOURS_MIN}
+                      max={TASK_ESTIMATE_HOURS_MAX}
                       placeholder="1.00"
                       {...field}
                       onChange={(e) => {

--- a/apps/web/src/components/tasks/task-form-dialog.tsx
+++ b/apps/web/src/components/tasks/task-form-dialog.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import { log } from '@/lib/logger';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import * as z from 'zod';
 import {
   Dialog,
   DialogContent,
@@ -34,22 +33,12 @@ import {
 import { useCreateTask } from '@/hooks/use-tasks-query';
 import { toast } from '@/hooks/use-toast';
 import { roundToDecimals, parseFloatSafe } from '@/lib/number-utils';
-
-const taskFormSchema = z.object({
-  title: z.string().min(1, '必須項目です').max(100, '100文字以内で入力してください'),
-  description: z.string().max(500, '500文字以内で入力してください').optional(),
-  estimate_hours: z.number()
-    .min(0.01, '0.01時間以上で入力してください')
-    .max(999.99, '999.99時間以内で入力してください')
-    .refine((val) => Number((val * 100).toFixed()) / 100 === val, {
-      message: '小数点以下は2桁以内で入力してください'
-    }),
-  due_date: z.string().optional(),
-  work_type: z.enum(['light_work', 'study', 'focused_work']).optional(),
-  priority: z.number().int().min(1, '1以上で入力してください').max(5, '5以下で入力してください').optional(),
-});
-
-type TaskFormData = z.infer<typeof taskFormSchema>;
+import {
+  TASK_ESTIMATE_HOURS_MAX,
+  TASK_ESTIMATE_HOURS_MIN,
+  taskCreateFormSchema,
+  type TaskCreateFormData,
+} from '@/lib/validations/task';
 
 interface TaskFormDialogProps {
   goalId: string;
@@ -60,8 +49,8 @@ export function TaskFormDialog({ goalId, children }: TaskFormDialogProps) {
   const [open, setOpen] = useState(false);
   const createTaskMutation = useCreateTask();
 
-  const form = useForm<TaskFormData>({
-    resolver: zodResolver(taskFormSchema),
+  const form = useForm<TaskCreateFormData>({
+    resolver: zodResolver(taskCreateFormSchema),
     defaultValues: {
       title: '',
       description: '',
@@ -72,7 +61,7 @@ export function TaskFormDialog({ goalId, children }: TaskFormDialogProps) {
     },
   });
 
-  const onSubmit = async (data: TaskFormData) => {
+  const onSubmit = async (data: TaskCreateFormData) => {
     try {
       const taskData = {
         title: data.title,
@@ -163,8 +152,8 @@ export function TaskFormDialog({ goalId, children }: TaskFormDialogProps) {
                     <Input
                       type="number"
                       step="0.01"
-                      min="0.01"
-                      max="999.99"
+                      min={TASK_ESTIMATE_HOURS_MIN}
+                      max={TASK_ESTIMATE_HOURS_MAX}
                       placeholder="1.00"
                       {...field}
                       onChange={(e) => {

--- a/apps/web/src/components/tasks/task-logs-memo-panel.tsx
+++ b/apps/web/src/components/tasks/task-logs-memo-panel.tsx
@@ -23,6 +23,7 @@ import { formatJSTDateTime } from '@/lib/date-utils';
 import { LogEditDialog } from '@/components/logs/log-edit-dialog';
 import { LogDeleteDialog } from '@/components/logs/log-delete-dialog';
 import type { Log } from '@/types/log';
+import { TASK_MEMO_MAX_LENGTH, taskMemoSchema } from '@/lib/validations/task';
 
 interface TaskLogsMemoPanelProps {
   task: Task;
@@ -62,6 +63,9 @@ export function TaskLogsMemoPanel({
   const hasSessionSummary = isOpen || sessions.length > 0;
   const updateTaskMutation = useUpdateTask();
   const { toast } = useToast();
+  const memoLength = memoText.length;
+  const memoValidation = taskMemoSchema.safeParse(memoText);
+  const memoCounterId = `task-${task.id}-memo-counter`;
 
   // Performance optimization: memoize total log time calculation
   const totalLogTime = useMemo(() =>
@@ -76,6 +80,15 @@ export function TaskLogsMemoPanel({
   );
 
   const handleSaveMemo = async () => {
+    if (!memoValidation.success) {
+      toast({
+        variant: "destructive",
+        title: "メモを保存できません",
+        description: memoValidation.error.issues[0]?.message ?? "入力内容を確認してください。",
+      });
+      return;
+    }
+
     try {
       await updateTaskMutation.mutateAsync({
         id: task.id,
@@ -175,12 +188,20 @@ export function TaskLogsMemoPanel({
                     onChange={(e) => setMemoText(e.target.value)}
                     placeholder="タスクに関するメモを入力してください..."
                     className="min-h-[80px]"
+                    maxLength={TASK_MEMO_MAX_LENGTH}
+                    aria-describedby={memoCounterId}
                   />
+                  <div
+                    id={memoCounterId}
+                    className={`text-xs text-right ${memoValidation.success ? 'text-gray-500' : 'text-red-600'}`}
+                  >
+                    {memoLength}/{TASK_MEMO_MAX_LENGTH}
+                  </div>
                   <div className="flex gap-2">
                     <Button
                       size="sm"
                       onClick={handleSaveMemo}
-                      disabled={updateTaskMutation.isPending}
+                      disabled={updateTaskMutation.isPending || !memoValidation.success}
                     >
                       <Save className="h-4 w-4 mr-1" />
                       保存

--- a/apps/web/src/lib/__tests__/task-validation.test.ts
+++ b/apps/web/src/lib/__tests__/task-validation.test.ts
@@ -1,0 +1,67 @@
+import {
+  TASK_DESCRIPTION_MAX_LENGTH,
+  TASK_ESTIMATE_HOURS_MAX,
+  TASK_MEMO_MAX_LENGTH,
+  TASK_TITLE_MAX_LENGTH,
+  taskCreateFormSchema,
+  taskEditFormSchema,
+  taskMemoSchema,
+} from '../validations/task';
+
+const validTaskForm = {
+  title: 'Valid task',
+  description: 'Valid description',
+  estimate_hours: 1.25,
+  due_date: '',
+  work_type: 'light_work' as const,
+  priority: 3,
+};
+
+describe('task validation schemas', () => {
+  it('uses API-aligned task create limits', () => {
+    expect(taskCreateFormSchema.safeParse({
+      ...validTaskForm,
+      title: 'a'.repeat(TASK_TITLE_MAX_LENGTH),
+      description: 'b'.repeat(TASK_DESCRIPTION_MAX_LENGTH),
+      estimate_hours: TASK_ESTIMATE_HOURS_MAX,
+    }).success).toBe(true);
+
+    expect(taskCreateFormSchema.safeParse({
+      ...validTaskForm,
+      title: 'a'.repeat(TASK_TITLE_MAX_LENGTH + 1),
+    }).success).toBe(false);
+
+    expect(taskCreateFormSchema.safeParse({
+      ...validTaskForm,
+      description: 'b'.repeat(TASK_DESCRIPTION_MAX_LENGTH + 1),
+    }).success).toBe(false);
+  });
+
+  it('rejects task estimates outside numeric precision limits', () => {
+    expect(taskCreateFormSchema.safeParse({
+      ...validTaskForm,
+      estimate_hours: TASK_ESTIMATE_HOURS_MAX + 0.01,
+    }).success).toBe(false);
+
+    expect(taskCreateFormSchema.safeParse({
+      ...validTaskForm,
+      estimate_hours: 1.234,
+    }).success).toBe(false);
+  });
+
+  it('derives edit validation by adding status to the base task schema', () => {
+    expect(taskEditFormSchema.safeParse({
+      ...validTaskForm,
+      status: 'pending',
+    }).success).toBe(true);
+
+    expect(taskEditFormSchema.safeParse({
+      ...validTaskForm,
+    }).success).toBe(false);
+  });
+
+  it('validates task memo length', () => {
+    expect(taskMemoSchema.safeParse('a'.repeat(TASK_MEMO_MAX_LENGTH)).success).toBe(true);
+    expect(taskMemoSchema.safeParse('a'.repeat(TASK_MEMO_MAX_LENGTH + 1)).success).toBe(false);
+  });
+});

--- a/apps/web/src/lib/validations/task.ts
+++ b/apps/web/src/lib/validations/task.ts
@@ -1,0 +1,43 @@
+import * as z from 'zod';
+
+export const TASK_TITLE_MAX_LENGTH = 200;
+export const TASK_DESCRIPTION_MAX_LENGTH = 1000;
+export const TASK_MEMO_MAX_LENGTH = 2000;
+export const TASK_ESTIMATE_HOURS_MIN = 0.01;
+export const TASK_ESTIMATE_HOURS_MAX = 999.99;
+
+export const taskEstimateHoursSchema = z.number()
+  .min(TASK_ESTIMATE_HOURS_MIN, '0.01時間以上で入力してください')
+  .max(TASK_ESTIMATE_HOURS_MAX, '999.99時間以内で入力してください')
+  .refine((val) => Number((val * 100).toFixed()) / 100 === val, {
+    message: '小数点以下は2桁以内で入力してください',
+  });
+
+export const taskBaseFormSchema = z.object({
+  title: z.string()
+    .min(1, '必須項目です')
+    .max(TASK_TITLE_MAX_LENGTH, '200文字以内で入力してください'),
+  description: z.string()
+    .max(TASK_DESCRIPTION_MAX_LENGTH, '1000文字以内で入力してください')
+    .optional(),
+  estimate_hours: taskEstimateHoursSchema,
+  due_date: z.string().optional(),
+  work_type: z.enum(['light_work', 'study', 'focused_work']).optional(),
+  priority: z.number()
+    .int()
+    .min(1, '1以上で入力してください')
+    .max(5, '5以下で入力してください')
+    .optional(),
+});
+
+export const taskCreateFormSchema = taskBaseFormSchema;
+
+export const taskEditFormSchema = taskBaseFormSchema.extend({
+  status: z.enum(['pending', 'in_progress', 'completed', 'cancelled']),
+});
+
+export const taskMemoSchema = z.string()
+  .max(TASK_MEMO_MAX_LENGTH, '2000文字以内で入力してください');
+
+export type TaskCreateFormData = z.infer<typeof taskCreateFormSchema>;
+export type TaskEditFormData = z.infer<typeof taskEditFormSchema>;


### PR DESCRIPTION
## Summary

Closes #289.

- Align task form validation with the API/database limits: title 200 chars, description 1000 chars, estimate_hours 0.01-999.99 with at most 2 decimal places.
- Move shared task Zod validation into `src/lib/validations/task.ts` and derive create/edit schemas from the same base.
- Add memo validation to the task logs/memo panel with a 2000-character limit and counter.
- Add the missing `TaskUpdate.estimate_hours` Pydantic precision constraint so partial updates match the task database model.

## Root Cause

The create/edit task dialogs had duplicated Zod schemas with stricter title/description limits than the API, while memo editing had no frontend limit even though the backend rejects values above 2000 characters. `TaskUpdate` also only checked `gt=0`, so update validation did not fully match the task database field precision.

## Validation

- `pnpm --filter web test -- task-validation.test.ts task-edit-payload.test.ts --runInBand`
- `pnpm --filter web type-check`
- `pnpm --filter web lint` (passes with existing warnings)
- `apps/api/.venv/bin/python -m ruff check src/humancompiler_api/models.py tests/test_task_update_clears_optional_fields.py`
- `apps/api/.venv/bin/python -m pytest -s tests/test_task_update_clears_optional_fields.py`