### PR TITLE
[codex] Fix health check RLS dependency

### DIFF
--- a/apps/api/src/humancompiler_api/database.py
+++ b/apps/api/src/humancompiler_api/database.py
@@ -244,7 +244,13 @@ class Database:
                 "❌ Database health check timed out after %.1fs",
                 DB_HEALTH_CHECK_TIMEOUT_SECONDS,
             )
-            self.get_engine().dispose()
+            try:
+                self.get_engine().dispose()
+            except Exception as dispose_err:
+                logger.warning(
+                    "Engine dispose after health-check timeout failed: %s",
+                    dispose_err,
+                )
             return False
         except Exception as e:
             logger.error(f"❌ Database health check failed: {e}")

--- a/apps/api/src/humancompiler_api/database.py
+++ b/apps/api/src/humancompiler_api/database.py
@@ -244,6 +244,7 @@ class Database:
                 "❌ Database health check timed out after %.1fs",
                 DB_HEALTH_CHECK_TIMEOUT_SECONDS,
             )
+            self.get_engine().dispose()
             return False
         except Exception as e:
             logger.error(f"❌ Database health check failed: {e}")

--- a/apps/api/src/humancompiler_api/database.py
+++ b/apps/api/src/humancompiler_api/database.py
@@ -33,6 +33,7 @@ POOL_RECYCLE_DEFAULT = 55
 # Connection-level timeouts for PostgreSQL (seconds)
 PG_CONNECT_TIMEOUT = 5
 PG_STATEMENT_TIMEOUT_MS = 30000  # 30 seconds
+DB_HEALTH_CHECK_TIMEOUT_SECONDS = 6.0
 
 
 class Database:
@@ -225,14 +226,25 @@ class Database:
 
     async def health_check(self) -> bool:
         """Check database connection health"""
+        import asyncio
+
         try:
-            client = self.get_client()
-            if client is None:
-                logger.warning("Database client not available (development mode)")
-                return False
-            # Simple query to test connection
-            client.table("users").select("count", count="exact").execute()
+            # Health checks should validate the same direct Postgres connection
+            # used by API handlers and background schedulers. Avoid Supabase Data
+            # API table reads here because anon/authenticated grants and RLS
+            # policies can legitimately block those even when the backend DB
+            # connection is healthy.
+            await asyncio.wait_for(
+                asyncio.to_thread(self._try_connect),
+                timeout=DB_HEALTH_CHECK_TIMEOUT_SECONDS,
+            )
             return True
+        except TimeoutError:
+            logger.error(
+                "❌ Database health check timed out after %.1fs",
+                DB_HEALTH_CHECK_TIMEOUT_SECONDS,
+            )
+            return False
         except Exception as e:
             logger.error(f"❌ Database health check failed: {e}")
             return False

--- a/apps/api/tests/test_database_health.py
+++ b/apps/api/tests/test_database_health.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import patch
 
 import pytest
@@ -26,3 +27,20 @@ async def test_health_check_returns_false_on_direct_connection_failure():
 
     with patch.object(database, "_try_connect", side_effect=RuntimeError("boom")):
         assert await database.health_check() is False
+
+
+@pytest.mark.asyncio
+async def test_health_check_disposes_engine_on_timeout():
+    database = Database()
+
+    with patch.object(database, "get_engine") as get_engine:
+        engine = get_engine.return_value
+        with patch("humancompiler_api.database.DB_HEALTH_CHECK_TIMEOUT_SECONDS", 0.01):
+            with patch.object(
+                database,
+                "_try_connect",
+                side_effect=lambda: time.sleep(0.1),
+            ):
+                assert await database.health_check() is False
+
+    engine.dispose.assert_called_once()

--- a/apps/api/tests/test_database_health.py
+++ b/apps/api/tests/test_database_health.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+
+import pytest
+
+from humancompiler_api.database import Database
+
+
+@pytest.mark.asyncio
+async def test_health_check_uses_direct_database_connection():
+    database = Database()
+
+    with patch.object(
+        database,
+        "get_client",
+        side_effect=AssertionError("Supabase Data API should not be used"),
+    ):
+        with patch.object(database, "_try_connect") as try_connect:
+            assert await database.health_check() is True
+
+    try_connect.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_health_check_returns_false_on_direct_connection_failure():
+    database = Database()
+
+    with patch.object(database, "_try_connect", side_effect=RuntimeError("boom")):
+        assert await database.health_check() is False

--- a/apps/api/tests/test_database_health.py
+++ b/apps/api/tests/test_database_health.py
@@ -44,3 +44,21 @@ async def test_health_check_disposes_engine_on_timeout():
                 assert await database.health_check() is False
 
     engine.dispose.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_health_check_returns_false_when_timeout_cleanup_fails():
+    database = Database()
+
+    with patch.object(database, "get_engine") as get_engine:
+        engine = get_engine.return_value
+        engine.dispose.side_effect = RuntimeError("dispose failed")
+        with patch("humancompiler_api.database.DB_HEALTH_CHECK_TIMEOUT_SECONDS", 0.01):
+            with patch.object(
+                database,
+                "_try_connect",
+                side_effect=lambda: time.sleep(0.1),
+            ):
+                assert await database.health_check() is False
+
+    engine.dispose.assert_called_once()


### PR DESCRIPTION
## Summary

- Change API database health checks to use the backend's direct SQLAlchemy/Postgres connection instead of the Supabase anon Data API.
- Add tests that lock health checks to the direct DB path and verify failures return `False`.

## Root Cause

The health check read `public.users` through the Supabase anon client. After RLS/policy changes, that table read can be denied for anon even when the backend `DATABASE_URL` connection is healthy. Because startup only starts background schedulers after `db.health_check()` succeeds, this could prevent notification/triage scheduler jobs from starting and make Fly.io mark the service unhealthy.

## Impact

`/health` now validates the same database connection used by API handlers and background jobs, so RLS/grant changes for anon/authenticated Data API access no longer break API health checks.

## Validation

- `.venv/bin/python -m pytest tests/test_database_health.py tests/test_main.py -q -s`
- `.venv/bin/ruff check src/humancompiler_api/database.py tests/test_database_health.py`
- pre-commit hooks during commit: ruff, ruff format, trim trailing whitespace, EOF, merge conflict check