### PR TITLE
Add cross-project task workspace MVP

### DIFF
--- a/apps/api/src/humancompiler_api/models.py
+++ b/apps/api/src/humancompiler_api/models.py
@@ -102,6 +102,14 @@ class TaskWorkspaceSortBy(StrEnum):
     UPDATED_AT = "updated_at"
 
 
+class TaskWorkspacePlanFilter(StrEnum):
+    """Plan-membership filters for the cross-project task workspace."""
+
+    TODAY = "today"
+    WEEK = "week"
+    UNPLANNED = "unplanned"
+
+
 class CheckoutType(StrEnum):
     """Checkout type for work sessions"""
 

--- a/apps/api/src/humancompiler_api/models.py
+++ b/apps/api/src/humancompiler_api/models.py
@@ -92,6 +92,16 @@ class SortOrder(StrEnum):
     DESC = "desc"
 
 
+class TaskWorkspaceSortBy(StrEnum):
+    """Sort field options for the cross-project task workspace."""
+
+    DUE_DATE = "due_date"
+    PRIORITY = "priority"
+    STATUS = "status"
+    TITLE = "title"
+    UPDATED_AT = "updated_at"
+
+
 class CheckoutType(StrEnum):
     """Checkout type for work sessions"""
 
@@ -1042,6 +1052,7 @@ class TaskUpdate(BaseModel):
     status: TaskStatus | None = None
     work_type: WorkType | None = None
     priority: int | None = Field(None, ge=1, le=5)
+    goal_id: UUID | None = None
 
 
 class TaskResponse(TaskBase):
@@ -1059,6 +1070,42 @@ class TaskResponse(TaskBase):
     def serialize_estimate_hours(self, value: Decimal) -> float:
         """Convert Decimal to float for JSON serialization"""
         return float(value)
+
+
+class TaskWorkspaceItem(TaskResponse):
+    """Task enriched with hierarchy and execution context for the workspace."""
+
+    project_id: UUID
+    project_title: str
+    goal_title: str
+    remaining_estimate_hours: Decimal = Field(ge=0)
+    is_blocked: bool = False
+    blocking_task_ids: list[UUID] = Field(default_factory=list)
+    last_worked_at: datetime | None = None
+    planned_today: bool = False
+    planned_this_week: bool = False
+
+    @field_serializer("remaining_estimate_hours")
+    def serialize_remaining_estimate_hours(self, value: Decimal) -> float:
+        """Convert Decimal to float for JSON serialization."""
+        return float(value)
+
+
+class TaskWorkspacePage(BaseModel):
+    """Paginated task workspace response."""
+
+    items: list[TaskWorkspaceItem]
+    total: int
+    skip: int
+    limit: int
+
+
+class TaskRecommendation(BaseModel):
+    """A safe, read-only next-task recommendation with an explicit rationale."""
+
+    task: TaskWorkspaceItem
+    score: int
+    reason: str
 
 
 class TaskSummary(BaseModel):

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Annotated
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Query, status
 from sqlmodel import Session, select
@@ -36,6 +37,7 @@ from humancompiler_api.services import task_service
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
+APP_TIMEZONE = ZoneInfo("Asia/Tokyo")
 
 
 def get_session() -> Generator[Session, None, None]:
