### PR TITLE
クイックタスクの完了操作を追加

### DIFF
--- a/apps/web/src/components/quick-tasks/__tests__/quick-task-list.test.tsx
+++ b/apps/web/src/components/quick-tasks/__tests__/quick-task-list.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { toast } from '@/hooks/use-toast';
 import { quickTasksApi } from '@/lib/api';
@@ -42,6 +42,12 @@ const task: QuickTask = {
   priority: 3,
   created_at: '2026-07-16T00:00:00Z',
   updated_at: '2026-07-16T00:00:00Z',
+};
+
+const otherTask: QuickTask = {
+  ...task,
+  id: 'quick-task-2',
+  title: '別のテストタスク',
 };
 
 describe('QuickTaskList completion', () => {
@@ -87,5 +93,36 @@ describe('QuickTaskList completion', () => {
       );
     });
     expect(screen.getByText(task.title)).toBeInTheDocument();
+  });
+
+  it('allows different quick tasks to be completed concurrently', async () => {
+    jest.mocked(quickTasksApi.getAll).mockResolvedValue([task, otherTask]);
+
+    let resolveFirst!: (value: QuickTask) => void;
+    let resolveSecond!: (value: QuickTask) => void;
+    jest.mocked(quickTasksApi.update)
+      .mockImplementationOnce(
+        () => new Promise((resolve) => {
+          resolveFirst = resolve;
+        })
+      )
+      .mockImplementationOnce(
+        () => new Promise((resolve) => {
+          resolveSecond = resolve;
+        })
+      );
+
+    render(<QuickTaskList />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '「テストタスク」を完了' }));
+    fireEvent.click(screen.getByRole('button', { name: '「別のテストタスク」を完了' }));
+
+    expect(quickTasksApi.update).toHaveBeenNthCalledWith(1, task.id, { status: 'completed' });
+    expect(quickTasksApi.update).toHaveBeenNthCalledWith(2, otherTask.id, { status: 'completed' });
+
+    await act(async () => {
+      resolveFirst({ ...task, status: 'completed' });
+      resolveSecond({ ...otherTask, status: 'completed' });
+    });
   });
 });

