### PR TITLE
[codex] Add hook quick task ingestion

### DIFF
--- a/apps/api/migrations/024_add_hook_tokens.sql
+++ b/apps/api/migrations/024_add_hook_tokens.sql
@@ -1,0 +1,42 @@
+-- Migration: Add hook tokens for external quick task ingestion
+-- Created: 2026-07-07
+-- Description: User-scoped hook tokens for creating quick tasks from external tools
+
+CREATE TABLE IF NOT EXISTS public.hook_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    name VARCHAR(100) NOT NULL,
+    token_hash CHAR(64) NOT NULL UNIQUE,
+    token_prefix VARCHAR(16) NOT NULL,
+    last_used_at TIMESTAMP WITH TIME ZONE,
+    revoked_at TIMESTAMP WITH TIME ZONE,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hook_tokens_user_id
+    ON public.hook_tokens(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_hook_tokens_active_by_user
+    ON public.hook_tokens(user_id, created_at DESC)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_hook_tokens_token_hash
+    ON public.hook_tokens(token_hash)
+    WHERE revoked_at IS NULL;
+
+ALTER TABLE public.hook_tokens ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "hook_tokens_own_data" ON public.hook_tokens
+    FOR ALL
+    TO authenticated
+    USING (auth.uid()::text = user_id::text)
+    WITH CHECK (auth.uid()::text = user_id::text);
+
+COMMENT ON TABLE public.hook_tokens IS 'User-scoped hashed tokens for external hook ingestion';
+COMMENT ON COLUMN public.hook_tokens.user_id IS 'Owner of the hook token';
+COMMENT ON COLUMN public.hook_tokens.name IS 'User-facing token label';
+COMMENT ON COLUMN public.hook_tokens.token_hash IS 'SHA-256 hash of the hook token secret';
+COMMENT ON COLUMN public.hook_tokens.token_prefix IS 'Non-secret token prefix shown in the UI';
+COMMENT ON COLUMN public.hook_tokens.last_used_at IS 'Most recent successful hook use';
+COMMENT ON COLUMN public.hook_tokens.revoked_at IS 'Set when the token is revoked';

--- a/apps/api/migrations/024_add_hook_tokens.sql
+++ b/apps/api/migrations/024_add_hook_tokens.sql
@@ -27,16 +27,31 @@ CREATE INDEX IF NOT EXISTS idx_hook_tokens_token_hash
 
 ALTER TABLE public.hook_tokens ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "hook_tokens_own_data" ON public.hook_tokens
-    FOR ALL
+DROP POLICY IF EXISTS "hook_tokens_own_data" ON public.hook_tokens;
+DROP POLICY IF EXISTS "hook_tokens_own_metadata" ON public.hook_tokens;
+
+CREATE POLICY "hook_tokens_own_metadata" ON public.hook_tokens
+    FOR SELECT
     TO authenticated
-    USING (auth.uid()::text = user_id::text)
-    WITH CHECK (auth.uid()::text = user_id::text);
+    USING (auth.uid()::text = user_id::text);
+
+REVOKE ALL ON public.hook_tokens FROM anon, authenticated;
+
+GRANT SELECT (
+    id,
+    user_id,
+    name,
+    token_prefix,
+    last_used_at,
+    revoked_at,
+    created_at,
+    updated_at
+) ON public.hook_tokens TO authenticated;
 
 COMMENT ON TABLE public.hook_tokens IS 'User-scoped hashed tokens for external hook ingestion';
 COMMENT ON COLUMN public.hook_tokens.user_id IS 'Owner of the hook token';
 COMMENT ON COLUMN public.hook_tokens.name IS 'User-facing token label';
 COMMENT ON COLUMN public.hook_tokens.token_hash IS 'SHA-256 hash of the hook token secret';
-COMMENT ON COLUMN public.hook_tokens.token_prefix IS 'Non-secret token prefix shown in the UI';
+COMMENT ON COLUMN public.hook_tokens.token_prefix IS 'Non-secret public token id shown in the UI';
 COMMENT ON COLUMN public.hook_tokens.last_used_at IS 'Most recent successful hook use';
 COMMENT ON COLUMN public.hook_tokens.revoked_at IS 'Set when the token is revoked';

--- a/apps/api/src/humancompiler_api/main.py
+++ b/apps/api/src/humancompiler_api/main.py
@@ -34,6 +34,8 @@ from humancompiler_api.routers import (
     data_export,
     goal_dependencies,
     goals,
+    hook_tokens,
+    hooks,
     logs,
     monitoring,
     notes,
@@ -316,6 +318,8 @@ app.include_router(user_settings.router)
 app.include_router(monitoring.router)
 app.include_router(simple_backup_api.router)
 app.include_router(data_export.router, tags=["data-export"])
+app.include_router(hook_tokens.router)
+app.include_router(hooks.router, prefix="/api")
 app.include_router(work_sessions.router, prefix="/api")
 # Issue #227: Reschedule router
 app.include_router(reschedule.router, prefix="/api")

--- a/apps/api/src/humancompiler_api/models.py
+++ b/apps/api/src/humancompiler_api/models.py
@@ -238,6 +238,7 @@ class User(UserBase, table=True):  # type: ignore[call-arg]
     push_subscriptions: list["PushSubscription"] = Relationship(back_populates="user")
     quick_tasks: list["QuickTask"] = Relationship(back_populates="owner")
     slot_templates: list["SlotTemplate"] = Relationship(back_populates="user")
+    hook_tokens: list["HookToken"] = Relationship(back_populates="user")
 
 
 class ProjectBase(SQLModel):
@@ -777,6 +778,32 @@ class UserSettings(UserSettingsBase, table=True):  # type: ignore[call-arg]
 
     # Relationships
     user: User = Relationship(back_populates="settings")
+
+
+class HookToken(SQLModel, table=True):  # type: ignore[call-arg]
+    """User-scoped token for external hook ingestion."""
+
+    __tablename__ = "hook_tokens"
+
+    id: UUID | None = SQLField(
+        default=None,
+        sa_column=Column(
+            "id",
+            SQLAlchemyUUID,
+            primary_key=True,
+            server_default=text("gen_random_uuid()"),
+        ),
+    )
+    user_id: UUID = SQLField(foreign_key="users.id", index=True)
+    name: str = SQLField(min_length=1, max_length=100)
+    token_hash: str = SQLField(max_length=64, unique=True, index=True)
+    token_prefix: str = SQLField(max_length=16)
+    last_used_at: datetime | None = SQLField(default=None)
+    revoked_at: datetime | None = SQLField(default=None)
+    created_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime | None = SQLField(default_factory=lambda: datetime.now(UTC))
+
+    user: User = Relationship(back_populates="hook_tokens")
 
 
 # Email Notification Models (Issue #261)
@@ -1364,6 +1391,50 @@ class UserSettingsResponse(BaseModel):
             # Assume naive datetime is UTC and add timezone info
             value = value.replace(tzinfo=UTC)
         return value.isoformat()
+
+
+class HookTokenCreate(BaseModel):
+    """Hook token creation request."""
+
+    name: str = Field(min_length=1, max_length=100)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        """Normalize token names and reject whitespace-only values."""
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("Hook token name cannot be empty")
+        return stripped
+
+
+class HookTokenResponse(BaseModel):
+    """Hook token metadata response. The token secret is never returned here."""
+
+    id: UUID
+    user_id: UUID
+    name: str
+    token_prefix: str
+    last_used_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_serializer("last_used_at", "created_at", "updated_at")
+    def serialize_datetimes(self, value: datetime | None) -> str | None:
+        """Ensure datetimes are serialized with UTC timezone info."""
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=UTC)
+        return value.isoformat()
+
+
+class HookTokenCreatedResponse(HookTokenResponse):
+    """Hook token creation response, including the one-time token secret."""
+
+    token: str
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/apps/api/src/humancompiler_api/routers/__init__.py
+++ b/apps/api/src/humancompiler_api/routers/__init__.py
@@ -2,6 +2,8 @@
 from . import (
     ai_planning,
     goals,
+    hook_tokens,
+    hooks,
     monitoring,
     notes,
     notifications,
@@ -19,6 +21,8 @@ from . import (
 __all__ = [
     "ai_planning",
     "goals",
+    "hook_tokens",
+    "hooks",
     "monitoring",
     "notes",
     "notifications",

--- a/apps/api/src/humancompiler_api/routers/hook_tokens.py
+++ b/apps/api/src/humancompiler_api/routers/hook_tokens.py
@@ -1,0 +1,76 @@
+"""Hook token management API routes."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from sqlmodel import Session
+
+from humancompiler_api.auth import AuthUser, get_current_user
+from humancompiler_api.database import get_session
+from humancompiler_api.models import (
+    HookToken,
+    HookTokenCreate,
+    HookTokenCreatedResponse,
+    HookTokenResponse,
+)
+from humancompiler_api.services import hook_token_service
+
+router = APIRouter(prefix="/api/user/hook-tokens", tags=["hook-tokens"])
+
+
+def _created_response(token_model: HookToken, token: str) -> HookTokenCreatedResponse:
+    """Build the one-time token creation response."""
+    return HookTokenCreatedResponse(
+        id=token_model.id,
+        user_id=token_model.user_id,
+        name=token_model.name,
+        token_prefix=token_model.token_prefix,
+        last_used_at=token_model.last_used_at,
+        created_at=token_model.created_at,
+        updated_at=token_model.updated_at,
+        token=token,
+    )
+
+
+@router.get("", response_model=list[HookTokenResponse])
+@router.get("/", response_model=list[HookTokenResponse], include_in_schema=False)
+async def list_hook_tokens(
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+) -> list[HookTokenResponse]:
+    """List active hook tokens for the current user."""
+    tokens = hook_token_service.get_hook_tokens(session, current_user.user_id)
+    return [HookTokenResponse.model_validate(token) for token in tokens]
+
+
+@router.post(
+    "",
+    response_model=HookTokenCreatedResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+@router.post(
+    "/",
+    response_model=HookTokenCreatedResponse,
+    status_code=status.HTTP_201_CREATED,
+    include_in_schema=False,
+)
+async def create_hook_token(
+    token_data: HookTokenCreate,
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+) -> HookTokenCreatedResponse:
+    """Create a hook token and return its secret once."""
+    token_model, token = hook_token_service.create_hook_token(
+        session, token_data, current_user.user_id
+    )
+    return _created_response(token_model, token)
+
+
+@router.delete("/{token_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def revoke_hook_token(
+    token_id: str,
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+) -> None:
+    """Revoke an active hook token."""
+    hook_token_service.revoke_hook_token(session, token_id, current_user.user_id)

--- a/apps/api/src/humancompiler_api/routers/hooks.py
+++ b/apps/api/src/humancompiler_api/routers/hooks.py
@@ -1,0 +1,61 @@
+"""External hook ingestion API routes."""
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlmodel import Session
+
+from humancompiler_api.database import get_session
+from humancompiler_api.models import QuickTaskCreate, QuickTaskResponse
+from humancompiler_api.services import hook_token_service, quick_task_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/hooks", tags=["hooks"])
+
+
+def _extract_hook_token(request: Request) -> str:
+    """Extract a hook token from supported headers."""
+    authorization = request.headers.get("authorization")
+    if authorization:
+        scheme, _, value = authorization.partition(" ")
+        if scheme.lower() == "bearer" and value.strip():
+            return value.strip()
+
+    header_token = request.headers.get("x-humancompiler-hook-token")
+    if header_token and header_token.strip():
+        return header_token.strip()
+
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Hook token required",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+@router.post(
+    "/quick-tasks",
+    response_model=QuickTaskResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_quick_task_from_hook(
+    task_data: QuickTaskCreate,
+    request: Request,
+    session: Annotated[Session, Depends(get_session)],
+) -> QuickTaskResponse:
+    """Create a quick task using a user-scoped hook token."""
+    token = _extract_hook_token(request)
+    hook_token = hook_token_service.get_active_token_by_secret(session, token)
+    if hook_token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid hook token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    task = quick_task_service.create_quick_task(session, task_data, hook_token.user_id)
+    hook_token_service.mark_token_used(session, hook_token)
+
+    logger.info("Created hook quick task %s for user %s", task.id, hook_token.user_id)
+    return QuickTaskResponse.model_validate(task)

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -5,14 +5,21 @@ Refactored services using base service class
 from collections import deque
 from datetime import datetime, UTC
 from decimal import Decimal, ROUND_HALF_UP
+import hashlib
+import secrets
 from uuid import UUID
+from uuid import uuid4
 
 from fastapi import HTTPException, status
 from sqlalchemy.orm import selectinload
 from sqlmodel import Session, and_, delete, func, select
 
 from humancompiler_api.base_service import BaseService
-from humancompiler_api.common.error_handlers import validate_uuid
+from humancompiler_api.common.error_handlers import (
+    ResourceNotFoundError,
+    safe_execute,
+    validate_uuid,
+)
 from humancompiler_api.models import (
     Goal,
     GoalCreate,
@@ -50,6 +57,8 @@ from humancompiler_api.models import (
     QuickTask,
     QuickTaskCreate,
     QuickTaskUpdate,
+    HookToken,
+    HookTokenCreate,
     TaskStatus,
     SlotTemplate,
     SlotTemplateCreate,
@@ -1564,6 +1573,106 @@ class WorkSessionService(
         return work_session
 
 
+class HookTokenService:
+    """Service for user-scoped hook ingestion tokens."""
+
+    TOKEN_PREFIX = "hc_hook_"
+    TOKEN_PREFIX_LENGTH = 16
+
+    @classmethod
+    def generate_token(cls) -> str:
+        """Generate a new hook token secret."""
+        return f"{cls.TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
+
+    @staticmethod
+    def hash_token(token: str) -> str:
+        """Hash a hook token for storage and lookup."""
+        return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+    def create_hook_token(
+        self, session: Session, token_data: HookTokenCreate, user_id: str | UUID
+    ) -> tuple[HookToken, str]:
+        """Create a hook token and return the one-time plaintext secret."""
+        user_id_validated = validate_uuid(user_id, "user_id")
+        token = self.generate_token()
+        now = datetime.now(UTC)
+        hook_token = HookToken(
+            id=uuid4(),
+            user_id=user_id_validated,
+            name=token_data.name,
+            token_hash=self.hash_token(token),
+            token_prefix=token[: self.TOKEN_PREFIX_LENGTH],
+            created_at=now,
+            updated_at=now,
+        )
+
+        def create_operation() -> HookToken:
+            session.add(hook_token)
+            session.flush()
+            return hook_token
+
+        return safe_execute(session, create_operation), token
+
+    def get_hook_tokens(self, session: Session, user_id: str | UUID) -> list[HookToken]:
+        """Return active hook token metadata for a user."""
+        user_id_validated = validate_uuid(user_id, "user_id")
+        statement = (
+            select(HookToken)
+            .where(
+                HookToken.user_id == user_id_validated,
+                HookToken.revoked_at.is_(None),
+            )
+            .order_by(HookToken.created_at.desc(), HookToken.id.asc())
+        )
+        return list(session.exec(statement).all())
+
+    def revoke_hook_token(
+        self, session: Session, token_id: str | UUID, user_id: str | UUID
+    ) -> HookToken:
+        """Revoke an active hook token."""
+        token_id_validated = validate_uuid(token_id, "token_id")
+        user_id_validated = validate_uuid(user_id, "user_id")
+        hook_token = session.exec(
+            select(HookToken).where(
+                HookToken.id == token_id_validated,
+                HookToken.user_id == user_id_validated,
+                HookToken.revoked_at.is_(None),
+            )
+        ).first()
+        if hook_token is None:
+            raise ResourceNotFoundError("HookToken", token_id_validated)
+
+        now = datetime.now(UTC)
+        hook_token.revoked_at = now
+        hook_token.updated_at = now
+        session.add(hook_token)
+        session.commit()
+        session.refresh(hook_token)
+        return hook_token
+
+    def get_active_token_by_secret(
+        self, session: Session, token: str
+    ) -> HookToken | None:
+        """Resolve an active hook token from a plaintext secret."""
+        token_hash = self.hash_token(token)
+        return session.exec(
+            select(HookToken).where(
+                HookToken.token_hash == token_hash,
+                HookToken.revoked_at.is_(None),
+            )
+        ).first()
+
+    def mark_token_used(self, session: Session, hook_token: HookToken) -> HookToken:
+        """Record successful hook token use."""
+        now = datetime.now(UTC)
+        hook_token.last_used_at = now
+        hook_token.updated_at = now
+        session.add(hook_token)
+        session.commit()
+        session.refresh(hook_token)
+        return hook_token
+
+
 class QuickTaskService(BaseService[QuickTask, QuickTaskCreate, QuickTaskUpdate]):
     """QuickTask service for unclassified tasks not belonging to any project"""
 
@@ -1958,5 +2067,6 @@ task_service = TaskService()
 log_service = LogService()
 weekly_recurring_task_service = WeeklyRecurringTaskService()
 work_session_service = WorkSessionService()
+hook_token_service = HookTokenService()
 quick_task_service = QuickTaskService()
 slot_template_service = SlotTemplateService()

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -1576,7 +1576,7 @@ class WorkSessionService(
 class HookTokenService:
     """Service for user-scoped hook ingestion tokens."""
 
-    TOKEN_PREFIX = "hc_hook_"
+    HOOK_NAMESPACE = "hc_hook_"
     PUBLIC_ID_BYTES = 6
     TOKEN_PREFIX_LENGTH = 16
 
@@ -1584,7 +1584,7 @@ class HookTokenService:
     def generate_token(cls) -> tuple[str, str]:
         """Generate a hook token and its non-secret display prefix."""
         public_id = secrets.token_urlsafe(cls.PUBLIC_ID_BYTES)
-        token_prefix = f"{cls.TOKEN_PREFIX}{public_id}"
+        token_prefix = f"{cls.HOOK_NAMESPACE}{public_id}"
         return f"{token_prefix}_{secrets.token_urlsafe(32)}", token_prefix
 
     @staticmethod

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -1577,12 +1577,15 @@ class HookTokenService:
     """Service for user-scoped hook ingestion tokens."""
 
     TOKEN_PREFIX = "hc_hook_"
+    PUBLIC_ID_BYTES = 6
     TOKEN_PREFIX_LENGTH = 16
 
     @classmethod
-    def generate_token(cls) -> str:
-        """Generate a new hook token secret."""
-        return f"{cls.TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
+    def generate_token(cls) -> tuple[str, str]:
+        """Generate a hook token and its non-secret display prefix."""
+        public_id = secrets.token_urlsafe(cls.PUBLIC_ID_BYTES)
+        token_prefix = f"{cls.TOKEN_PREFIX}{public_id}"
+        return f"{token_prefix}_{secrets.token_urlsafe(32)}", token_prefix
 
     @staticmethod
     def hash_token(token: str) -> str:
@@ -1594,14 +1597,14 @@ class HookTokenService:
     ) -> tuple[HookToken, str]:
         """Create a hook token and return the one-time plaintext secret."""
         user_id_validated = validate_uuid(user_id, "user_id")
-        token = self.generate_token()
+        token, token_prefix = self.generate_token()
         now = datetime.now(UTC)
         hook_token = HookToken(
             id=uuid4(),
             user_id=user_id_validated,
             name=token_data.name,
             token_hash=self.hash_token(token),
-            token_prefix=token[: self.TOKEN_PREFIX_LENGTH],
+            token_prefix=token_prefix[: self.TOKEN_PREFIX_LENGTH],
             created_at=now,
             updated_at=now,
         )

--- a/apps/api/tests/test_hook_tokens.py
+++ b/apps/api/tests/test_hook_tokens.py
@@ -70,10 +70,12 @@ def test_create_hook_token_returns_secret_once_and_stores_hash(session: Session)
     data = response.json()
     assert data["name"] == "PR review hook"
     assert data["token"].startswith("hc_hook_")
-    assert data["token_prefix"] == data["token"][:16]
+    assert len(data["token_prefix"]) == 16
+    assert data["token"].startswith(f"{data['token_prefix']}_")
     assert "token_hash" not in data
 
     stored_token = session.exec(select(HookToken)).one()
+    assert stored_token.token_prefix == data["token_prefix"]
     assert (
         stored_token.token_hash
         == hashlib.sha256(data["token"].encode("utf-8")).hexdigest()

--- a/apps/api/tests/test_hook_tokens.py
+++ b/apps/api/tests/test_hook_tokens.py
@@ -1,0 +1,188 @@
+import hashlib
+import logging
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, select
+
+from humancompiler_api.auth import AuthUser, get_current_user
+from humancompiler_api.database import get_session
+from humancompiler_api.main import app
+from humancompiler_api.models import HookToken, QuickTask, User
+from humancompiler_api.routers import hooks
+
+client = TestClient(app)
+
+TEST_USER_ID = UUID("12345678-1234-1234-1234-123456789012")
+
+
+@pytest.fixture(autouse=True)
+def reset_dependency_overrides():
+    clear_overrides()
+    yield
+    clear_overrides()
+
+
+def seed_user(session: Session, user_id: UUID = TEST_USER_ID) -> User:
+    user = User(id=user_id, email="hook-user@example.com")
+    session.add(user)
+    session.commit()
+    return user
+
+
+def install_overrides(session: Session, user_id: UUID = TEST_USER_ID) -> None:
+    def override_session():
+        yield session
+
+    def override_user():
+        return AuthUser(user_id=str(user_id), email="hook-user@example.com")
+
+    app.dependency_overrides[get_session] = override_session
+    app.dependency_overrides[get_current_user] = override_user
+
+
+def clear_overrides() -> None:
+    app.dependency_overrides.pop(get_session, None)
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+def create_hook_token(session: Session, name: str = "PR reviews") -> str:
+    seed_user(session)
+    install_overrides(session)
+    response = client.post("/api/user/hook-tokens", json={"name": name})
+
+    assert response.status_code == 201
+    return response.json()["token"]
+
+
+def test_create_hook_token_returns_secret_once_and_stores_hash(session: Session):
+    seed_user(session)
+    install_overrides(session)
+
+    response = client.post(
+        "/api/user/hook-tokens",
+        json={"name": "  PR review hook  "},
+    )
+    list_response = client.get("/api/user/hook-tokens")
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "PR review hook"
+    assert data["token"].startswith("hc_hook_")
+    assert data["token_prefix"] == data["token"][:16]
+    assert "token_hash" not in data
+
+    stored_token = session.exec(select(HookToken)).one()
+    assert (
+        stored_token.token_hash
+        == hashlib.sha256(data["token"].encode("utf-8")).hexdigest()
+    )
+    assert stored_token.token_hash != data["token"]
+
+    assert list_response.status_code == 200
+    listed_token = list_response.json()[0]
+    assert listed_token["name"] == "PR review hook"
+    assert listed_token["token_prefix"] == data["token_prefix"]
+    assert "token" not in listed_token
+    assert "token_hash" not in listed_token
+
+
+def test_hook_token_creates_quick_task_and_updates_last_used(session: Session):
+    token = create_hook_token(session)
+
+    response = client.post(
+        "/api/hooks/quick-tasks",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "title": "Review PR 299",
+            "description": "Read comments",
+            "estimate_hours": 0.5,
+            "priority": 2,
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "Review PR 299"
+    assert data["owner_id"] == str(TEST_USER_ID)
+
+    quick_task = session.exec(select(QuickTask)).one()
+    assert quick_task.title == "Review PR 299"
+    assert quick_task.owner_id == TEST_USER_ID
+
+    stored_token = session.exec(select(HookToken)).one()
+    assert stored_token.last_used_at is not None
+
+
+def test_hook_token_header_creates_quick_task(session: Session):
+    token = create_hook_token(session)
+
+    response = client.post(
+        "/api/hooks/quick-tasks",
+        headers={"X-HumanCompiler-Hook-Token": token},
+        json={"title": "Read paper"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["title"] == "Read paper"
+
+
+def test_missing_invalid_and_revoked_hook_tokens_are_rejected(session: Session):
+    token = create_hook_token(session)
+    token_id = session.exec(select(HookToken.id)).one()
+    revoke_response = client.delete(f"/api/user/hook-tokens/{token_id}")
+
+    assert revoke_response.status_code == 204
+
+    missing_response = client.post(
+        "/api/hooks/quick-tasks",
+        json={"title": "Missing token task"},
+    )
+    invalid_response = client.post(
+        "/api/hooks/quick-tasks",
+        headers={"Authorization": "Bearer invalid-token"},
+        json={"title": "Invalid token task"},
+    )
+    revoked_response = client.post(
+        "/api/hooks/quick-tasks",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"title": "Revoked token task"},
+    )
+
+    assert missing_response.status_code == 401
+    assert invalid_response.status_code == 401
+    assert revoked_response.status_code == 401
+    assert session.exec(select(QuickTask)).all() == []
+
+
+def test_hook_quick_task_validation_uses_existing_quick_task_schema(session: Session):
+    token = create_hook_token(session)
+
+    response = client.post(
+        "/api/hooks/quick-tasks",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"title": "Invalid priority", "priority": 9},
+    )
+
+    assert response.status_code == 422
+    assert session.exec(select(QuickTask)).all() == []
+
+
+def test_hook_quick_task_logs_do_not_include_user_content(session: Session, caplog):
+    token = create_hook_token(session)
+
+    with caplog.at_level(logging.INFO, logger=hooks.logger.name):
+        response = client.post(
+            "/api/hooks/quick-tasks",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "title": "Sensitive hook title",
+                "description": "Sensitive hook description",
+            },
+        )
+
+    assert response.status_code == 201
+    assert str(TEST_USER_ID) in caplog.text
+    assert "Sensitive hook title" not in caplog.text
+    assert "Sensitive hook description" not in caplog.text

--- a/apps/web/src/app/settings/__tests__/page.test.tsx
+++ b/apps/web/src/app/settings/__tests__/page.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+
+const mockPush = jest.fn()
+const mockSecureFetch = jest.fn()
+const mockGetHookTokens = jest.fn()
+const mockCreateHookToken = jest.fn()
+const mockRevokeHookToken = jest.fn()
+const mockGetUser = jest.fn()
+const mockGetSession = jest.fn()
+const mockClipboardWriteText = jest.fn()
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}))
+
+jest.mock('@/lib/api', () => ({
+  secureFetch: (...args: unknown[]) => mockSecureFetch(...args),
+  hookTokensApi: {
+    getAll: () => mockGetHookTokens(),
+    create: (data: unknown) => mockCreateHookToken(data),
+    revoke: (tokenId: string) => mockRevokeHookToken(tokenId),
+  },
+}))
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: () => mockGetUser(),
+      getSession: () => mockGetSession(),
+    },
+  },
+}))
+
+jest.mock('@/components/layout/app-header', () => ({
+  AppHeader: () => <header>App Header</header>,
+}))
+
+jest.mock('@/components/triage/triage-settings-card', () => ({
+  TriageSettingsCard: () => <section>Triage Settings</section>,
+}))
+
+jest.mock('@/components/ui/confirmation-modal', () => ({
+  ConfirmationModal: ({
+    isOpen,
+    onConfirm,
+    title,
+    confirmText,
+  }: {
+    isOpen: boolean
+    onConfirm: () => void
+    title: string
+    confirmText?: string
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-label={title}>
+        <button onClick={onConfirm}>{confirmText ?? '確認'}</button>
+      </div>
+    ) : null,
+}))
+
+import SettingsPage from '../page'
+
+const jsonResponse = (data: unknown, ok = true) =>
+  ({
+    ok,
+    json: jest.fn().mockResolvedValue(data),
+  }) as unknown as Response
+
+const defaultSettings = {
+  has_api_key: false,
+  openai_model: 'gpt-5.5',
+  email_notifications_enabled: false,
+  email_deadline_reminder_hours: 24,
+  email_overdue_alerts_enabled: true,
+  email_daily_digest_enabled: false,
+  email_daily_digest_hour: 9,
+}
+
+const defaultExportInfo = {
+  current_data_summary: {
+    projects: 0,
+    goals: 0,
+    tasks: 0,
+    quick_tasks: 0,
+    schedules: 0,
+    weekly_schedules: 0,
+  },
+}
+
+describe('SettingsPage hook tokens', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockClipboardWriteText },
+      configurable: true,
+    })
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'user-1', email: 'test@example.com' } },
+    })
+    mockGetSession.mockResolvedValue({
+      data: { session: { access_token: 'session-token' } },
+    })
+    mockSecureFetch.mockImplementation((endpoint: string) => {
+      if (endpoint === '/api/user/models') {
+        return Promise.resolve(
+          jsonResponse({
+            models: {
+              'gpt-5.5': {
+                name: 'GPT-5.5',
+                description: 'Model',
+                max_context: '400k',
+                max_output: '128k',
+                modalities: ['text'],
+              },
+            },
+          })
+        )
+      }
+      if (endpoint === '/api/user/settings') {
+        return Promise.resolve(jsonResponse(defaultSettings))
+      }
+      if (endpoint === '/api/export/info') {
+        return Promise.resolve(jsonResponse(defaultExportInfo))
+      }
+      return Promise.resolve(jsonResponse({}))
+    })
+    mockGetHookTokens.mockResolvedValue([])
+    mockCreateHookToken.mockResolvedValue({
+      id: 'token-1',
+      user_id: 'user-1',
+      name: 'PR review',
+      token_prefix: 'hc_hook_created',
+      token: 'hc_hook_created_secret',
+      last_used_at: null,
+      created_at: '2026-07-07T00:00:00Z',
+      updated_at: '2026-07-07T00:00:00Z',
+    })
+    mockRevokeHookToken.mockResolvedValue(undefined)
+    mockClipboardWriteText.mockResolvedValue(undefined)
+  })
+
+  it('creates a hook token and shows the one-time secret for copying', async () => {
+    render(<SettingsPage />)
+
+    await screen.findByText('Hook Tokens')
+    fireEvent.change(screen.getByPlaceholderText('Token name'), {
+      target: { value: 'PR review' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /作成/ }))
+
+    await waitFor(() => {
+      expect(mockCreateHookToken).toHaveBeenCalledWith({ name: 'PR review' })
+    })
+    expect(screen.getByText('hc_hook_created_secret')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /コピー/ }))
+
+    await waitFor(() => {
+      expect(mockClipboardWriteText).toHaveBeenCalledWith(
+        'hc_hook_created_secret'
+      )
+    })
+  })
+
+  it('revokes an existing hook token from the settings list', async () => {
+    mockGetHookTokens.mockResolvedValue([
+      {
+        id: 'token-1',
+        user_id: 'user-1',
+        name: 'Paper intake',
+        token_prefix: 'hc_hook_paper',
+        last_used_at: null,
+        created_at: '2026-07-07T00:00:00Z',
+        updated_at: '2026-07-07T00:00:00Z',
+      },
+    ])
+
+    render(<SettingsPage />)
+
+    await screen.findByText('Paper intake')
+    fireEvent.click(screen.getByRole('button', { name: /失効/ }))
+    fireEvent.click(
+      within(screen.getByRole('dialog', { name: 'Hook tokenを失効' })).getByRole(
+        'button',
+        { name: '失効' }
+      )
+    )
+
+    await waitFor(() => {
+      expect(mockRevokeHookToken).toHaveBeenCalledWith('token-1')
+    })
+    expect(screen.queryByText('Paper intake')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -8,7 +8,7 @@ import { Label } from "@/components/ui/label"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { Eye, EyeOff, Key, AlertCircle, CheckCircle, Download, Upload, Database, Mail, Bell } from "lucide-react"
+import { Eye, EyeOff, Key, AlertCircle, CheckCircle, Download, Upload, Database, Mail, Bell, Copy, Plus, Trash2 } from "lucide-react"
 import { Switch } from "@/components/ui/switch"
 import { AppHeader } from "@/components/layout/app-header"
 import { TriageSettingsCard } from "@/components/triage/triage-settings-card"
@@ -16,7 +16,8 @@ import { ConfirmationModal } from "@/components/ui/confirmation-modal"
 import { supabase } from "@/lib/supabase"
 import { log } from "@/lib/logger"
 import { getJSTDateString } from "@/lib/date-utils"
-import { secureFetch } from "@/lib/api"
+import { hookTokensApi, secureFetch } from "@/lib/api"
+import type { HookToken } from "@/types/hook-token"
 
 
 interface ModelInfo {
@@ -37,6 +38,14 @@ const USER_API_KEY_REGEX = /^sk-[a-zA-Z0-9-_]{20,}$/
 // Default model from environment or fallback
 const DEFAULT_MODEL = process.env.NEXT_PUBLIC_DEFAULT_OPENAI_MODEL || "gpt-5.5"
 
+const formatHookTokenDate = (value: string | null) => {
+  if (!value) return "未使用"
+  return new Date(value).toLocaleString("ja-JP", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  })
+}
+
 export default function SettingsPage() {
   const router = useRouter()
   const abortControllerRef = useRef<AbortController | null>(null)
@@ -50,6 +59,12 @@ export default function SettingsPage() {
   const [success, setSuccess] = useState("")
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [availableModels, setAvailableModels] = useState<AvailableModels | null>(null)
+  const [hookTokens, setHookTokens] = useState<HookToken[]>([])
+  const [hookTokenName, setHookTokenName] = useState("")
+  const [newHookToken, setNewHookToken] = useState<string | null>(null)
+  const [hookTokensLoading, setHookTokensLoading] = useState(false)
+  const [hookTokenActionLoading, setHookTokenActionLoading] = useState(false)
+  const [hookTokenToRevoke, setHookTokenToRevoke] = useState<HookToken | null>(null)
   const [exportLoading, setExportLoading] = useState(false)
   const [importLoading, setImportLoading] = useState(false)
   const [importFile, setImportFile] = useState<File | null>(null)
@@ -87,6 +102,7 @@ export default function SettingsPage() {
 
     fetchUserSettings()
     fetchAvailableModels()
+    fetchHookTokens()
     fetchExportInfo()
 
     // Cleanup function
@@ -178,6 +194,78 @@ export default function SettingsPage() {
       log.error('Failed to fetch settings', err as Error, { component: 'Settings' })
     } finally {
       setLoadingSettings(false)
+    }
+  }
+
+  const fetchHookTokens = async () => {
+    setHookTokensLoading(true)
+    try {
+      const tokens = await hookTokensApi.getAll()
+      setHookTokens(tokens)
+    } catch (err) {
+      log.error('Failed to fetch hook tokens', err as Error, { component: 'Settings' })
+    } finally {
+      setHookTokensLoading(false)
+    }
+  }
+
+  const handleCreateHookToken = async () => {
+    const trimmedName = hookTokenName.trim()
+    if (!trimmedName) {
+      setError("Hook token名を入力してください")
+      return
+    }
+
+    setHookTokenActionLoading(true)
+    setError("")
+    setSuccess("")
+    setNewHookToken(null)
+
+    try {
+      const createdToken = await hookTokensApi.create({ name: trimmedName })
+      setHookTokens((currentTokens) => [createdToken, ...currentTokens])
+      setHookTokenName("")
+      setNewHookToken(createdToken.token)
+      setSuccess("Hook tokenを作成しました")
+    } catch (err) {
+      log.error('Failed to create hook token', err as Error, { component: 'Settings' })
+      setError("Hook tokenの作成に失敗しました")
+    } finally {
+      setHookTokenActionLoading(false)
+    }
+  }
+
+  const handleCopyHookToken = async () => {
+    if (!newHookToken) return
+
+    try {
+      await navigator.clipboard.writeText(newHookToken)
+      setSuccess("Hook tokenをコピーしました")
+    } catch (err) {
+      log.error('Failed to copy hook token', err as Error, { component: 'Settings' })
+      setError("Hook tokenのコピーに失敗しました")
+    }
+  }
+
+  const confirmRevokeHookToken = async () => {
+    if (!hookTokenToRevoke) return
+
+    setHookTokenActionLoading(true)
+    setError("")
+    setSuccess("")
+
+    try {
+      await hookTokensApi.revoke(hookTokenToRevoke.id)
+      setHookTokens((currentTokens) =>
+        currentTokens.filter((token) => token.id !== hookTokenToRevoke.id)
+      )
+      setHookTokenToRevoke(null)
+      setSuccess("Hook tokenを失効しました")
+    } catch (err) {
+      log.error('Failed to revoke hook token', err as Error, { component: 'Settings' })
+      setError("Hook tokenの失効に失敗しました")
+    } finally {
+      setHookTokenActionLoading(false)
     }
   }
 
@@ -639,6 +727,101 @@ export default function SettingsPage() {
         </CardContent>
       </Card>
 
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Key className="h-5 w-5" />
+            Hook Tokens
+          </CardTitle>
+          <CardDescription>
+            外部hookからQuick Taskを登録するためのtoken
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {newHookToken && (
+            <Alert>
+              <CheckCircle className="h-4 w-4" />
+              <AlertDescription>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <code className="min-w-0 flex-1 overflow-x-auto rounded bg-muted px-2 py-1 text-xs">
+                    {newHookToken}
+                  </code>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleCopyHookToken}
+                  >
+                    <Copy className="h-4 w-4 mr-2" />
+                    コピー
+                  </Button>
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Input
+              value={hookTokenName}
+              onChange={(event) => setHookTokenName(event.target.value)}
+              placeholder="Token name"
+              maxLength={100}
+              disabled={hookTokenActionLoading}
+            />
+            <Button
+              onClick={handleCreateHookToken}
+              disabled={hookTokenActionLoading || !hookTokenName.trim()}
+              className="sm:w-auto"
+            >
+              {hookTokenActionLoading ? (
+                "作成中..."
+              ) : (
+                <>
+                  <Plus className="h-4 w-4 mr-2" />
+                  作成
+                </>
+              )}
+            </Button>
+          </div>
+
+          <div className="space-y-2">
+            {hookTokensLoading ? (
+              <div className="text-sm text-muted-foreground">読み込み中...</div>
+            ) : hookTokens.length === 0 ? (
+              <div className="rounded border border-dashed p-4 text-sm text-muted-foreground">
+                Active tokenはありません
+              </div>
+            ) : (
+              hookTokens.map((token) => (
+                <div
+                  key={token.id}
+                  className="flex flex-col gap-3 rounded border p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0 space-y-1">
+                    <div className="font-medium truncate">{token.name}</div>
+                    <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                      <span>{token.token_prefix}...</span>
+                      <span>作成: {formatHookTokenDate(token.created_at)}</span>
+                      <span>最終使用: {formatHookTokenDate(token.last_used_at)}</span>
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setHookTokenToRevoke(token)}
+                    disabled={hookTokenActionLoading}
+                  >
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    失効
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
       <div className="mt-6">
         <TriageSettingsCard />
       </div>
@@ -933,6 +1116,17 @@ export default function SettingsPage() {
         cancelText="キャンセル"
         variant="destructive"
         loading={loading}
+      />
+      <ConfirmationModal
+        isOpen={hookTokenToRevoke !== null}
+        onClose={() => setHookTokenToRevoke(null)}
+        onConfirm={confirmRevokeHookToken}
+        title="Hook tokenを失効"
+        description="このHook tokenを失効してもよろしいですか？"
+        confirmText="失効"
+        cancelText="キャンセル"
+        variant="destructive"
+        loading={hookTokenActionLoading}
       />
       </div>
     </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -74,6 +74,11 @@ import type {
   QuickTaskConvertRequest,
 } from "@/types/quick-task";
 import type {
+  HookToken,
+  HookTokenCreate,
+  HookTokenCreated,
+} from "@/types/hook-token";
+import type {
   TriageApplyRequest,
   TriageApplyResponse,
   TriageCapacitySettings,
@@ -1515,6 +1520,27 @@ class ApiClient {
     return normalizeTask(task);
   }
 
+  // === Hook Token API methods ===
+
+  async getHookTokens(): Promise<HookToken[]> {
+    return this.request<HookToken[]>("/api/user/hook-tokens");
+  }
+
+  async createHookToken(
+    tokenData: HookTokenCreate,
+  ): Promise<HookTokenCreated> {
+    return this.request<HookTokenCreated>("/api/user/hook-tokens", {
+      method: "POST",
+      body: JSON.stringify(tokenData),
+    });
+  }
+
+  async revokeHookToken(tokenId: string): Promise<void> {
+    return this.request<void>(`/api/user/hook-tokens/${tokenId}`, {
+      method: "DELETE",
+    });
+  }
+
   // === Slot Template Methods ===
 
   /**
@@ -1916,6 +1942,16 @@ export const quickTasksApi = {
   delete: (taskId: string) => apiClient.deleteQuickTask(taskId),
   convertToTask: (taskId: string, goalId: string) =>
     apiClient.convertQuickTaskToTask(taskId, goalId),
+};
+
+/**
+ * Hook Tokens API convenience wrapper.
+ * Provides methods for managing external quick-task hook tokens.
+ */
+export const hookTokensApi = {
+  getAll: () => apiClient.getHookTokens(),
+  create: (tokenData: HookTokenCreate) => apiClient.createHookToken(tokenData),
+  revoke: (tokenId: string) => apiClient.revokeHookToken(tokenId),
 };
 
 /**

--- a/apps/web/src/types/hook-token.ts
+++ b/apps/web/src/types/hook-token.ts
@@ -1,0 +1,17 @@
+export interface HookToken {
+  id: string;
+  user_id: string;
+  name: string;
+  token_prefix: string;
+  last_used_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface HookTokenCreate {
+  name: string;
+}
+
+export interface HookTokenCreated extends HookToken {
+  token: string;
+}


### PR DESCRIPTION
## Summary

Closes #299.

Adds a user-scoped hook token flow so external tools can create Quick Tasks without a browser session.

## Changes

- Add `hook_tokens` storage with hashed token secrets and active-token metadata.
- Add token management endpoints under `/api/user/hook-tokens`.
- Add external ingestion endpoint `POST /api/hooks/quick-tasks`.
- Add Settings UI for creating, copying, listing, and revoking hook tokens.
- Add backend and frontend coverage for token creation, hook ingestion, revocation, validation, and Settings UI behavior.

## Usage

1. Apply the DB migration before deployment: `cd apps/api && python migrate.py apply`.
2. Open Settings and create a Hook Token.
3. Copy the token shown immediately after creation.
4. Send a quick task with either `Authorization: Bearer <token>` or `X-HumanCompiler-Hook-Token: <token>`.

Example:

```bash
curl -X POST https://<api-host>/api/hooks/quick-tasks \
  -H "Authorization: Bearer <hook-token>" \
  -H "Content-Type: application/json" \
  -d '{"title":"Review PR","description":"Read review comments","estimate_hours":0.5,"priority":2}'
```

## Validation

- `uv run ruff check src/humancompiler_api/models.py src/humancompiler_api/services.py src/humancompiler_api/routers/hooks.py src/humancompiler_api/routers/hook_tokens.py tests/test_hook_tokens.py`
- `uv run pytest -s tests/test_hook_tokens.py tests/test_api.py`
- `pnpm test -- src/app/settings/__tests__/page.test.tsx --runInBand`
- `pnpm type-check`
- `git diff --check`
