### PR TITLE
[codex] Stage Fly secrets before deploy

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -106,6 +106,7 @@ jobs:
               SUPABASE_ANON_KEY="${{ secrets.SUPABASE_ANON_KEY }}" \
               SUPABASE_SERVICE_ROLE_KEY="${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
               ENCRYPTION_SALT="${{ secrets.ENCRYPTION_SALT }}" \
+              --stage \
               --app humancompiler-api-masa-preview; then
               break
             fi
@@ -197,6 +198,7 @@ jobs:
               SUPABASE_ANON_KEY="${{ secrets.SUPABASE_ANON_KEY }}" \
               SUPABASE_SERVICE_ROLE_KEY="${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}" \
               ENCRYPTION_SALT="${{ secrets.ENCRYPTION_SALT }}" \
+              --stage \
               --app humancompiler-api-masa; then
               break
             fi

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -10,6 +10,7 @@ on:
     branches: [main]
     paths:
       - 'apps/api/**'
+      - '.github/workflows/deploy-api.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `--stage` to Fly.io secret updates for both preview and production deploy jobs.
- Keep secret synchronization in the workflow, but avoid triggering a Machine rollout before the new image deploy step runs.
- Include `.github/workflows/deploy-api.yml` in the PR path filter so deploy workflow changes get checked before merge.

## Root Cause
The production workflow failed in `Set Production secrets`, before reaching `flyctl deploy`. `flyctl secrets set` restarts Machines by default for Machine apps and waits for rolling health checks. Because the current production Machine was already failing `/health`, the secret update retried three times and timed out waiting for the old Machine to become healthy.

## Impact
This lets the workflow stage secrets for the upcoming deployment instead of restarting the currently unhealthy production Machine. The subsequent `flyctl deploy` step can then roll out the image that contains the DB health-check fix.

## Validation
- `git diff --check`
- Ruby YAML parse of `.github/workflows/deploy-api.yml`
- pre-commit YAML hook during commit