### PR TITLE
[codex] chore(api): clean up task creation logging

### DIFF
--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -54,40 +54,9 @@ async def create_task(
     current_user: Annotated[AuthUser, Depends(get_current_user)],
 ) -> TaskResponse:
     """Create a new task"""
-    import time
-
-    start_time = time.time()
-    logger.info(
-        f"📋 Creating task for user {current_user.user_id}, goal {task_data.goal_id}"
-    )
-
-    try:
-        logger.info(
-            f"🔍 [TASKS] About to call task_service.create_task with user_id: {current_user.user_id}, goal_id: {task_data.goal_id}"
-        )
-        db_start = time.time()
-        task = task_service.create_task(session, task_data, current_user.user_id)
-        db_time = time.time() - db_start
-        logger.info(f"✅ [TASKS] Successfully created task {task.id} in {db_time:.3f}s")
-
-        response_start = time.time()
-        result = TaskResponse.model_validate(task)
-        response_time = time.time() - response_start
-
-        total_time = time.time() - start_time
-        logger.info(
-            f"✅ Created task {task.id} | DB: {db_time:.3f}s | Response: {response_time:.3f}s | Total: {total_time:.3f}s"
-        )
-
-        return result
-    except Exception as e:
-        logger.error(f"❌ [TASKS] Error creating task: {type(e).__name__}: {e}")
-        logger.error(f"❌ [TASKS] User ID was: {current_user.user_id}")
-        logger.error(f"❌ [TASKS] Task data: {task_data}")
-        import traceback
-
-        logger.error(f"❌ [TASKS] Traceback: {traceback.format_exc()}")
-        raise
+    task = task_service.create_task(session, task_data, current_user.user_id)
+    logger.info("Created task %s for user %s", task.id, current_user.user_id)
+    return TaskResponse.model_validate(task)
 
 
 @router.get(

--- a/apps/api/tests/test_tasks_router.py
+++ b/apps/api/tests/test_tasks_router.py
@@ -1,0 +1,56 @@
+import logging
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+
+from humancompiler_api.auth import AuthUser
+from humancompiler_api.models import Task, TaskCreate
+from humancompiler_api.routers import tasks
+
+
+@pytest.mark.asyncio
+async def test_create_task_logs_only_task_id_and_user_id(monkeypatch, caplog):
+    """Task creation logs should not include user-authored task content."""
+    user_id = UUID("12345678-1234-1234-1234-123456789012")
+    goal_id = uuid4()
+    task_id = uuid4()
+    task_data = TaskCreate(
+        goal_id=goal_id,
+        title="Sensitive task title",
+        description="Sensitive task description",
+        memo="Sensitive task memo",
+        estimate_hours=Decimal("1.5"),
+    )
+    created_task = Task(
+        id=task_id,
+        goal_id=goal_id,
+        title=task_data.title,
+        description=task_data.description,
+        memo=task_data.memo,
+        estimate_hours=task_data.estimate_hours,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    def create_task(session, received_task_data, received_user_id):
+        assert received_task_data is task_data
+        assert received_user_id == user_id
+        return created_task
+
+    monkeypatch.setattr(tasks.task_service, "create_task", create_task)
+
+    with caplog.at_level(logging.INFO, logger=tasks.logger.name):
+        response = await tasks.create_task(
+            task_data,
+            session=None,
+            current_user=AuthUser(user_id=user_id, email="test@example.com"),
+        )
+
+    assert response.id == task_id
+    assert str(task_id) in caplog.text
+    assert str(user_id) in caplog.text
+    assert "Sensitive task title" not in caplog.text
+    assert "Sensitive task description" not in caplog.text
+    assert "Sensitive task memo" not in caplog.text

--- a/apps/api/tests/test_tasks_router.py
+++ b/apps/api/tests/test_tasks_router.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
 import logging
 from datetime import UTC, datetime
 from decimal import Decimal


### PR DESCRIPTION
## Summary

- Simplified the `POST /tasks` handler to remove debug-era timing/logging boilerplate.
- Removed broad exception logging that duplicated FastAPI exception handling and could include user-authored task content.
- Added a regression test that verifies create-task logs include only task/user identifiers, not task title, description, or memo content.

## Why

`create_task` was the only task CRUD route carrying verbose debug logs, emoji-prefixed messages, manual latency measurement, and raw task input logging. This keeps the route consistent with the rest of the CRUD handlers and improves log hygiene/privacy.

Closes #290

## Validation

- `apps/api/.venv/bin/ruff check apps/api/src/humancompiler_api/routers/tasks.py apps/api/tests/test_tasks_router.py`
- `apps/api/.venv/bin/pytest apps/api/tests/test_tasks_router.py apps/api/tests/test_api.py -q -s`

Note: pytest without `-s` hit a local pytest capture cleanup `FileNotFoundError`; rerunning with capture disabled passed: 13 passed, 6 warnings.