@@ -74,16 +76,27 @@ def build_task_responses_with_dependencies(
     return task_responses
 
 
+def _plan_date_windows(
+    now: datetime | None = None,
+) -> tuple[datetime, datetime, datetime, datetime]:
+    """Return naive date boundaries matching stored JST schedule dates."""
+    instant = now or datetime.now(UTC)
+    if instant.tzinfo is None:
+        instant = instant.replace(tzinfo=UTC)
+    local_date = instant.astimezone(APP_TIMEZONE).date()
+    day_start = datetime.combine(local_date, datetime.min.time())
+    day_end = day_start + timedelta(days=1)
+    week_start = day_start - timedelta(days=day_start.weekday())
+    week_end = week_start + timedelta(days=7)
+    return day_start, day_end, week_start, week_end
+
+
 def _extract_planned_task_ids(
     session: Session, owner_id: str | UUID
 ) -> tuple[set[str], set[str]]:
     """Return task IDs in today's daily plan and the current weekly plan."""
     owner_uuid = UUID(str(owner_id))
-    now = datetime.now(UTC)
-    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-    day_end = day_start + timedelta(days=1)
-    week_start = day_start - timedelta(days=day_start.weekday())
-    week_end = week_start + timedelta(days=7)
+    day_start, day_end, week_start, week_end = _plan_date_windows()
 
     daily_schedules = session.exec(
         select(Schedule).where(
@@ -130,6 +143,8 @@ def build_workspace_items(
     session: Session,
     rows: list[tuple[Task, object, object, int, datetime | None]],
     owner_id: str | UUID,
+    today_ids: set[str] | None = None,
+    week_ids: set[str] | None = None,
 ) -> list[TaskWorkspaceItem]:
     """Hydrate workspace query rows without per-task database calls."""
     if not rows:
@@ -138,7 +153,8 @@ def build_workspace_items(
     tasks = [row[0] for row in rows]
     task_ids = [task.id for task in tasks if task.id is not None]
     dependencies = task_service.get_task_dependencies_batch(session, task_ids, owner_id)
-    today_ids, week_ids = _extract_planned_task_ids(session, owner_id)
+    if today_ids is None or week_ids is None:
+        today_ids, week_ids = _extract_planned_task_ids(session, owner_id)
 
     items: list[TaskWorkspaceItem] = []
     for task, goal, project, actual_minutes, last_worked_at in rows:
@@ -200,6 +216,8 @@ async def get_task_workspace(
     """List tasks across all owned projects using one filtered, paginated query."""
     included_task_ids: set[UUID] | None = None
     excluded_task_ids: set[UUID] | None = None
+    today_ids: set[str] | None = None
+    week_ids: set[str] | None = None
     if plan is not None:
         today_ids, week_ids = _extract_planned_task_ids(session, current_user.user_id)
         if plan == TaskWorkspacePlanFilter.TODAY:
@@ -228,7 +246,13 @@ async def get_task_workspace(
         sort_order=sort_order,
     )
     return TaskWorkspacePage(
-        items=build_workspace_items(session, rows, current_user.user_id),
+        items=build_workspace_items(
+            session,
+            rows,
+            current_user.user_id,
+            today_ids=today_ids,
+            week_ids=week_ids,
+        ),
         total=total,
         skip=skip,
         limit=limit,

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -1,10 +1,12 @@
 import logging
 from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, status
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from humancompiler_api.auth import AuthUser, get_current_user
 from humancompiler_api.database import db
@@ -19,6 +21,13 @@ from humancompiler_api.models import (
     SortBy,
     SortOrder,
     Task,
+    TaskRecommendation,
+    TaskStatus,
+    TaskWorkspaceItem,
+    TaskWorkspacePage,
+    TaskWorkspaceSortBy,
+    Schedule,
+    WeeklySchedule,
 )
 from humancompiler_api.services import task_service
 
@@ -61,6 +70,196 @@ def build_task_responses_with_dependencies(
         task_responses.append(task_response)
 
     return task_responses
+
+
+def _extract_planned_task_ids(
+    session: Session, owner_id: str | UUID
+) -> tuple[set[str], set[str]]:
+    """Return task IDs in today's daily plan and the current weekly plan."""
+    owner_uuid = UUID(str(owner_id))
+    now = datetime.now(UTC)
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start + timedelta(days=1)
+    week_start = day_start - timedelta(days=day_start.weekday())
+    week_end = week_start + timedelta(days=7)
+
+    daily_schedules = session.exec(
+        select(Schedule).where(
+            Schedule.user_id == owner_uuid,
+            Schedule.date >= day_start,
+            Schedule.date < day_end,
+        )
+    ).all()
+    weekly_schedules = session.exec(
+        select(WeeklySchedule).where(
+            WeeklySchedule.user_id == owner_uuid,
+            WeeklySchedule.week_start_date >= week_start,
+            WeeklySchedule.week_start_date < week_end,
+        )
+    ).all()
+
+    today_ids = {
+        str(assignment.get("task_id"))
+        for schedule in daily_schedules
+        for assignment in (schedule.plan_json or {}).get("assignments", [])
+        if assignment.get("task_id")
+    }
+    week_ids = {
+        str(task.get("task_id"))
+        for schedule in weekly_schedules
+        for task in (schedule.schedule_json or {}).get("selected_tasks", [])
+        if task.get("task_id")
+    }
+    return today_ids, week_ids
+
+
+def build_workspace_items(
+    session: Session,
+    rows: list[tuple[Task, object, object, int, datetime | None]],
+    owner_id: str | UUID,
+) -> list[TaskWorkspaceItem]:
+    """Hydrate workspace query rows without per-task database calls."""
+    if not rows:
+        return []
+
+    tasks = [row[0] for row in rows]
+    dependencies = task_service.get_task_dependencies_batch(
+        session, [task.id for task in tasks], owner_id
+    )
+    today_ids, week_ids = _extract_planned_task_ids(session, owner_id)
+
+    items: list[TaskWorkspaceItem] = []
+    for task, goal, project, actual_minutes, last_worked_at in rows:
+        task_response = TaskResponse.model_validate(task)
+        task_dependencies = dependencies.get(str(task.id), [])
+        dependency_responses = []
+        blocking_task_ids = []
+        for dependency in task_dependencies:
+            dependency_response = TaskDependencyResponse.model_validate(dependency)
+            if dependency.depends_on_task:
+                dependency_response.depends_on_task = (
+                    TaskDependencyTaskInfo.model_validate(dependency.depends_on_task)
+                )
+                if dependency.depends_on_task.status != TaskStatus.COMPLETED:
+                    blocking_task_ids.append(dependency.depends_on_task.id)
+            dependency_responses.append(dependency_response)
+
+        task_response.dependencies = dependency_responses
+        remaining = max(
+            Decimal("0"),
+            task.estimate_hours - (Decimal(str(actual_minutes)) / Decimal("60")),
+        )
+        items.append(
+            TaskWorkspaceItem(
+                **task_response.model_dump(),
+                project_id=project.id,
+                project_title=project.title,
+                goal_title=goal.title,
+                remaining_estimate_hours=remaining.quantize(Decimal("0.01")),
+                is_blocked=bool(blocking_task_ids),
+                blocking_task_ids=blocking_task_ids,
+                last_worked_at=last_worked_at,
+                planned_today=str(task.id) in today_ids,
+                planned_this_week=str(task.id) in week_ids,
+            )
+        )
+    return items
+
+
+@router.get("/", response_model=TaskWorkspacePage)
+@router.get("", response_model=TaskWorkspacePage, include_in_schema=False)
+async def get_task_workspace(
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+    task_statuses: Annotated[list[TaskStatus] | None, Query(alias="status")] = None,
+    project_id: UUID | None = None,
+    goal_id: UUID | None = None,
+    due_before: datetime | None = None,
+    due_after: datetime | None = None,
+    search: Annotated[str | None, Query(max_length=200)] = None,
+    blocked: bool | None = None,
+    sort_by: TaskWorkspaceSortBy = TaskWorkspaceSortBy.DUE_DATE,
+    sort_order: SortOrder = SortOrder.ASC,
+) -> TaskWorkspacePage:
+    """List tasks across all owned projects using one filtered, paginated query."""
+    rows, total = task_service.get_workspace_tasks(
+        session,
+        current_user.user_id,
+        skip=skip,
+        limit=limit,
+        statuses=task_statuses,
+        project_id=project_id,
+        goal_id=goal_id,
+        due_before=due_before,
+        due_after=due_after,
+        search=search,
+        blocked=blocked,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+    return TaskWorkspacePage(
+        items=build_workspace_items(session, rows, current_user.user_id),
+        total=total,
+        skip=skip,
+        limit=limit,
+    )
+
+
+@router.get("/recommendations", response_model=list[TaskRecommendation])
+async def get_task_recommendations(
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+) -> list[TaskRecommendation]:
+    """Return up to three deterministic, read-only next-task recommendations."""
+    rows, _ = task_service.get_workspace_tasks(
+        session,
+        current_user.user_id,
+        limit=100,
+        statuses=[TaskStatus.PENDING, TaskStatus.IN_PROGRESS],
+        sort_by=TaskWorkspaceSortBy.PRIORITY,
+    )
+    items = build_workspace_items(session, rows, current_user.user_id)
+    now = datetime.now(UTC)
+    recommendations: list[TaskRecommendation] = []
+    for item in items:
+        if item.is_blocked:
+            continue
+
+        score = (6 - item.priority) * 20
+        reasons = [f"優先度が{item.priority}"]
+        if item.status == TaskStatus.IN_PROGRESS:
+            score += 20
+            reasons.append("すでに作業中")
+        if item.planned_today:
+            score += 30
+            reasons.append("今日の計画に登録済み")
+        elif item.planned_this_week:
+            score += 10
+            reasons.append("今週の計画に登録済み")
+        if item.due_date:
+            due_date = item.due_date
+            if due_date.tzinfo is None:
+                due_date = due_date.replace(tzinfo=UTC)
+            days = (due_date - now).total_seconds() / 86400
+            if days < 0:
+                score += 50
+                reasons.append("期限超過")
+            elif days <= 1:
+                score += 40
+                reasons.append("期限まで24時間以内")
+            elif days <= 3:
+                score += 25
+                reasons.append("期限まで3日以内")
+            elif days <= 7:
+                score += 10
+                reasons.append("期限まで1週間以内")
+        recommendations.append(
+            TaskRecommendation(task=item, score=score, reason="、".join(reasons))
+        )
+
+    return sorted(recommendations, key=lambda item: item.score, reverse=True)[:3]
 
 
 @router.post(

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -23,8 +23,10 @@ from humancompiler_api.models import (
     Task,
     TaskRecommendation,
     TaskStatus,
+    ProjectStatus,
     TaskWorkspaceItem,
     TaskWorkspacePage,
+    TaskWorkspacePlanFilter,
     TaskWorkspaceSortBy,
     Schedule,
     WeeklySchedule,
@@ -99,18 +101,29 @@ def _extract_planned_task_ids(
     ).all()
 
     today_ids = {
-        str(assignment.get("task_id"))
+        str(assignment.get("task_id") or assignment.get("taskId"))
         for schedule in daily_schedules
         for assignment in (schedule.plan_json or {}).get("assignments", [])
-        if assignment.get("task_id")
+        if assignment.get("task_id") or assignment.get("taskId")
     }
     week_ids = {
-        str(task.get("task_id"))
+        str(task.get("task_id") or task.get("taskId"))
         for schedule in weekly_schedules
         for task in (schedule.schedule_json or {}).get("selected_tasks", [])
-        if task.get("task_id")
+        if task.get("task_id") or task.get("taskId")
     }
     return today_ids, week_ids
+
+
+def _valid_task_uuids(task_ids: set[str]) -> set[UUID]:
+    """Return valid UUIDs from stored plan payloads, ignoring stale invalid IDs."""
+    valid_ids: set[UUID] = set()
+    for task_id in task_ids:
+        try:
+            valid_ids.add(UUID(task_id))
+        except ValueError:
+            logger.warning("Ignoring invalid task ID in saved plan: %s", task_id)
+    return valid_ids
 
 
 def build_workspace_items(
@@ -174,15 +187,28 @@ async def get_task_workspace(
     limit: Annotated[int, Query(ge=1, le=100)] = 50,
     task_statuses: Annotated[list[TaskStatus] | None, Query(alias="status")] = None,
     project_id: UUID | None = None,
+    project_status: ProjectStatus | None = None,
     goal_id: UUID | None = None,
     due_before: datetime | None = None,
     due_after: datetime | None = None,
     search: Annotated[str | None, Query(max_length=200)] = None,
     blocked: bool | None = None,
+    plan: TaskWorkspacePlanFilter | None = None,
     sort_by: TaskWorkspaceSortBy = TaskWorkspaceSortBy.DUE_DATE,
     sort_order: SortOrder = SortOrder.ASC,
 ) -> TaskWorkspacePage:
     """List tasks across all owned projects using one filtered, paginated query."""
+    included_task_ids: set[UUID] | None = None
+    excluded_task_ids: set[UUID] | None = None
+    if plan is not None:
+        today_ids, week_ids = _extract_planned_task_ids(session, current_user.user_id)
+        if plan == TaskWorkspacePlanFilter.TODAY:
+            included_task_ids = _valid_task_uuids(today_ids)
+        elif plan == TaskWorkspacePlanFilter.WEEK:
+            included_task_ids = _valid_task_uuids(week_ids)
+        else:
+            excluded_task_ids = _valid_task_uuids(today_ids | week_ids)
+
     rows, total = task_service.get_workspace_tasks(
         session,
         current_user.user_id,
@@ -190,11 +216,14 @@ async def get_task_workspace(
         limit=limit,
         statuses=task_statuses,
         project_id=project_id,
+        project_status=project_status,
         goal_id=goal_id,
         due_before=due_before,
         due_after=due_after,
         search=search,
         blocked=blocked,
+        included_task_ids=included_task_ids,
+        excluded_task_ids=excluded_task_ids,
         sort_by=sort_by,
         sort_order=sort_order,
     )

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -123,9 +123,8 @@ def build_workspace_items(
         return []
 
     tasks = [row[0] for row in rows]
-    dependencies = task_service.get_task_dependencies_batch(
-        session, [task.id for task in tasks], owner_id
-    )
+    task_ids = [task.id for task in tasks if task.id is not None]
+    dependencies = task_service.get_task_dependencies_batch(session, task_ids, owner_id)
     today_ids, week_ids = _extract_planned_task_ids(session, owner_id)
 
     items: list[TaskWorkspaceItem] = []

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -31,6 +31,7 @@ from humancompiler_api.models import (
     LogUpdate,
     Project,
     ProjectCreate,
+    ProjectStatus,
     ProjectUpdate,
     Task,
     TaskCreate,
@@ -644,11 +645,14 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
         limit: int = 50,
         statuses: list[TaskStatus] | None = None,
         project_id: UUID | None = None,
+        project_status: ProjectStatus | None = None,
         goal_id: UUID | None = None,
         due_before: datetime | None = None,
         due_after: datetime | None = None,
         search: str | None = None,
         blocked: bool | None = None,
+        included_task_ids: set[UUID] | None = None,
+        excluded_task_ids: set[UUID] | None = None,
         sort_by: TaskWorkspaceSortBy = TaskWorkspaceSortBy.DUE_DATE,
         sort_order: SortOrder = SortOrder.ASC,
     ) -> tuple[list[tuple[Task, Goal, Project, int, datetime | None]], int]:
@@ -676,6 +680,8 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
             conditions.append(Task.status.in_(statuses))
         if project_id:
             conditions.append(Project.id == project_id)
+        if project_status:
+            conditions.append(Project.status == project_status)
         if goal_id:
             conditions.append(Goal.id == goal_id)
         if due_before is not None:
@@ -704,6 +710,10 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
                 .exists()
             )
             conditions.append(blocking_dependency if blocked else ~blocking_dependency)
+        if included_task_ids is not None:
+            conditions.append(col(Task.id).in_(included_task_ids))
+        if excluded_task_ids:
+            conditions.append(~col(Task.id).in_(excluded_task_ids))
 
         count_statement = (
             select(func.count(Task.id))

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -11,7 +11,7 @@ from uuid import UUID
 from uuid import uuid4
 
 from fastapi import HTTPException, status
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import aliased, selectinload
 from sqlmodel import Session, and_, delete, func, select
 
 from humancompiler_api.base_service import BaseService
@@ -63,6 +63,7 @@ from humancompiler_api.models import (
     SlotTemplate,
     SlotTemplateCreate,
     SlotTemplateUpdate,
+    TaskWorkspaceSortBy,
 )
 
 
@@ -634,6 +635,120 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
         """Get all tasks for a user across all projects"""
         return self.get_all(session, owner_id, skip, limit)
 
+    def get_workspace_tasks(
+        self,
+        session: Session,
+        owner_id: str | UUID,
+        *,
+        skip: int = 0,
+        limit: int = 50,
+        statuses: list[TaskStatus] | None = None,
+        project_id: UUID | None = None,
+        goal_id: UUID | None = None,
+        due_before: datetime | None = None,
+        due_after: datetime | None = None,
+        search: str | None = None,
+        blocked: bool | None = None,
+        sort_by: TaskWorkspaceSortBy = TaskWorkspaceSortBy.DUE_DATE,
+        sort_order: SortOrder = SortOrder.ASC,
+    ) -> tuple[list[tuple[Task, Goal, Project, int, datetime | None]], int]:
+        """Fetch one page of user tasks with hierarchy and aggregate work data."""
+        owner_uuid = UUID(str(owner_id))
+        actual_minutes = (
+            select(
+                Log.task_id,
+                func.coalesce(func.sum(Log.actual_minutes), 0).label("minutes"),
+            )
+            .group_by(Log.task_id)
+            .subquery()
+        )
+        last_worked = (
+            select(
+                WorkSession.task_id,
+                func.max(WorkSession.started_at).label("last_worked_at"),
+            )
+            .group_by(WorkSession.task_id)
+            .subquery()
+        )
+
+        conditions = [Project.owner_id == owner_uuid]
+        if statuses:
+            conditions.append(Task.status.in_(statuses))
+        if project_id:
+            conditions.append(Project.id == project_id)
+        if goal_id:
+            conditions.append(Goal.id == goal_id)
+        if due_before:
+            conditions.append(Task.due_date <= due_before)
+        if due_after:
+            conditions.append(Task.due_date >= due_after)
+        if search and search.strip():
+            pattern = f"%{search.strip()}%"
+            conditions.append(
+                Task.title.ilike(pattern)
+                | Task.description.ilike(pattern)
+                | Task.memo.ilike(pattern)
+            )
+        if blocked is not None:
+            prerequisite = aliased(Task)
+            blocking_dependency = (
+                select(TaskDependency.id)
+                .join(
+                    prerequisite,
+                    TaskDependency.depends_on_task_id == prerequisite.id,
+                )
+                .where(
+                    TaskDependency.task_id == Task.id,
+                    prerequisite.status != TaskStatus.COMPLETED,
+                )
+                .exists()
+            )
+            conditions.append(blocking_dependency if blocked else ~blocking_dependency)
+
+        count_statement = (
+            select(func.count(Task.id))
+            .select_from(Task)
+            .join(Goal, Task.goal_id == Goal.id)
+            .join(Project, Goal.project_id == Project.id)
+            .where(*conditions)
+        )
+        total = int(session.exec(count_statement).one())
+
+        statement = (
+            select(
+                Task,
+                Goal,
+                Project,
+                func.coalesce(actual_minutes.c.minutes, 0),
+                last_worked.c.last_worked_at,
+            )
+            .join(Goal, Task.goal_id == Goal.id)
+            .join(Project, Goal.project_id == Project.id)
+            .outerjoin(actual_minutes, actual_minutes.c.task_id == Task.id)
+            .outerjoin(last_worked, last_worked.c.task_id == Task.id)
+            .where(*conditions)
+        )
+
+        sort_columns = {
+            TaskWorkspaceSortBy.DUE_DATE: Task.due_date,
+            TaskWorkspaceSortBy.PRIORITY: Task.priority,
+            TaskWorkspaceSortBy.STATUS: Task.status,
+            TaskWorkspaceSortBy.TITLE: Task.title,
+            TaskWorkspaceSortBy.UPDATED_AT: Task.updated_at,
+        }
+        sort_column = sort_columns[sort_by]
+        order_expression = (
+            sort_column.desc() if sort_order == SortOrder.DESC else sort_column.asc()
+        )
+        if sort_by == TaskWorkspaceSortBy.DUE_DATE:
+            order_expression = order_expression.nulls_last()
+        statement = (
+            statement.order_by(order_expression, Task.priority.asc(), Task.id.asc())
+            .offset(skip)
+            .limit(limit)
+        )
+        return list(session.exec(statement).all()), total
+
     def update_task(
         self,
         session: Session,
@@ -642,6 +757,8 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
         task_data: TaskUpdate,
     ) -> Task:
         """Update task"""
+        if task_data.goal_id is not None:
+            self.goal_service.get_goal(session, task_data.goal_id, owner_id)
         return self.update(session, task_id, task_data, owner_id)
 
     def delete_task(

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 from fastapi import HTTPException, status
 from sqlalchemy.orm import aliased, selectinload
-from sqlmodel import Session, and_, delete, func, select
+from sqlmodel import Session, and_, col, delete, func, select
 
 from humancompiler_api.base_service import BaseService
 from humancompiler_api.common.error_handlers import (
@@ -678,10 +678,10 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
             conditions.append(Project.id == project_id)
         if goal_id:
             conditions.append(Goal.id == goal_id)
-        if due_before:
-            conditions.append(Task.due_date <= due_before)
-        if due_after:
-            conditions.append(Task.due_date >= due_after)
+        if due_before is not None:
+            conditions.append(col(Task.due_date) <= due_before)
+        if due_after is not None:
+            conditions.append(col(Task.due_date) >= due_after)
         if search and search.strip():
             pattern = f"%{search.strip()}%"
             conditions.append(

--- a/apps/api/tests/test_task_workspace.py
+++ b/apps/api/tests/test_task_workspace.py
@@ -23,6 +23,7 @@ from humancompiler_api.models import (
 )
 from humancompiler_api.routers.tasks import (
     _extract_planned_task_ids,
+    _plan_date_windows,
     build_workspace_items,
 )
 from humancompiler_api.services import (
@@ -199,6 +200,17 @@ def test_extract_planned_task_ids_supports_camel_case_assignments(
     today_ids, _ = _extract_planned_task_ids(session, test_user_id)
 
     assert str(task_id) in today_ids
+
+
+def test_plan_date_windows_use_jst_calendar_boundaries():
+    day_start, day_end, week_start, week_end = _plan_date_windows(
+        datetime(2026, 7, 15, 16, 0, tzinfo=UTC)
+    )
+
+    assert day_start == datetime(2026, 7, 16)
+    assert day_end == datetime(2026, 7, 17)
+    assert week_start == datetime(2026, 7, 13)
+    assert week_end == datetime(2026, 7, 20)
 
 
 def test_moving_task_preserves_related_records(session, test_user_id):

--- a/apps/api/tests/test_task_workspace.py
+++ b/apps/api/tests/test_task_workspace.py
@@ -1,0 +1,193 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlmodel import select
+
+from conftest import create_test_data
+from humancompiler_api.common.error_handlers import ResourceNotFoundError
+from humancompiler_api.models import (
+    GoalCreate,
+    Log,
+    ProjectCreate,
+    TaskCreate,
+    TaskDependency,
+    TaskStatus,
+    TaskUpdate,
+    TaskWorkspaceSortBy,
+    UserCreate,
+    WorkSession,
+)
+from humancompiler_api.routers.tasks import build_workspace_items
+from humancompiler_api.services import (
+    GoalService,
+    ProjectService,
+    TaskService,
+    UserService,
+)
+
+
+def test_workspace_lists_and_filters_tasks_across_projects(session, test_user_id):
+    first = create_test_data(session, test_user_id)
+    project_service = ProjectService()
+    goal_service = GoalService()
+    task_service = TaskService()
+    second_project = project_service.create_project(
+        session, ProjectCreate(title="Second project"), test_user_id
+    )
+    second_goal = goal_service.create_goal(
+        session,
+        GoalCreate(
+            project_id=second_project.id,
+            title="Second goal",
+            estimate_hours=Decimal("8"),
+        ),
+        test_user_id,
+    )
+    first_task = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=first["goal"].id,
+            title="Write workspace tests",
+            estimate_hours=Decimal("2"),
+            priority=1,
+        ),
+        test_user_id,
+    )
+    prerequisite = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=second_goal.id,
+            title="Prepare fixtures",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    session.add(Log(id=uuid4(), task_id=first_task.id, actual_minutes=30))
+    session.add(
+        TaskDependency(
+            id=uuid4(),
+            task_id=first_task.id,
+            depends_on_task_id=prerequisite.id,
+        )
+    )
+    session.flush()
+
+    rows, total = task_service.get_workspace_tasks(
+        session,
+        test_user_id,
+        statuses=[TaskStatus.PENDING],
+        search="workspace",
+        sort_by=TaskWorkspaceSortBy.PRIORITY,
+    )
+    items = build_workspace_items(session, rows, test_user_id)
+
+    assert total == 1
+    assert len(items) == 1
+    assert items[0].project_title == first["project"].title
+    assert items[0].goal_title == first["goal"].title
+    assert items[0].remaining_estimate_hours == Decimal("1.50")
+    assert items[0].is_blocked is True
+    assert items[0].blocking_task_ids == [prerequisite.id]
+
+    blocked_rows, blocked_total = task_service.get_workspace_tasks(
+        session, test_user_id, blocked=True
+    )
+    assert blocked_total == 1
+    assert [row[0].id for row in blocked_rows] == [first_task.id]
+
+
+def test_moving_task_preserves_related_records(session, test_user_id):
+    data = create_test_data(session, test_user_id)
+    goal_service = GoalService()
+    task_service = TaskService()
+    destination = goal_service.create_goal(
+        session,
+        GoalCreate(
+            project_id=data["project"].id,
+            title="Destination",
+            estimate_hours=Decimal("5"),
+        ),
+        test_user_id,
+    )
+    task = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Movable task",
+            estimate_hours=Decimal("2"),
+        ),
+        test_user_id,
+    )
+    prerequisite = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Prerequisite",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    log = Log(id=uuid4(), task_id=task.id, actual_minutes=15)
+    dependency = TaskDependency(
+        id=uuid4(), task_id=task.id, depends_on_task_id=prerequisite.id
+    )
+    work_session = WorkSession(
+        id=uuid4(),
+        user_id=test_user_id,
+        task_id=task.id,
+        planned_checkout_at=datetime.now(UTC) + timedelta(hours=1),
+    )
+    session.add(log)
+    session.add(dependency)
+    session.add(work_session)
+    session.flush()
+
+    updated = task_service.update_task(
+        session, task.id, test_user_id, TaskUpdate(goal_id=destination.id)
+    )
+
+    assert updated.goal_id == destination.id
+    assert session.get(Log, log.id).task_id == task.id
+    assert session.get(TaskDependency, dependency.id).task_id == task.id
+    assert session.get(WorkSession, work_session.id).task_id == task.id
+
+
+def test_moving_task_rejects_goal_owned_by_another_user(session, test_user_id):
+    data = create_test_data(session, test_user_id)
+    other_user_id = uuid4()
+    UserService().create_user(
+        session, UserCreate(email="other@example.com"), other_user_id
+    )
+    other_project = ProjectService().create_project(
+        session, ProjectCreate(title="Other project"), other_user_id
+    )
+    other_goal = GoalService().create_goal(
+        session,
+        GoalCreate(
+            project_id=other_project.id,
+            title="Other goal",
+            estimate_hours=Decimal("5"),
+        ),
+        other_user_id,
+    )
+    task = TaskService().create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Owned task",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+
+    with pytest.raises(ResourceNotFoundError):
+        TaskService().update_task(
+            session, task.id, test_user_id, TaskUpdate(goal_id=other_goal.id)
+        )
+
+    assert (
+        session.exec(select(type(task)).where(type(task).id == task.id)).one().goal_id
+        == data["goal"].id
+    )

--- a/apps/api/tests/test_task_workspace.py
+++ b/apps/api/tests/test_task_workspace.py
@@ -182,6 +182,9 @@ def test_workspace_filters_by_project_status_and_plan_membership(session, test_u
 def test_extract_planned_task_ids_supports_camel_case_assignments(
     session, test_user_id
 ):
+    UserService().create_user(
+        session, UserCreate(email="schedule-owner@example.com"), test_user_id
+    )
     task_id = uuid4()
     session.add(
         Schedule(

--- a/apps/api/tests/test_task_workspace.py
+++ b/apps/api/tests/test_task_workspace.py
@@ -11,6 +11,8 @@ from humancompiler_api.models import (
     GoalCreate,
     Log,
     ProjectCreate,
+    ProjectStatus,
+    Schedule,
     TaskCreate,
     TaskDependency,
     TaskStatus,
@@ -19,7 +21,10 @@ from humancompiler_api.models import (
     UserCreate,
     WorkSession,
 )
-from humancompiler_api.routers.tasks import build_workspace_items
+from humancompiler_api.routers.tasks import (
+    _extract_planned_task_ids,
+    build_workspace_items,
+)
 from humancompiler_api.services import (
     GoalService,
     ProjectService,
@@ -96,6 +101,101 @@ def test_workspace_lists_and_filters_tasks_across_projects(session, test_user_id
     )
     assert blocked_total == 1
     assert [row[0].id for row in blocked_rows] == [first_task.id]
+
+
+def test_workspace_filters_by_project_status_and_plan_membership(session, test_user_id):
+    pending_data = create_test_data(session, test_user_id)
+    project_service = ProjectService()
+    goal_service = GoalService()
+    task_service = TaskService()
+    active_project = project_service.create_project(
+        session,
+        ProjectCreate(title="Active project", status=ProjectStatus.IN_PROGRESS),
+        test_user_id,
+    )
+    active_goal = goal_service.create_goal(
+        session,
+        GoalCreate(
+            project_id=active_project.id,
+            title="Active goal",
+            estimate_hours=Decimal("8"),
+        ),
+        test_user_id,
+    )
+    pending_task = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=pending_data["goal"].id,
+            title="Pending project task",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    planned_task = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=active_goal.id,
+            title="Planned active task",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    unplanned_task = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=active_goal.id,
+            title="Unplanned active task",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+
+    active_rows, active_total = task_service.get_workspace_tasks(
+        session,
+        test_user_id,
+        project_status=ProjectStatus.IN_PROGRESS,
+    )
+    assert active_total == 2
+    assert {row[0].id for row in active_rows} == {planned_task.id, unplanned_task.id}
+    assert pending_task.id not in {row[0].id for row in active_rows}
+
+    planned_rows, planned_total = task_service.get_workspace_tasks(
+        session,
+        test_user_id,
+        included_task_ids={planned_task.id},
+    )
+    assert planned_total == 1
+    assert [row[0].id for row in planned_rows] == [planned_task.id]
+
+    unplanned_rows, unplanned_total = task_service.get_workspace_tasks(
+        session,
+        test_user_id,
+        excluded_task_ids={planned_task.id},
+    )
+    assert unplanned_total == 2
+    assert {row[0].id for row in unplanned_rows} == {
+        pending_task.id,
+        unplanned_task.id,
+    }
+
+
+def test_extract_planned_task_ids_supports_camel_case_assignments(
+    session, test_user_id
+):
+    task_id = uuid4()
+    session.add(
+        Schedule(
+            id=uuid4(),
+            user_id=test_user_id,
+            date=datetime.now(UTC),
+            plan_json={"assignments": [{"taskId": str(task_id)}]},
+        )
+    )
+    session.flush()
+
+    today_ids, _ = _extract_planned_task_ids(session, test_user_id)
+
+    assert str(task_id) in today_ids
 
 
 def test_moving_task_preserves_related_records(session, test_user_id):

--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -295,8 +295,8 @@ export default function TasksPage() {
     status,
   ]);
 
-  const workspace = useTaskWorkspace(filters);
-  const recommendations = useTaskRecommendations();
+  const workspace = useTaskWorkspace(filters, Boolean(user));
+  const recommendations = useTaskRecommendations(Boolean(user));
   const visibleTasks = workspace.data?.items ?? [];
 
   const filteredGoals = projectId

--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -247,39 +247,46 @@ export default function TasksPage() {
       projects.map((project) => project.id).join(","),
     ],
     queryFn: async () => {
-      const results = await Promise.all(
+      const results = await Promise.allSettled(
         projects.map((project) => goalsApi.getByProject(project.id, 0, 100)),
       );
-      return results.flat();
+      return results.flatMap((result) =>
+        result.status === "fulfilled" ? result.value : [],
+      );
     },
     enabled: projects.length > 0,
   });
 
-  const clientPlanPreset =
-    preset === "today" || preset === "week" || preset === "unplanned";
   const filters = useMemo<TaskWorkspaceFilters>(() => {
     let statuses = status ? [status] : undefined;
     if (
       !status &&
-      (preset === "next" || preset === "overdue" || clientPlanPreset)
+      (preset === "next" ||
+        preset === "overdue" ||
+        preset === "today" ||
+        preset === "week" ||
+        preset === "unplanned")
     ) {
       statuses = actionableStatuses;
     }
     if (!status && preset === "in_progress") statuses = ["in_progress"];
 
     return {
-      skip: clientPlanPreset ? 0 : page * 50,
-      limit: clientPlanPreset ? 100 : 50,
+      skip: page * 50,
+      limit: 50,
       status: statuses,
       projectId: projectId || undefined,
       goalId: goalId || undefined,
       dueBefore: preset === "overdue" ? new Date().toISOString() : undefined,
       search: deferredSearch || undefined,
       blocked: preset === "blocked" ? true : undefined,
+      plan:
+        preset === "today" || preset === "week" || preset === "unplanned"
+          ? preset
+          : undefined,
       sortBy: preset === "next" ? "priority" : "due_date",
     };
   }, [
-    clientPlanPreset,
     deferredSearch,
     goalId,
     page,
@@ -290,18 +297,7 @@ export default function TasksPage() {
 
   const workspace = useTaskWorkspace(filters);
   const recommendations = useTaskRecommendations();
-  const visibleTasks = useMemo(() => {
-    const items = workspace.data?.items ?? [];
-    if (preset === "today") return items.filter((task) => task.planned_today);
-    if (preset === "week")
-      return items.filter((task) => task.planned_this_week);
-    if (preset === "unplanned") {
-      return items.filter(
-        (task) => !task.planned_today && !task.planned_this_week,
-      );
-    }
-    return items;
-  }, [preset, workspace.data?.items]);
+  const visibleTasks = workspace.data?.items ?? [];
 
   const filteredGoals = projectId
     ? goals.filter((goal) => goal.project_id === projectId)
@@ -495,7 +491,7 @@ export default function TasksPage() {
               )}
             </Card>
 
-            {!clientPlanPreset && (workspace.data?.total ?? 0) > 50 && (
+            {(workspace.data?.total ?? 0) > 50 && (
               <div className="flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">
                   {page * 50 + 1}–

--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -1,0 +1,641 @@
+"use client";
+
+import Link from "next/link";
+import { useDeferredValue, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  Bot,
+  CalendarDays,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Inbox,
+  ListTodo,
+  Play,
+  Search,
+} from "lucide-react";
+
+import { AppHeader } from "@/components/layout/app-header";
+import { QuickTaskList } from "@/components/quick-tasks";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { useAuth } from "@/hooks/use-auth";
+import { toast } from "@/hooks/use-toast";
+import {
+  useTaskRecommendations,
+  useTaskWorkspace,
+  useUpdateTask,
+} from "@/hooks/use-tasks-query";
+import { goalsApi, projectsApi, quickTasksApi } from "@/lib/api";
+import type { Goal } from "@/types/goal";
+import type { QuickTask } from "@/types/quick-task";
+import type {
+  TaskStatus,
+  TaskWorkspaceFilters,
+  TaskWorkspaceItem,
+} from "@/types/task";
+import { taskStatusLabels } from "@/types/task";
+
+type Preset =
+  | "next"
+  | "today"
+  | "week"
+  | "in_progress"
+  | "overdue"
+  | "blocked"
+  | "unplanned"
+  | "inbox"
+  | "all";
+
+const PRESETS: Array<{ id: Preset; label: string }> = [
+  { id: "next", label: "次にやる" },
+  { id: "today", label: "今日" },
+  { id: "week", label: "今週" },
+  { id: "in_progress", label: "作業中" },
+  { id: "overdue", label: "期限切れ" },
+  { id: "blocked", label: "ブロック中" },
+  { id: "unplanned", label: "未計画" },
+  { id: "inbox", label: "Inbox" },
+  { id: "all", label: "全タスク" },
+];
+
+const actionableStatuses: TaskStatus[] = ["pending", "in_progress"];
+
+function dateInputValue(value: string | null) {
+  return value ? value.slice(0, 10) : "";
+}
+
+function TaskRow({
+  task,
+  goals,
+  onOpen,
+}: {
+  task: TaskWorkspaceItem;
+  goals: Goal[];
+  onOpen: () => void;
+}) {
+  const updateTask = useUpdateTask();
+
+  const update = async (
+    data: Parameters<typeof updateTask.mutateAsync>[0]["data"],
+  ) => {
+    try {
+      await updateTask.mutateAsync({ id: task.id, data });
+    } catch {
+      toast({
+        title: "タスクを更新できませんでした",
+        description: "入力内容を確認して、もう一度お試しください。",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="grid gap-3 border-b border-border px-4 py-4 last:border-b-0 xl:grid-cols-[minmax(260px,2fr)_140px_110px_150px_120px_minmax(210px,1fr)_110px] xl:items-center">
+      <div className="min-w-0">
+        <button className="block max-w-full text-left" onClick={onOpen}>
+          <span className="block truncate font-medium hover:text-primary hover:underline">
+            {task.title}
+          </span>
+        </button>
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+          <span>
+            {task.project_title} › {task.goal_title}
+          </span>
+          {task.is_blocked && <Badge variant="destructive">ブロック中</Badge>}
+          {task.planned_today && <Badge variant="info">今日</Badge>}
+          {!task.planned_today && task.planned_this_week && (
+            <Badge variant="secondary">今週</Badge>
+          )}
+        </div>
+      </div>
+
+      <label className="text-xs text-muted-foreground">
+        <span className="mb-1 block xl:hidden">ステータス</span>
+        <select
+          aria-label={`${task.title}のステータス`}
+          className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+          value={task.status}
+          disabled={updateTask.isPending}
+          onChange={(event) =>
+            update({ status: event.target.value as TaskStatus })
+          }
+        >
+          {Object.entries(taskStatusLabels).map(([value, label]) => (
+            <option key={value} value={value}>
+              {label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="text-xs text-muted-foreground">
+        <span className="mb-1 block xl:hidden">優先度</span>
+        <select
+          aria-label={`${task.title}の優先度`}
+          className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+          value={task.priority}
+          disabled={updateTask.isPending}
+          onChange={(event) => update({ priority: Number(event.target.value) })}
+        >
+          {[1, 2, 3, 4, 5].map((priority) => (
+            <option key={priority} value={priority}>
+              {priority}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="text-xs text-muted-foreground">
+        <span className="mb-1 block xl:hidden">期限</span>
+        <Input
+          aria-label={`${task.title}の期限`}
+          type="date"
+          defaultValue={dateInputValue(task.due_date)}
+          disabled={updateTask.isPending}
+          onChange={(event) =>
+            update({
+              due_date: event.target.value
+                ? new Date(`${event.target.value}T23:59:59`).toISOString()
+                : null,
+            })
+          }
+        />
+      </label>
+
+      <label className="text-xs text-muted-foreground">
+        <span className="mb-1 block xl:hidden">見積時間</span>
+        <Input
+          aria-label={`${task.title}の見積時間`}
+          type="number"
+          min="0.01"
+          step="0.25"
+          defaultValue={task.estimate_hours}
+          disabled={updateTask.isPending}
+          onBlur={(event) => {
+            const value = Number(event.target.value);
+            if (value > 0 && value !== task.estimate_hours)
+              update({ estimate_hours: value });
+          }}
+        />
+      </label>
+
+      <label className="text-xs text-muted-foreground">
+        <span className="mb-1 block xl:hidden">所属ゴール</span>
+        <select
+          aria-label={`${task.title}の所属ゴール`}
+          className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+          value={task.goal_id}
+          disabled={updateTask.isPending}
+          onChange={(event) => update({ goal_id: event.target.value })}
+        >
+          {goals.map((goal) => (
+            <option key={goal.id} value={goal.id}>
+              {goal.title}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <Button size="sm" asChild>
+        <Link href={`/runner?taskId=${encodeURIComponent(task.id)}`}>
+          <Play className="mr-1 h-4 w-4" />
+          開始
+        </Link>
+      </Button>
+    </div>
+  );
+}
+
+export default function TasksPage() {
+  const { user, loading: authLoading } = useAuth();
+  const queryClient = useQueryClient();
+  const [preset, setPreset] = useState<Preset>("next");
+  const [search, setSearch] = useState("");
+  const deferredSearch = useDeferredValue(search.trim());
+  const [projectId, setProjectId] = useState("");
+  const [goalId, setGoalId] = useState("");
+  const [status, setStatus] = useState<TaskStatus | "">("");
+  const [page, setPage] = useState(0);
+  const [selectedTask, setSelectedTask] = useState<TaskWorkspaceItem | null>(
+    null,
+  );
+  const [convertingTask, setConvertingTask] = useState<QuickTask | null>(null);
+  const [convertGoalId, setConvertGoalId] = useState("");
+  const [inboxVersion, setInboxVersion] = useState(0);
+  const [isConverting, setIsConverting] = useState(false);
+
+  const { data: projects = [] } = useQuery({
+    queryKey: ["projects", "task-workspace"],
+    queryFn: () => projectsApi.getAll(0, 100),
+    enabled: Boolean(user),
+  });
+  const { data: goals = [] } = useQuery({
+    queryKey: [
+      "goals",
+      "task-workspace",
+      projects.map((project) => project.id).join(","),
+    ],
+    queryFn: async () => {
+      const results = await Promise.all(
+        projects.map((project) => goalsApi.getByProject(project.id, 0, 100)),
+      );
+      return results.flat();
+    },
+    enabled: projects.length > 0,
+  });
+
+  const clientPlanPreset =
+    preset === "today" || preset === "week" || preset === "unplanned";
+  const filters = useMemo<TaskWorkspaceFilters>(() => {
+    let statuses = status ? [status] : undefined;
+    if (
+      !status &&
+      (preset === "next" || preset === "overdue" || clientPlanPreset)
+    ) {
+      statuses = actionableStatuses;
+    }
+    if (!status && preset === "in_progress") statuses = ["in_progress"];
+
+    return {
+      skip: clientPlanPreset ? 0 : page * 50,
+      limit: clientPlanPreset ? 100 : 50,
+      status: statuses,
+      projectId: projectId || undefined,
+      goalId: goalId || undefined,
+      dueBefore: preset === "overdue" ? new Date().toISOString() : undefined,
+      search: deferredSearch || undefined,
+      blocked: preset === "blocked" ? true : undefined,
+      sortBy: preset === "next" ? "priority" : "due_date",
+    };
+  }, [
+    clientPlanPreset,
+    deferredSearch,
+    goalId,
+    page,
+    preset,
+    projectId,
+    status,
+  ]);
+
+  const workspace = useTaskWorkspace(filters);
+  const recommendations = useTaskRecommendations();
+  const visibleTasks = useMemo(() => {
+    const items = workspace.data?.items ?? [];
+    if (preset === "today") return items.filter((task) => task.planned_today);
+    if (preset === "week")
+      return items.filter((task) => task.planned_this_week);
+    if (preset === "unplanned") {
+      return items.filter(
+        (task) => !task.planned_today && !task.planned_this_week,
+      );
+    }
+    return items;
+  }, [preset, workspace.data?.items]);
+
+  const filteredGoals = projectId
+    ? goals.filter((goal) => goal.project_id === projectId)
+    : goals;
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen bg-muted/20">
+        <AppHeader currentPage="tasks" />
+      </div>
+    );
+  }
+  if (!user) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        ログインしてください
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-muted/20">
+      <AppHeader currentPage="tasks" />
+      <main className="mx-auto max-w-screen-2xl space-y-5 px-4 py-6 sm:px-6 lg:px-8">
+        <div>
+          <h1 className="flex items-center gap-2 text-2xl font-bold">
+            <ListTodo className="h-6 w-6" />
+            タスクワークスペース
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            プロジェクト階層をまたいで、次に取り組むタスクを探して調整できます。
+          </p>
+        </div>
+
+        {recommendations.data &&
+          recommendations.data.length > 0 &&
+          preset !== "inbox" && (
+            <Card>
+              <CardHeader className="pb-3">
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Bot className="h-5 w-5" />
+                  次のおすすめ
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="grid gap-3 md:grid-cols-3">
+                {recommendations.data.map((recommendation) => (
+                  <Link
+                    key={recommendation.task.id}
+                    href={`/runner?taskId=${encodeURIComponent(recommendation.task.id)}`}
+                    className="rounded-lg border border-border p-3 transition-colors hover:bg-muted/60"
+                  >
+                    <div className="truncate font-medium">
+                      {recommendation.task.title}
+                    </div>
+                    <div className="mt-1 truncate text-xs text-muted-foreground">
+                      {recommendation.task.project_title} ›{" "}
+                      {recommendation.task.goal_title}
+                    </div>
+                    <p className="mt-2 text-xs">{recommendation.reason}</p>
+                  </Link>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+
+        <div className="flex gap-2 overflow-x-auto pb-1">
+          {PRESETS.map((item) => (
+            <Button
+              key={item.id}
+              size="sm"
+              variant={preset === item.id ? "default" : "outline"}
+              onClick={() => {
+                setPreset(item.id);
+                setPage(0);
+              }}
+            >
+              {item.id === "inbox" && <Inbox className="mr-1 h-4 w-4" />}
+              {item.label}
+            </Button>
+          ))}
+        </div>
+
+        {preset === "inbox" ? (
+          <QuickTaskList
+            key={inboxVersion}
+            limit={100}
+            onConvertToTask={(task) => {
+              setConvertingTask(task);
+              setConvertGoalId(goals[0]?.id ?? "");
+            }}
+          />
+        ) : (
+          <>
+            <Card>
+              <CardContent className="grid gap-3 p-4 md:grid-cols-2 xl:grid-cols-5">
+                <div className="relative md:col-span-2">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    value={search}
+                    onChange={(event) => {
+                      setSearch(event.target.value);
+                      setPage(0);
+                    }}
+                    placeholder="タイトル・説明・メモを検索"
+                    className="pl-9"
+                  />
+                </div>
+                <select
+                  aria-label="プロジェクトで絞り込み"
+                  className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                  value={projectId}
+                  onChange={(event) => {
+                    setProjectId(event.target.value);
+                    setGoalId("");
+                    setPage(0);
+                  }}
+                >
+                  <option value="">全プロジェクト</option>
+                  {projects.map((project) => (
+                    <option key={project.id} value={project.id}>
+                      {project.title}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  aria-label="ゴールで絞り込み"
+                  className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                  value={goalId}
+                  onChange={(event) => {
+                    setGoalId(event.target.value);
+                    setPage(0);
+                  }}
+                >
+                  <option value="">全ゴール</option>
+                  {filteredGoals.map((goal) => (
+                    <option key={goal.id} value={goal.id}>
+                      {goal.title}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  aria-label="ステータスで絞り込み"
+                  className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+                  value={status}
+                  onChange={(event) => {
+                    setStatus(event.target.value as TaskStatus | "");
+                    setPage(0);
+                  }}
+                >
+                  <option value="">全ステータス</option>
+                  {Object.entries(taskStatusLabels).map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </CardContent>
+            </Card>
+
+            <Card className="overflow-hidden">
+              <div className="hidden grid-cols-[minmax(260px,2fr)_140px_110px_150px_120px_minmax(210px,1fr)_110px] gap-3 border-b bg-muted/50 px-4 py-2 text-xs font-medium text-muted-foreground xl:grid">
+                <span>タスク</span>
+                <span>ステータス</span>
+                <span>優先度</span>
+                <span>期限</span>
+                <span>見積時間</span>
+                <span>所属ゴール</span>
+                <span>Runner</span>
+              </div>
+              {workspace.isLoading ? (
+                <div className="p-12 text-center text-muted-foreground">
+                  読み込み中...
+                </div>
+              ) : workspace.isError ? (
+                <div className="p-12 text-center text-destructive">
+                  タスクの取得に失敗しました
+                </div>
+              ) : visibleTasks.length === 0 ? (
+                <div className="p-12 text-center text-muted-foreground">
+                  条件に一致するタスクはありません
+                </div>
+              ) : (
+                visibleTasks.map((task) => (
+                  <TaskRow
+                    key={task.id}
+                    task={task}
+                    goals={goals}
+                    onOpen={() => setSelectedTask(task)}
+                  />
+                ))
+              )}
+            </Card>
+
+            {!clientPlanPreset && (workspace.data?.total ?? 0) > 50 && (
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">
+                  {page * 50 + 1}–
+                  {Math.min((page + 1) * 50, workspace.data?.total ?? 0)} /{" "}
+                  {workspace.data?.total}
+                </span>
+                <div className="flex gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page === 0}
+                    onClick={() => setPage((value) => value - 1)}
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                    前へ
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={(page + 1) * 50 >= (workspace.data?.total ?? 0)}
+                    onClick={() => setPage((value) => value + 1)}
+                  >
+                    次へ
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </main>
+
+      <Dialog
+        open={Boolean(selectedTask)}
+        onOpenChange={(open) => !open && setSelectedTask(null)}
+      >
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+          {selectedTask && (
+            <>
+              <DialogHeader>
+                <DialogTitle>{selectedTask.title}</DialogTitle>
+                <DialogDescription>
+                  {selectedTask.project_title} › {selectedTask.goal_title}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4 text-sm">
+                <p className="whitespace-pre-wrap">
+                  {selectedTask.description || "説明はありません。"}
+                </p>
+                {selectedTask.memo && (
+                  <div className="rounded-md bg-muted p-3 whitespace-pre-wrap">
+                    {selectedTask.memo}
+                  </div>
+                )}
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="flex items-center gap-2">
+                    <Clock className="h-4 w-4" />
+                    残り見積 {selectedTask.remaining_estimate_hours}時間
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <CalendarDays className="h-4 w-4" />
+                    最終作業{" "}
+                    {selectedTask.last_worked_at
+                      ? new Date(selectedTask.last_worked_at).toLocaleString(
+                          "ja-JP",
+                        )
+                      : "なし"}
+                  </div>
+                </div>
+                {selectedTask.is_blocked && (
+                  <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
+                    <AlertTriangle className="mt-0.5 h-4 w-4 text-destructive" />
+                    <span>
+                      未完了の依存タスクが{" "}
+                      {selectedTask.blocking_task_ids.length} 件あります。
+                    </span>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={Boolean(convertingTask)}
+        onOpenChange={(open) => !open && setConvertingTask(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Inboxからタスクへ整理</DialogTitle>
+            <DialogDescription>
+              「{convertingTask?.title}」の所属ゴールを選択してください。
+            </DialogDescription>
+          </DialogHeader>
+          <select
+            aria-label="変換先ゴール"
+            className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            value={convertGoalId}
+            onChange={(event) => setConvertGoalId(event.target.value)}
+          >
+            {goals.map((goal) => (
+              <option key={goal.id} value={goal.id}>
+                {goal.title}
+              </option>
+            ))}
+          </select>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setConvertingTask(null)}>
+              キャンセル
+            </Button>
+            <Button
+              disabled={!convertGoalId || isConverting}
+              onClick={async () => {
+                if (!convertingTask || !convertGoalId) return;
+                setIsConverting(true);
+                try {
+                  await quickTasksApi.convertToTask(
+                    convertingTask.id,
+                    convertGoalId,
+                  );
+                  await queryClient.invalidateQueries({ queryKey: ["tasks"] });
+                  setConvertingTask(null);
+                  setInboxVersion((value) => value + 1);
+                  toast({ title: "通常タスクへ移動しました" });
+                } catch {
+                  toast({
+                    title: "タスクを変換できませんでした",
+                    variant: "destructive",
+                  });
+                } finally {
+                  setIsConverting(false);
+                }
+              }}
+            >
+              {isConverting ? "移動中..." : "移動"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/app-header.tsx
+++ b/apps/web/src/components/layout/app-header.tsx
@@ -19,18 +19,19 @@ import {
 } from '@/components/ui/dropdown-menu'
 
 // Icons
-import { TrendingUp, Menu, Home, FolderOpen, Calendar, Clock, History, Settings, Play, Timer, ListChecks, MoreHorizontal, ChevronDown, CalendarDays, SlidersHorizontal, LayoutTemplate } from 'lucide-react'
+import { TrendingUp, Menu, Home, FolderOpen, Calendar, Clock, History, Settings, Play, Timer, ListChecks, MoreHorizontal, ChevronDown, CalendarDays, SlidersHorizontal, LayoutTemplate, ListTodo } from 'lucide-react'
 
 // Hooks
 import { useAuth } from '@/hooks/use-auth'
 
 interface AppHeaderProps {
-  currentPage?: 'dashboard' | 'projects' | 'ai-planning' | 'triage' | 'scheduling' | 'scheduling-daily' | 'scheduling-settings' | 'scheduler-tuning' | 'schedule-history' | 'work-session-history' | 'timeline' | 'settings' | 'runner'
+  currentPage?: 'dashboard' | 'tasks' | 'projects' | 'ai-planning' | 'triage' | 'scheduling' | 'scheduling-daily' | 'scheduling-settings' | 'scheduler-tuning' | 'schedule-history' | 'work-session-history' | 'timeline' | 'settings' | 'runner'
 }
 
 const NAVIGATION_ITEMS = [
   { id: 'dashboard', label: 'ダッシュボード', path: '/dashboard', icon: Home },
   { id: 'runner', label: 'Runner', path: '/runner', icon: Play },
+  { id: 'tasks', label: 'タスク', path: '/tasks', icon: ListTodo },
   { id: 'projects', label: 'プロジェクト', path: '/projects', icon: FolderOpen },
   { id: 'scheduling', label: 'スケジューリング', path: '/scheduling', icon: Calendar },
   { id: 'triage', label: 'トリアージ', path: '/triage', icon: ListChecks },
@@ -51,6 +52,7 @@ const SCHEDULING_NAVIGATION_ITEMS = [
 const PRIMARY_NAVIGATION_IDS = new Set([
   'dashboard',
   'runner',
+  'tasks',
   'projects',
   'scheduling',
   'triage',

--- a/apps/web/src/components/runner/__tests__/manual-task-select-dialog.test.tsx
+++ b/apps/web/src/components/runner/__tests__/manual-task-select-dialog.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { projectsApi, tasksApi } from '@/lib/api';
+import { ManualTaskSelectDialog } from '../manual-task-select-dialog';
+
+jest.mock('@/lib/api', () => ({
+  projectsApi: {
+    getAll: jest.fn(),
+  },
+  tasksApi: {
+    getById: jest.fn(),
+    getWorkspace: jest.fn(),
+  },
+}));
+
+const task = {
+  id: 'task-from-recommendation',
+  title: 'おすすめされたタスク',
+  description: 'このタスクをそのまま開始する',
+  estimate_hours: 2,
+  due_date: null,
+  status: 'pending' as const,
+  priority: 1,
+  goal_id: 'goal-1',
+  created_at: '2026-07-15T00:00:00Z',
+  updated_at: '2026-07-15T00:00:00Z',
+};
+
+function renderDialog(onStart = jest.fn().mockResolvedValue(undefined)) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ManualTaskSelectDialog
+        open
+        onOpenChange={jest.fn()}
+        isStarting={false}
+        initialTaskId={task.id}
+        onStart={onStart}
+      />
+    </QueryClientProvider>
+  );
+
+  return { onStart };
+}
+
+describe('ManualTaskSelectDialog recommended task flow', () => {
+  it('loads the selected task directly and starts it without opening the task picker', async () => {
+    jest.mocked(tasksApi.getById).mockResolvedValue(task);
+
+    const { onStart } = renderDialog();
+
+    expect(await screen.findByText(task.title)).toBeInTheDocument();
+    expect(screen.getByText('開始するタスク')).toBeInTheDocument();
+    expect(screen.getByText('タスク選択').closest('div')).toHaveClass('hidden');
+    expect(tasksApi.getById).toHaveBeenCalledWith(task.id);
+    expect(tasksApi.getWorkspace).not.toHaveBeenCalled();
+    expect(projectsApi.getAll).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'セッション開始' }));
+
+    await waitFor(() => {
+      expect(onStart).toHaveBeenCalledWith(
+        task.id,
+        expect.any(String),
+        undefined,
+        true
+      );
+    });
+  });
+});

--- a/apps/web/src/components/runner/__tests__/manual-task-select-dialog.test.tsx
+++ b/apps/web/src/components/runner/__tests__/manual-task-select-dialog.test.tsx
@@ -74,4 +74,34 @@ describe('ManualTaskSelectDialog recommended task flow', () => {
       );
     });
   });
+
+  it('limits the all-project picker to active projects', async () => {
+    jest.mocked(projectsApi.getAll).mockResolvedValue([]);
+    jest.mocked(tasksApi.getWorkspace).mockResolvedValue({
+      items: [],
+      total: 0,
+      skip: 0,
+      limit: 100,
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ManualTaskSelectDialog
+          open
+          onOpenChange={jest.fn()}
+          isStarting={false}
+          onStart={jest.fn()}
+        />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(tasksApi.getWorkspace).toHaveBeenCalledWith(
+        expect.objectContaining({ projectStatus: 'in_progress' })
+      );
+    });
+  });
 });

--- a/apps/web/src/components/runner/manual-task-select-dialog.tsx
+++ b/apps/web/src/components/runner/manual-task-select-dialog.tsx
@@ -53,12 +53,14 @@ export function ManualTaskSelectDialog({
   const [searchQuery, setSearchQuery] = useState('');
   const [duration, setDuration] = useState<number>(60);
   const [plannedOutcome, setPlannedOutcome] = useState('');
+  const [chooseAnotherTask, setChooseAnotherTask] = useState(false);
+  const isInitialTaskMode = Boolean(initialTaskId) && !chooseAnotherTask;
 
   // Fetch all projects
   const { data: projects = [], isLoading: projectsLoading } = useQuery({
     queryKey: ['projects', 'all'],
     queryFn: () => projectsApi.getAll(0, 100),
-    enabled: open,
+    enabled: open && !isInitialTaskMode,
   });
   const selectableProjects = useMemo(
     () => getSelectableProjects(projects),
@@ -84,12 +86,27 @@ export function ManualTaskSelectDialog({
       search: searchQuery.trim() || undefined,
       sortBy: 'priority',
     }),
-    enabled: open,
+    enabled: open && !isInitialTaskMode,
   });
   const filteredTasks = taskPage?.items ?? [];
 
+  // A workspace or recommendation link may point to a task outside the first
+  // page of the manual picker, so load that task directly by ID.
+  const {
+    data: initialTask,
+    isLoading: initialTaskLoading,
+    isError: initialTaskError,
+  } = useQuery({
+    queryKey: ['tasks', 'manual-select', 'initial', initialTaskId],
+    queryFn: () => tasksApi.getById(initialTaskId as string),
+    enabled: open && isInitialTaskMode,
+  });
+
   useEffect(() => {
-    if (open && initialTaskId) setSelectedTaskId(initialTaskId);
+    if (open && initialTaskId) {
+      setSelectedTaskId(initialTaskId);
+      setChooseAnotherTask(false);
+    }
   }, [initialTaskId, open]);
 
   // Calculate planned checkout time
@@ -116,29 +133,84 @@ export function ManualTaskSelectDialog({
     setSearchQuery('');
     setDuration(60);
     setPlannedOutcome('');
+    setChooseAnotherTask(false);
     onOpenChange(false);
   };
 
-  const selectedTask = filteredTasks.find((t) => t.id === selectedTaskId);
-  const isLoading = projectsLoading || tasksLoading;
+  const selectedTask = isInitialTaskMode
+    ? initialTask
+    : filteredTasks.find((t) => t.id === selectedTaskId);
+  const isLoading = isInitialTaskMode
+    ? initialTaskLoading
+    : projectsLoading || tasksLoading;
 
   return (
-    <Dialog open={open} onOpenChange={handleClose}>
+    <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && handleClose()}>
       <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <FolderOpen className="h-5 w-5" />
-            タスクを手動で選択
+            {isInitialTaskMode ? 'セッション開始' : 'タスクを手動で選択'}
           </DialogTitle>
           <DialogDescription>
-            スケジュール外のタスクを選択して作業を開始できます。
-            作業完了時にスケジュールへの影響が提案されます。
+            {isInitialTaskMode ? (
+              <>選択したタスクの作業時間と今回の目標を確認してください。</>
+            ) : (
+              <>
+                スケジュール外のタスクを選択して作業を開始できます。
+                作業完了時にスケジュールへの影響が提案されます。
+              </>
+            )}
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-6 py-4">
+          {isInitialTaskMode && (
+            <div className="space-y-3">
+              <Label>開始するタスク</Label>
+              {isLoading ? (
+                <div className="text-center py-8 text-muted-foreground">
+                  読み込み中...
+                </div>
+              ) : initialTaskError || !initialTask ? (
+                <div className="rounded-lg border border-destructive/40 p-4 text-sm text-destructive">
+                  選択したタスクを読み込めませんでした。
+                </div>
+              ) : (
+                <div className="rounded-lg border border-primary/40 bg-primary/5 p-4">
+                  <p className="font-medium">{initialTask.title}</p>
+                  {initialTask.description && (
+                    <p className="mt-1 text-sm text-muted-foreground line-clamp-3">
+                      {initialTask.description}
+                    </p>
+                  )}
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <Badge variant="outline" className="text-xs">
+                      <Clock className="h-3 w-3 mr-1" />
+                      見積もり {initialTask.estimate_hours}h
+                    </Badge>
+                    <Badge variant="secondary" className="text-xs">
+                      {initialTask.status === 'pending' ? '未着手' : '進行中'}
+                    </Badge>
+                  </div>
+                </div>
+              )}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setChooseAnotherTask(true);
+                  setSelectedTaskId('');
+                }}
+              >
+                別のタスクを選択
+              </Button>
+            </div>
+          )}
+
           {/* Project filter */}
-          <div className="space-y-2">
+          <div className={isInitialTaskMode ? 'hidden' : 'space-y-2'}>
             <Label>プロジェクト</Label>
             <Select
               value={selectedProjectId}
@@ -162,7 +234,7 @@ export function ManualTaskSelectDialog({
           </div>
 
           {/* Search */}
-          <div className="space-y-2">
+          <div className={isInitialTaskMode ? 'hidden' : 'space-y-2'}>
             <Label>タスク検索</Label>
             <div className="relative">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -176,7 +248,7 @@ export function ManualTaskSelectDialog({
           </div>
 
           {/* Task selection */}
-          <div className="space-y-3">
+          <div className={isInitialTaskMode ? 'hidden' : 'space-y-3'}>
             <Label>タスク選択</Label>
             {isLoading ? (
               <div className="text-center py-8 text-muted-foreground">
@@ -307,7 +379,12 @@ export function ManualTaskSelectDialog({
           </Button>
           <Button
             onClick={handleStart}
-            disabled={!selectedTaskId || isStarting}
+            disabled={
+              !selectedTaskId ||
+              isStarting ||
+              isLoading ||
+              (isInitialTaskMode && (initialTaskError || !initialTask))
+            }
           >
             {isStarting ? '開始中...' : 'セッション開始'}
           </Button>

--- a/apps/web/src/components/runner/manual-task-select-dialog.tsx
+++ b/apps/web/src/components/runner/manual-task-select-dialog.tsx
@@ -83,6 +83,7 @@ export function ManualTaskSelectDialog({
       limit: 100,
       status: ['pending', 'in_progress'],
       projectId: selectedProjectId === 'all' ? undefined : selectedProjectId,
+      projectStatus: selectedProjectId === 'all' ? 'in_progress' : undefined,
       search: searchQuery.trim() || undefined,
       sortBy: 'priority',
     }),

--- a/apps/web/src/components/runner/manual-task-select-dialog.tsx
+++ b/apps/web/src/components/runner/manual-task-select-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useDeferredValue } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import {
   Dialog,
@@ -55,6 +55,7 @@ export function ManualTaskSelectDialog({
   const [plannedOutcome, setPlannedOutcome] = useState('');
   const [chooseAnotherTask, setChooseAnotherTask] = useState(false);
   const isInitialTaskMode = Boolean(initialTaskId) && !chooseAnotherTask;
+  const deferredSearch = useDeferredValue(searchQuery.trim());
 
   // Fetch all projects
   const { data: projects = [], isLoading: projectsLoading } = useQuery({
@@ -78,13 +79,13 @@ export function ManualTaskSelectDialog({
 
   // Fetch cross-project tasks in one server-side query.
   const { data: taskPage, isLoading: tasksLoading } = useQuery({
-    queryKey: ['tasks', 'manual-select', selectedProjectId, searchQuery],
+    queryKey: ['tasks', 'manual-select', selectedProjectId, deferredSearch],
     queryFn: () => tasksApi.getWorkspace({
       limit: 100,
       status: ['pending', 'in_progress'],
       projectId: selectedProjectId === 'all' ? undefined : selectedProjectId,
       projectStatus: selectedProjectId === 'all' ? 'in_progress' : undefined,
-      search: searchQuery.trim() || undefined,
+      search: deferredSearch || undefined,
       sortBy: 'priority',
     }),
     enabled: open && !isInitialTaskMode,

--- a/apps/web/src/components/runner/manual-task-select-dialog.tsx
+++ b/apps/web/src/components/runner/manual-task-select-dialog.tsx
@@ -25,7 +25,6 @@ import {
 } from '@/components/ui/select';
 import { Clock, Search, FolderOpen, AlertCircle } from 'lucide-react';
 import { projectsApi, tasksApi } from '@/lib/api';
-import { log } from '@/lib/logger';
 import { getSelectableProjects } from '@/lib/project-filters';
 import type { Project } from '@/types/project';
 
@@ -33,6 +32,7 @@ interface ManualTaskSelectDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   isStarting: boolean;
+  initialTaskId?: string | null;
   onStart: (
     taskId: string,
     plannedCheckoutAt: string,
@@ -45,6 +45,7 @@ export function ManualTaskSelectDialog({
   open,
   onOpenChange,
   isStarting,
+  initialTaskId,
   onStart,
 }: ManualTaskSelectDialogProps) {
   const [selectedProjectId, setSelectedProjectId] = useState<string>('all');
@@ -73,54 +74,23 @@ export function ManualTaskSelectDialog({
     }
   }, [selectableProjects, selectedProjectId]);
 
-  // Fetch tasks for selected project (or all projects)
-  const { data: tasks = [], isLoading: tasksLoading } = useQuery({
-    queryKey: ['tasks', 'manual-select', selectedProjectId, selectableProjects.map(p => p.id).join(',')],
-    queryFn: async () => {
-      if (selectedProjectId === 'all') {
-        // Fetch tasks from all projects in parallel.
-        // Ignore failures for individual projects and return other projects' tasks.
-        const taskPromises = selectableProjects.map((project) =>
-          tasksApi.getByProject(project.id, 0, 100)
-        );
-        const taskResults = await Promise.allSettled(taskPromises);
-        return taskResults.flatMap((result, index) => {
-          if (result.status === 'fulfilled') {
-            return result.value;
-          }
-
-          log.error(
-            `Failed to load tasks for project ${selectableProjects[index]?.id}`,
-            result.reason instanceof Error ? result.reason : new Error(String(result.reason)),
-            { component: 'ManualTaskSelectDialog' }
-          );
-
-          return [];
-        });
-      } else {
-        return tasksApi.getByProject(selectedProjectId, 0, 100);
-      }
-    },
-    enabled: open && (selectedProjectId !== 'all' || selectableProjects.length > 0),
+  // Fetch cross-project tasks in one server-side query.
+  const { data: taskPage, isLoading: tasksLoading } = useQuery({
+    queryKey: ['tasks', 'manual-select', selectedProjectId, searchQuery],
+    queryFn: () => tasksApi.getWorkspace({
+      limit: 100,
+      status: ['pending', 'in_progress'],
+      projectId: selectedProjectId === 'all' ? undefined : selectedProjectId,
+      search: searchQuery.trim() || undefined,
+      sortBy: 'priority',
+    }),
+    enabled: open,
   });
+  const filteredTasks = taskPage?.items ?? [];
 
-  // Filter to only show actionable tasks (pending or in_progress)
-  const actionableTasks = useMemo(() => {
-    return tasks.filter(
-      (task) => task.status === 'pending' || task.status === 'in_progress'
-    );
-  }, [tasks]);
-
-  // Filter tasks by search query
-  const filteredTasks = useMemo(() => {
-    if (!searchQuery.trim()) return actionableTasks;
-    const query = searchQuery.toLowerCase();
-    return actionableTasks.filter(
-      (task) =>
-        task.title.toLowerCase().includes(query) ||
-        (task.description?.toLowerCase().includes(query) ?? false)
-    );
-  }, [actionableTasks, searchQuery]);
+  useEffect(() => {
+    if (open && initialTaskId) setSelectedTaskId(initialTaskId);
+  }, [initialTaskId, open]);
 
   // Calculate planned checkout time
   const calculateCheckoutTime = (): string => {
@@ -149,11 +119,6 @@ export function ManualTaskSelectDialog({
     onOpenChange(false);
   };
 
-  // Reset task selection when project changes
-  useEffect(() => {
-    setSelectedTaskId('');
-  }, [selectedProjectId]);
-
   const selectedTask = filteredTasks.find((t) => t.id === selectedTaskId);
   const isLoading = projectsLoading || tasksLoading;
 
@@ -177,7 +142,10 @@ export function ManualTaskSelectDialog({
             <Label>プロジェクト</Label>
             <Select
               value={selectedProjectId}
-              onValueChange={setSelectedProjectId}
+              onValueChange={(value) => {
+                setSelectedProjectId(value);
+                setSelectedTaskId('');
+              }}
             >
               <SelectTrigger>
                 <SelectValue placeholder="プロジェクトを選択" />
@@ -248,6 +216,9 @@ export function ManualTaskSelectDialog({
                         </p>
                       )}
                       <div className="flex items-center gap-2 mt-2 flex-wrap">
+                        <Badge variant="outline" className="text-xs">
+                          {task.project_title} › {task.goal_title}
+                        </Badge>
                         <Badge variant="outline" className="text-xs">
                           <Clock className="h-3 w-3 mr-1" />
                           {task.estimate_hours}h

--- a/apps/web/src/components/runner/runner-page.tsx
+++ b/apps/web/src/components/runner/runner-page.tsx
@@ -18,7 +18,7 @@ import { PauseDialog } from './pause-dialog';
 import { ResumeDialog } from './resume-dialog';
 import { NotificationBanner } from './notification-banner';
 import { RescheduleSuggestionCard } from './reschedule-suggestion-card';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Play, AlertCircle, Pause, FolderOpen, Calendar } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { formatDuration } from '@/types/runner';
@@ -54,10 +54,19 @@ export function RunnerPage() {
 
   const [startDialogOpen, setStartDialogOpen] = useState(false);
   const [manualTaskDialogOpen, setManualTaskDialogOpen] = useState(false);
+  const [initialTaskId, setInitialTaskId] = useState<string | null>(null);
   const [checkoutDialogOpen, setCheckoutDialogOpen] = useState(false);
   const [pauseDialogOpen, setPauseDialogOpen] = useState(false);
   const [resumeDialogOpen, setResumeDialogOpen] = useState(false);
   const [selectedNextTaskId, setSelectedNextTaskId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const taskId = new URLSearchParams(window.location.search).get('taskId');
+    if (taskId) {
+      setInitialTaskId(taskId);
+      setManualTaskDialogOpen(true);
+    }
+  }, []);
 
   // Issue #227: Reschedule suggestion state
   const [lastRescheduleSuggestion, setLastRescheduleSuggestion] = useState<RescheduleSuggestion | null>(null);
@@ -304,12 +313,17 @@ export function RunnerPage() {
 
         <ManualTaskSelectDialog
           open={manualTaskDialogOpen}
-          onOpenChange={setManualTaskDialogOpen}
+          onOpenChange={(open) => {
+            setManualTaskDialogOpen(open);
+            if (!open) setInitialTaskId(null);
+          }}
           isStarting={isStarting}
+          initialTaskId={initialTaskId}
           onStart={async (taskId, plannedCheckoutAt, plannedOutcome, isManualExecution) => {
             try {
               await startSession(taskId, plannedCheckoutAt, plannedOutcome, isManualExecution);
               setManualTaskDialogOpen(false);
+              setInitialTaskId(null);
             } catch (error) {
               console.error('Start session failed:', error);
             }

--- a/apps/web/src/hooks/__tests__/use-tasks-query.test.ts
+++ b/apps/web/src/hooks/__tests__/use-tasks-query.test.ts
@@ -5,7 +5,14 @@ import { act, waitFor } from '@testing-library/react'
 import { QueryClient } from '@tanstack/react-query'
 import { createMockTask, createMockTasks, resetIdCounter } from './helpers/mock-factories'
 import { renderHookWithClient } from './helpers/test-utils'
-import type { Task, TaskCreate, TaskDependency, TaskUpdate } from '@/types/task'
+import type {
+  Task,
+  TaskCreate,
+  TaskDependency,
+  TaskRecommendation,
+  TaskUpdate,
+  TaskWorkspacePage,
+} from '@/types/task'
 import { SortBy, SortOrder } from '@/types/sort'
 import type { SortOptions } from '@/types/sort'
 
@@ -18,6 +25,8 @@ const mockUpdate = jest.fn<Promise<Task>, [string, TaskUpdate]>()
 const mockDelete = jest.fn<Promise<void>, [string]>()
 const mockAddDependency = jest.fn<Promise<TaskDependency>, [string, string]>()
 const mockDeleteDependency = jest.fn<Promise<void>, [string, string]>()
+const mockGetWorkspace = jest.fn<Promise<TaskWorkspacePage>, [object?]>()
+const mockGetRecommendations = jest.fn<Promise<TaskRecommendation[]>, []>()
 
 const createPersistentQueryClient = () =>
   new QueryClient({
@@ -44,6 +53,8 @@ jest.mock('@/lib/api', () => ({
     delete: (id: string) => mockDelete(id),
     addDependency: (taskId: string, dependsOnTaskId: string) => mockAddDependency(taskId, dependsOnTaskId),
     deleteDependency: (taskId: string, dependencyId: string) => mockDeleteDependency(taskId, dependencyId),
+    getWorkspace: (filters?: object) => mockGetWorkspace(filters),
+    getRecommendations: () => mockGetRecommendations(),
   },
 }))
 
@@ -58,6 +69,8 @@ import {
   useDeleteTask,
   useAddTaskDependency,
   useDeleteTaskDependency,
+  useTaskRecommendations,
+  useTaskWorkspace,
   taskKeys,
 } from '../use-tasks-query'
 
@@ -74,6 +87,30 @@ describe('taskKeys', () => {
     expect(taskKeys.all).toEqual(['tasks'])
     expect(taskKeys.details()).toEqual(['tasks', 'detail'])
     expect(taskKeys.detail('task-1')).toEqual(['tasks', 'detail', 'task-1'])
+  })
+})
+
+describe('workspace queries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('waits for authentication before fetching workspace data', () => {
+    const { result } = renderHookWithClient(() =>
+      useTaskWorkspace({ status: ['pending'] }, false)
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockGetWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('waits for authentication before fetching recommendations', () => {
+    const { result } = renderHookWithClient(() =>
+      useTaskRecommendations(false)
+    )
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(mockGetRecommendations).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/web/src/hooks/use-tasks-query.ts
+++ b/apps/web/src/hooks/use-tasks-query.ts
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { DEFAULT_TASK_PAGE_LIMIT, tasksApi } from '@/lib/api'
 import type { QueryClient, Query } from '@tanstack/react-query'
-import type { Task, TaskCreate, TaskUpdate, TaskDependency } from '@/types/task'
+import type { Task, TaskCreate, TaskUpdate, TaskDependency, TaskWorkspaceFilters } from '@/types/task'
 import type { SortOptions } from '@/types/sort'
 
 /**
@@ -14,6 +14,8 @@ export const taskKeys = {
   detail: (id: string) => [...taskKeys.details(), id] as const,
   byGoal: (goalId: string) => [...taskKeys.all, 'goal', goalId] as const,
   byProject: (projectId: string) => [...taskKeys.all, 'project', projectId] as const,
+  workspace: (filters: TaskWorkspaceFilters) => [...taskKeys.all, 'workspace', filters] as const,
+  recommendations: () => [...taskKeys.all, 'recommendations'] as const,
 }
 
 const isTaskGoalQuery = (query: Query) =>
@@ -30,6 +32,24 @@ const invalidateTaskCollections = (queryClient: QueryClient, goalId?: string) =>
   }
 
   queryClient.invalidateQueries({ predicate: isTaskProjectQuery })
+  queryClient.invalidateQueries({ queryKey: [...taskKeys.all, 'workspace'] })
+  queryClient.invalidateQueries({ queryKey: taskKeys.recommendations() })
+}
+
+export function useTaskWorkspace(filters: TaskWorkspaceFilters) {
+  return useQuery({
+    queryKey: taskKeys.workspace(filters),
+    queryFn: () => tasksApi.getWorkspace(filters),
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useTaskRecommendations() {
+  return useQuery({
+    queryKey: taskKeys.recommendations(),
+    queryFn: () => tasksApi.getRecommendations(),
+    staleTime: 60 * 1000,
+  })
 }
 
 const updateTaskInList = (
@@ -194,7 +214,7 @@ export function useUpdateTask() {
   return useMutation({
     mutationFn: ({ id, data }: { id: string; data: TaskUpdate }) =>
       tasksApi.update(id, data),
-    onSuccess: (updatedTask: Task) => {
+    onSuccess: (updatedTask: Task, variables) => {
       // Update the cached task
       queryClient.setQueryData(
         taskKeys.detail(updatedTask.id),
@@ -202,7 +222,10 @@ export function useUpdateTask() {
       )
 
       // Invalidate task collections to reflect changes in goal and project views.
-      invalidateTaskCollections(queryClient, updatedTask.goal_id)
+      invalidateTaskCollections(
+        queryClient,
+        variables.data.goal_id ? undefined : updatedTask.goal_id
+      )
     },
   })
 }

--- a/apps/web/src/hooks/use-tasks-query.ts
+++ b/apps/web/src/hooks/use-tasks-query.ts
@@ -36,18 +36,20 @@ const invalidateTaskCollections = (queryClient: QueryClient, goalId?: string) =>
   queryClient.invalidateQueries({ queryKey: taskKeys.recommendations() })
 }
 
-export function useTaskWorkspace(filters: TaskWorkspaceFilters) {
+export function useTaskWorkspace(filters: TaskWorkspaceFilters, enabled = true) {
   return useQuery({
     queryKey: taskKeys.workspace(filters),
     queryFn: () => tasksApi.getWorkspace(filters),
+    enabled,
     staleTime: 30 * 1000,
   })
 }
 
-export function useTaskRecommendations() {
+export function useTaskRecommendations(enabled = true) {
   return useQuery({
     queryKey: taskKeys.recommendations(),
     queryFn: () => tasksApi.getRecommendations(),
+    enabled,
     staleTime: 60 * 1000,
   })
 }

--- a/apps/web/src/lib/__tests__/tasks-api.test.ts
+++ b/apps/web/src/lib/__tests__/tasks-api.test.ts
@@ -117,4 +117,42 @@ describe('tasksApi', () => {
 
     expect(task.estimate_hours).toBe(0)
   })
+
+  it('loads the cross-project workspace with filters in one request', async () => {
+    mockFetchWithFallback.mockResolvedValueOnce(
+      mockJsonResponse({
+        items: [
+          rawTask({
+            estimate_hours: '3.50',
+            remaining_estimate_hours: '2.25',
+            project_id: 'project-1',
+            project_title: 'Project 1',
+            goal_title: 'Goal 1',
+            is_blocked: false,
+            blocking_task_ids: [],
+            last_worked_at: null,
+            planned_today: true,
+            planned_this_week: true,
+          }),
+        ],
+        total: 1,
+        skip: 0,
+        limit: 50,
+      })
+    )
+
+    const page = await tasksApi.getWorkspace({
+      status: ['pending', 'in_progress'],
+      projectId: 'project-1',
+      search: 'workspace',
+    })
+
+    expect(mockFetchWithFallback).toHaveBeenCalledTimes(1)
+    expect(mockFetchWithFallback.mock.calls[0]?.[0]).toContain(
+      '/api/tasks?status=pending&status=in_progress&project_id=project-1&search=workspace'
+    )
+    expect(page.items[0]).toEqual(
+      expect.objectContaining({ estimate_hours: 3.5, remaining_estimate_hours: 2.25 })
+    )
+  })
 })

--- a/apps/web/src/lib/__tests__/tasks-api.test.ts
+++ b/apps/web/src/lib/__tests__/tasks-api.test.ts
@@ -144,12 +144,14 @@ describe('tasksApi', () => {
     const page = await tasksApi.getWorkspace({
       status: ['pending', 'in_progress'],
       projectId: 'project-1',
+      projectStatus: 'in_progress',
+      plan: 'today',
       search: 'workspace',
     })
 
     expect(mockFetchWithFallback).toHaveBeenCalledTimes(1)
     expect(mockFetchWithFallback.mock.calls[0]?.[0]).toContain(
-      '/api/tasks?status=pending&status=in_progress&project_id=project-1&search=workspace'
+      '/api/tasks?status=pending&status=in_progress&project_id=project-1&project_status=in_progress&search=workspace&plan=today'
     )
     expect(page.items[0]).toEqual(
       expect.objectContaining({ estimate_hours: 3.5, remaining_estimate_hours: 2.25 })

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -15,6 +15,10 @@ import type {
   TaskCreate,
   TaskUpdate,
   TaskDependency,
+  TaskRecommendation,
+  TaskWorkspaceFilters,
+  TaskWorkspaceItem,
+  TaskWorkspacePage,
 } from "@/types/task";
 import type { Log, LogCreate, LogUpdate } from "@/types/log";
 import type {
@@ -125,6 +129,22 @@ const normalizeTask = (task: RawTask): Task => ({
 });
 
 const normalizeTasks = (tasks: RawTask[]): Task[] => tasks.map(normalizeTask);
+
+type RawWorkspaceItem = Omit<
+  TaskWorkspaceItem,
+  "estimate_hours" | "remaining_estimate_hours"
+> & {
+  estimate_hours: number | string | null | undefined;
+  remaining_estimate_hours: number | string | null | undefined;
+};
+
+const normalizeWorkspaceItem = (task: RawWorkspaceItem): TaskWorkspaceItem => ({
+  ...task,
+  estimate_hours: normalizeEstimateHours(task.estimate_hours),
+  remaining_estimate_hours: normalizeEstimateHours(
+    task.remaining_estimate_hours,
+  ),
+});
 
 // Helper function to ensure HTTPS protocol
 const ensureHttps = (url: string): string => {
@@ -521,6 +541,42 @@ class ApiClient {
       `/api/tasks/project/${projectId}?${params.toString()}`,
     );
     return normalizeTasks(tasks);
+  }
+
+  async getTaskWorkspace(
+    filters: TaskWorkspaceFilters = {},
+  ): Promise<TaskWorkspacePage> {
+    const params = new URLSearchParams();
+    if (filters.skip !== undefined) params.set("skip", String(filters.skip));
+    if (filters.limit !== undefined) params.set("limit", String(filters.limit));
+    filters.status?.forEach((status) => params.append("status", status));
+    if (filters.projectId) params.set("project_id", filters.projectId);
+    if (filters.goalId) params.set("goal_id", filters.goalId);
+    if (filters.dueBefore) params.set("due_before", filters.dueBefore);
+    if (filters.dueAfter) params.set("due_after", filters.dueAfter);
+    if (filters.search) params.set("search", filters.search);
+    if (filters.blocked !== undefined)
+      params.set("blocked", String(filters.blocked));
+    if (filters.sortBy) params.set("sort_by", filters.sortBy);
+    if (filters.sortOrder) params.set("sort_order", filters.sortOrder);
+
+    const page = await this.request<{
+      items: RawWorkspaceItem[];
+      total: number;
+      skip: number;
+      limit: number;
+    }>(`/api/tasks?${params.toString()}`);
+    return { ...page, items: page.items.map(normalizeWorkspaceItem) };
+  }
+
+  async getTaskRecommendations(): Promise<TaskRecommendation[]> {
+    const recommendations = await this.request<
+      Array<Omit<TaskRecommendation, "task"> & { task: RawWorkspaceItem }>
+    >("/api/tasks/recommendations");
+    return recommendations.map((recommendation) => ({
+      ...recommendation,
+      task: normalizeWorkspaceItem(recommendation.task),
+    }));
   }
 
   async getTask(taskId: string): Promise<Task> {
@@ -1692,6 +1748,9 @@ export const goalsApi = {
  * Provides methods for task CRUD and dependency operations.
  */
 export const tasksApi = {
+  getWorkspace: (filters?: TaskWorkspaceFilters) =>
+    apiClient.getTaskWorkspace(filters),
+  getRecommendations: () => apiClient.getTaskRecommendations(),
   getByGoal: (
     goalId: string,
     skip?: number,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -551,12 +551,15 @@ class ApiClient {
     if (filters.limit !== undefined) params.set("limit", String(filters.limit));
     filters.status?.forEach((status) => params.append("status", status));
     if (filters.projectId) params.set("project_id", filters.projectId);
+    if (filters.projectStatus)
+      params.set("project_status", filters.projectStatus);
     if (filters.goalId) params.set("goal_id", filters.goalId);
     if (filters.dueBefore) params.set("due_before", filters.dueBefore);
     if (filters.dueAfter) params.set("due_after", filters.dueAfter);
     if (filters.search) params.set("search", filters.search);
     if (filters.blocked !== undefined)
       params.set("blocked", String(filters.blocked));
+    if (filters.plan) params.set("plan", filters.plan);
     if (filters.sortBy) params.set("sort_by", filters.sortBy);
     if (filters.sortOrder) params.set("sort_order", filters.sortOrder);
 

--- a/apps/web/src/types/task.ts
+++ b/apps/web/src/types/task.ts
@@ -151,11 +151,13 @@ export interface TaskWorkspaceFilters {
   limit?: number;
   status?: TaskStatus[];
   projectId?: string;
+  projectStatus?: 'pending' | 'in_progress' | 'completed' | 'cancelled';
   goalId?: string;
   dueBefore?: string;
   dueAfter?: string;
   search?: string;
   blocked?: boolean;
+  plan?: 'today' | 'week' | 'unplanned';
   sortBy?: 'due_date' | 'priority' | 'status' | 'title' | 'updated_at';
   sortOrder?: 'asc' | 'desc';
 }

--- a/apps/web/src/types/task.ts
+++ b/apps/web/src/types/task.ts
@@ -123,6 +123,47 @@ export interface TaskUpdate {
   work_type?: WorkType;
   /** 優先度 (1:最高 〜 5:最低) */
   priority?: number;
+  /** 移動先ゴールID */
+  goal_id?: string;
+}
+
+export interface TaskWorkspaceItem extends Task {
+  project_id: string;
+  project_title: string;
+  goal_title: string;
+  remaining_estimate_hours: number;
+  is_blocked: boolean;
+  blocking_task_ids: string[];
+  last_worked_at: string | null;
+  planned_today: boolean;
+  planned_this_week: boolean;
+}
+
+export interface TaskWorkspacePage {
+  items: TaskWorkspaceItem[];
+  total: number;
+  skip: number;
+  limit: number;
+}
+
+export interface TaskWorkspaceFilters {
+  skip?: number;
+  limit?: number;
+  status?: TaskStatus[];
+  projectId?: string;
+  goalId?: string;
+  dueBefore?: string;
+  dueAfter?: string;
+  search?: string;
+  blocked?: boolean;
+  sortBy?: 'due_date' | 'priority' | 'status' | 'title' | 'updated_at';
+  sortOrder?: 'asc' | 'desc';
+}
+
+export interface TaskRecommendation {
+  task: TaskWorkspaceItem;
+  score: number;
+  reason: string;
 }
 
 /**


### PR DESCRIPTION
## 概要

Issue #318 で定義された第一段階MVPとして、プロジェクト階層を横断してタスクを検索・調整・開始できるタスクワークスペースを追加します。

Refs #318

## 変更内容

- `GET /api/tasks` に全プロジェクト横断のJOIN・検索・フィルタ・ソート・ページネーションを追加
- プロジェクト/ゴール名、残り見積、ブロック状態、最終作業日時、今日/今週の計画状態をレスポンスへ追加
- 読み取り専用の決定論的な次タスク推薦と理由を最大3件返すエンドポイントを追加
- タスク更新APIで `goal_id` を受け付け、移動先ゴールの所有権を検証
- `/tasks` ワークスペースと主要ナビゲーション導線を追加
- 検索、プロジェクト/ゴール/状態/期限/ブロック状態のプリセット絞り込みを追加
- ステータス、優先度、期限、見積時間、所属ゴールのインライン編集を追加
- 詳細ダイアログ、Inbox（Quick Task）表示、通常タスクへの変換を追加
- ワークスペースからRunnerを開始できる導線を追加
- Runnerの全タスク選択をプロジェクトごとの複数API呼び出しから全タスクAPI 1回へ変更

## 影響

管理構造（Project → Goal → Task）と既存画面は維持したまま、実行時に階層をまたいでタスクを操作できます。所属変更でもログ、依存関係、作業セッションはタスクIDに紐づいたまま保持されます。推薦はデータを変更せず、順位の根拠を表示します。

## 検証

- API全テスト: `uv run --project apps/api pytest -s apps/api/tests -q`
- 追加・関連APIテスト: 10 passed
- Ruff / Ruff format / mypy
- Web型チェック: `pnpm --filter @human-compiler/web type-check`
- Web関連Jest: 26 passed
- Next.js production build: `pnpm --filter @human-compiler/web build`

## 既知事項

フロントエンド全テストでは既存の `use-project-page-state.test.ts` の「project loading中にprogressを取得しない」1件が失敗します。今回の変更対象外で、当該テスト単独でも再現します。今回追加・変更したテストはすべて成功しています。

## MVP後の範囲

Issue本文でMVP後とされている一括操作、自然言語一括変更、編集可能な週次計画はこのPRには含めていません。