--- a/apps/web/src/components/quick-tasks/__tests__/quick-task-list.test.tsx
+++ b/apps/web/src/components/quick-tasks/__tests__/quick-task-list.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { toast } from '@/hooks/use-toast';
+import { quickTasksApi } from '@/lib/api';
+import type { QuickTask } from '@/types/quick-task';
+import { QuickTaskList } from '../quick-task-list';
+
+jest.mock('@/lib/api', () => ({
+  quickTasksApi: {
+    getAll: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  toast: jest.fn(),
+}));
+
+jest.mock('@/lib/logger', () => ({
+  log: {
+    error: jest.fn(),
+  },
+}));
+
+jest.mock('../quick-task-form-dialog', () => ({
+  QuickTaskFormDialog: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+const task: QuickTask = {
+  id: 'quick-task-1',
+  owner_id: 'user-1',
+  title: 'テストタスク',
+  description: null,
+  estimate_hours: 0.5,
+  due_date: null,
+  status: 'pending',
+  work_type: 'light_work',
+  priority: 3,
+  created_at: '2026-07-16T00:00:00Z',
+  updated_at: '2026-07-16T00:00:00Z',
+};
+
+describe('QuickTaskList completion', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(quickTasksApi.getAll).mockResolvedValue([task]);
+  });
+
+  it('marks a quick task as completed and removes it from the active list', async () => {
+    jest.mocked(quickTasksApi.update).mockResolvedValue({
+      ...task,
+      status: 'completed',
+    });
+
+    render(<QuickTaskList />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '「テストタスク」を完了' }));
+
+    await waitFor(() => {
+      expect(quickTasksApi.update).toHaveBeenCalledWith(task.id, { status: 'completed' });
+    });
+    await waitFor(() => {
+      expect(screen.queryByText(task.title)).not.toBeInTheDocument();
+    });
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'クイックタスクを完了しました' })
+    );
+  });
+
+  it('keeps the quick task visible when completion fails', async () => {
+    jest.mocked(quickTasksApi.update).mockRejectedValue(new Error('network error'));
+
+    render(<QuickTaskList />);
+
+    fireEvent.click(await screen.findByRole('button', { name: '「テストタスク」を完了' }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'エラー',
+          variant: 'destructive',
+        })
+      );
+    });
+    expect(screen.getByText(task.title)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/quick-tasks/quick-task-card.tsx
+++ b/apps/web/src/components/quick-tasks/quick-task-card.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Clock, Flag, Calendar, MoreVertical, Inbox } from 'lucide-react';
+import { Check, Clock, Flag, Calendar, MoreVertical, Inbox, Loader2 } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,6 +25,8 @@ export interface QuickTaskCardProps {
   onEdit?: (task: QuickTask) => void;
   onDelete?: (task: QuickTask) => void;
   onConvert?: (task: QuickTask) => void;
+  onComplete?: (task: QuickTask) => void;
+  isCompleting?: boolean;
 }
 
 export function QuickTaskCard({
@@ -32,6 +34,8 @@ export function QuickTaskCard({
   onEdit,
   onDelete,
   onConvert,
+  onComplete,
+  isCompleting = false,
 }: QuickTaskCardProps) {
   const hasBadges = task.status || task.work_type;
   const hasMetadata = task.estimate_hours !== undefined || task.priority !== undefined || task.due_date;
@@ -41,6 +45,24 @@ export function QuickTaskCard({
       <CardContent className="p-4 space-y-2">
         <div className="flex items-start justify-between gap-2">
           <div className="flex items-center gap-2 min-w-0">
+            {onComplete && (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-7 w-7 flex-shrink-0 rounded-full"
+                onClick={() => onComplete(task)}
+                disabled={isCompleting}
+                aria-label={`「${task.title}」を完了`}
+                title="完了にする"
+              >
+                {isCompleting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Check className="h-4 w-4" />
+                )}
+              </Button>
+            )}
             <Inbox className="h-4 w-4 text-muted-foreground flex-shrink-0" />
             <span className="font-medium text-sm truncate">{task.title}</span>
           </div>

--- a/apps/web/src/components/quick-tasks/quick-task-list.tsx
+++ b/apps/web/src/components/quick-tasks/quick-task-list.tsx
@@ -32,7 +32,7 @@ export function QuickTaskList({
   const [editingTask, setEditingTask] = useState<QuickTask | null>(null);
   const [deletingTask, setDeletingTask] = useState<QuickTask | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [completingTaskId, setCompletingTaskId] = useState<string | null>(null);
+  const [completingTaskIds, setCompletingTaskIds] = useState<Set<string>>(new Set());
 
   const fetchTasks = useCallback(async () => {
     setIsLoading(true);
@@ -71,9 +71,9 @@ export function QuickTaskList({
   };
 
   const handleTaskComplete = async (task: QuickTask) => {
-    if (completingTaskId) return;
+    if (completingTaskIds.has(task.id)) return;
 
-    setCompletingTaskId(task.id);
+    setCompletingTaskIds((prev) => new Set(prev).add(task.id));
     try {
       await quickTasksApi.update(task.id, { status: 'completed' });
       setTasks((prev) => prev.filter((item) => item.id !== task.id));
@@ -92,7 +92,11 @@ export function QuickTaskList({
         variant: 'destructive',
       });
     } finally {
-      setCompletingTaskId(null);
+      setCompletingTaskIds((prev) => {
+        const next = new Set(prev);
+        next.delete(task.id);
+        return next;
+      });
     }
   };
 
@@ -189,7 +193,7 @@ export function QuickTaskList({
                   onDelete={setDeletingTask}
                   onConvert={onConvertToTask}
                   onComplete={handleTaskComplete}
-                  isCompleting={completingTaskId === task.id}
+                  isCompleting={completingTaskIds.has(task.id)}
                 />
               ))}
             </div>

--- a/apps/web/src/components/quick-tasks/quick-task-list.tsx
+++ b/apps/web/src/components/quick-tasks/quick-task-list.tsx
@@ -32,6 +32,7 @@ export function QuickTaskList({
   const [editingTask, setEditingTask] = useState<QuickTask | null>(null);
   const [deletingTask, setDeletingTask] = useState<QuickTask | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [completingTaskId, setCompletingTaskId] = useState<string | null>(null);
 
   const fetchTasks = useCallback(async () => {
     setIsLoading(true);
@@ -60,10 +61,39 @@ export function QuickTaskList({
   };
 
   const handleTaskUpdated = (updatedTask: QuickTask) => {
-    setTasks((prev) =>
-      prev.map((task) => (task.id === updatedTask.id ? updatedTask : task))
-    );
+    setTasks((prev) => {
+      if (updatedTask.status === 'completed' || updatedTask.status === 'cancelled') {
+        return prev.filter((task) => task.id !== updatedTask.id);
+      }
+      return prev.map((task) => (task.id === updatedTask.id ? updatedTask : task));
+    });
     setEditingTask(null);
+  };
+
+  const handleTaskComplete = async (task: QuickTask) => {
+    if (completingTaskId) return;
+
+    setCompletingTaskId(task.id);
+    try {
+      await quickTasksApi.update(task.id, { status: 'completed' });
+      setTasks((prev) => prev.filter((item) => item.id !== task.id));
+      toast({
+        title: 'クイックタスクを完了しました',
+        description: `「${task.title}」を完了にしました。`,
+      });
+    } catch (err) {
+      log.error('Failed to complete quick task', err, {
+        component: 'QuickTaskList',
+        taskId: task.id,
+      });
+      toast({
+        title: 'エラー',
+        description: 'クイックタスクを完了できませんでした。再試行してください。',
+        variant: 'destructive',
+      });
+    } finally {
+      setCompletingTaskId(null);
+    }
   };
 
   const handleDeleteConfirm = async () => {
@@ -158,6 +188,8 @@ export function QuickTaskList({
                   onEdit={setEditingTask}
                   onDelete={setDeletingTask}
                   onConvert={onConvertToTask}
+                  onComplete={handleTaskComplete}
+                  isCompleting={completingTaskId === task.id}
                 />
               ))}
             </div>


### PR DESCRIPTION
## 概要

クイックタスクを一覧から直接完了できる操作を追加しました。

## 背景・原因

クイックタスクAPIは既に `status: completed` への更新をサポートしていましたが、Web画面には完了操作への導線がなく、利用者がクイックタスクを完了できませんでした。

## 変更内容

- クイックタスクカードにアクセシブルな完了ボタンを追加
- 完了APIの処理中にローディング表示し、重複操作を防止
- 完了成功時にアクティブ一覧からタスクを除外して成功通知を表示
- 完了失敗時はタスクを一覧に残し、再試行可能なエラー通知を表示
- 編集によって完了・キャンセル状態になった場合もアクティブ一覧から除外
- 成功・失敗のコンポーネントテストを追加

## 利用者への影響

利用者はクイックタスクカードのチェックボタンを押すだけでタスクを完了でき、完了済みタスクは現在のアクティブ一覧から自動的に消えます。

## 検証

- `pnpm test -- --runInBand src/components/quick-tasks/__tests__/quick-task-list.test.tsx`
- `pnpm type-check`
- 対象ファイルの ESLint
- `git diff --check`

すべて成功しています。ローカルNode.jsはプロジェクト指定の24系ではなく20系だったためエンジン警告が出ましたが、検証結果には影響していません。