### PR TITLE
feat(tasks): タスクのReady状態と依存関係を可視化

### DIFF
--- a/apps/api/src/humancompiler_api/models.py
+++ b/apps/api/src/humancompiler_api/models.py
@@ -1088,6 +1088,7 @@ class TaskWorkspaceItem(TaskResponse):
     goal_title: str
     remaining_estimate_hours: Decimal = Field(ge=0)
     is_blocked: bool = False
+    is_ready: bool = False
     blocking_task_ids: list[UUID] = Field(default_factory=list)
     last_worked_at: datetime | None = None
     planned_today: bool = False
@@ -1106,6 +1107,65 @@ class TaskWorkspacePage(BaseModel):
     total: int
     skip: int
     limit: int
+
+
+class TaskWorkspaceSummary(BaseModel):
+    """Counts used by the task workspace decision filters."""
+
+    total: int = 0
+    ready: int = 0
+    blocked: int = 0
+    in_progress: int = 0
+    overdue: int = 0
+
+
+class TaskDependencyContextTask(BaseModel):
+    """Task and hierarchy information shown in dependency context panels."""
+
+    id: UUID
+    title: str
+    status: TaskStatus
+    project_id: UUID
+    project_title: str
+    goal_id: UUID
+    goal_title: str
+    is_ready: bool = False
+    is_blocked: bool = False
+
+
+class TaskDependencyContext(BaseModel):
+    """Both directions of a task dependency relationship."""
+
+    prerequisites: list[TaskDependencyContextTask] = Field(default_factory=list)
+    dependents: list[TaskDependencyContextTask] = Field(default_factory=list)
+
+
+class TaskDependencyGraphNode(TaskDependencyContextTask):
+    """A task node in the filtered dependency graph."""
+
+    priority: int
+    due_date: datetime | None = None
+    is_context: bool = False
+
+
+class TaskDependencyGraphEdge(BaseModel):
+    """Directed dependency edge from prerequisite to dependent task."""
+
+    id: UUID
+    prerequisite_task_id: UUID
+    dependent_task_id: UUID
+    prerequisite_status: TaskStatus
+
+
+class TaskDependencyGraphResponse(BaseModel):
+    """Bounded graph payload for the task dependency map."""
+
+    nodes: list[TaskDependencyGraphNode] = Field(default_factory=list)
+    edges: list[TaskDependencyGraphEdge] = Field(default_factory=list)
+    total: int = 0
+    node_count: int = 0
+    exceeds_limit: bool = False
+    limit: int = 200
 
 
 class TaskRecommendation(BaseModel):

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -366,7 +366,7 @@ async def get_task_dependency_graph(
         else:
             excluded_task_ids = _valid_task_uuids(today_ids | week_ids)
 
-    rows, total = task_service.get_workspace_tasks(
+    tasks, total = task_service.get_workspace_graph_tasks(
         session,
         current_user.user_id,
         limit=DEPENDENCY_GRAPH_NODE_LIMIT + 1,
@@ -388,7 +388,7 @@ async def get_task_dependency_graph(
             limit=DEPENDENCY_GRAPH_NODE_LIMIT,
         )
 
-    root_ids = {row[0].id for row in rows if row[0].id}
+    root_ids = {task.id for task in tasks if task.id}
     if not root_ids:
         return TaskDependencyGraphResponse(total=0, node_count=0)
 

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -201,15 +201,6 @@ def _context_task(
     )
 
 
-def _is_overdue(task: Task, now: datetime) -> bool:
-    if task.status not in ACTIONABLE_TASK_STATUSES or task.due_date is None:
-        return False
-    due_date = task.due_date
-    if due_date.tzinfo is None:
-        due_date = due_date.replace(tzinfo=UTC)
-    return due_date < now
-
-
 def build_workspace_items(
     session: Session,
     rows: list[tuple[Task, object, object, int, datetime | None]],
@@ -340,34 +331,14 @@ async def get_task_workspace_summary(
     search: Annotated[str | None, Query(max_length=200)] = None,
 ) -> TaskWorkspaceSummary:
     """Return decision-oriented counts for the current workspace scope."""
-    rows, total = task_service.get_workspace_tasks(
+    counts = task_service.get_workspace_summary_counts(
         session,
         current_user.user_id,
-        limit=1_000_000,
         project_id=project_id,
         goal_id=goal_id,
         search=search,
     )
-    tasks = [row[0] for row in rows]
-    task_ids = [task.id for task in tasks if task.id]
-    dependencies = task_service.get_task_dependencies_batch(
-        session, task_ids, current_user.user_id
-    )
-    now = datetime.now(UTC)
-    summary = TaskWorkspaceSummary(total=total)
-    for task in tasks:
-        is_ready, is_blocked, _ = _dependency_state(
-            task, dependencies.get(str(task.id), [])
-        )
-        if is_ready:
-            summary.ready += 1
-        if is_blocked and task.status in ACTIONABLE_TASK_STATUSES:
-            summary.blocked += 1
-        if task.status == TaskStatus.IN_PROGRESS:
-            summary.in_progress += 1
-        if _is_overdue(task, now):
-            summary.overdue += 1
-    return summary
+    return TaskWorkspaceSummary(**counts)
 
 
 @router.get("/dependency-graph", response_model=TaskDependencyGraphResponse)
@@ -649,9 +620,7 @@ async def get_task_dependency_context(
     current_user: Annotated[AuthUser, Depends(get_current_user)],
 ) -> TaskDependencyContext:
     """Return prerequisite and dependent tasks with hierarchy information."""
-    task = task_service.get_task(session, task_id, current_user.user_id)
-    if not task:
-        return TaskDependencyContext()
+    task_service.get_task(session, task_id, current_user.user_id)
 
     relationships = list(
         session.exec(

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Query, status
-from sqlmodel import Session, select
+from sqlmodel import Session, or_, select
 
 from humancompiler_api.auth import AuthUser, get_current_user
 from humancompiler_api.database import db
@@ -17,6 +17,12 @@ from humancompiler_api.models import (
     TaskResponse,
     TaskUpdate,
     TaskDependencyCreate,
+    TaskDependency,
+    TaskDependencyContext,
+    TaskDependencyContextTask,
+    TaskDependencyGraphEdge,
+    TaskDependencyGraphNode,
+    TaskDependencyGraphResponse,
     TaskDependencyResponse,
     TaskDependencyTaskInfo,
     SortBy,
@@ -27,10 +33,13 @@ from humancompiler_api.models import (
     ProjectStatus,
     TaskWorkspaceItem,
     TaskWorkspacePage,
+    TaskWorkspaceSummary,
     TaskWorkspacePlanFilter,
     TaskWorkspaceSortBy,
     Schedule,
     WeeklySchedule,
+    Goal,
+    Project,
 )
 from humancompiler_api.services import task_service
 
@@ -38,6 +47,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 APP_TIMEZONE = ZoneInfo("Asia/Tokyo")
+DEPENDENCY_GRAPH_NODE_LIMIT = 200
+ACTIONABLE_TASK_STATUSES = {TaskStatus.PENDING, TaskStatus.IN_PROGRESS}
 
 
 def get_session() -> Generator[Session, None, None]:
@@ -139,6 +150,66 @@ def _valid_task_uuids(task_ids: set[str]) -> set[UUID]:
     return valid_ids
 
 
+def _dependency_state(
+    task: Task, dependencies: list[TaskDependency]
+) -> tuple[bool, bool, list[UUID]]:
+    """Return ready, blocked and blocker IDs using the canonical task rule."""
+    blocking_task_ids = [
+        dependency.depends_on_task.id
+        for dependency in dependencies
+        if dependency.depends_on_task
+        and dependency.depends_on_task.status != TaskStatus.COMPLETED
+        and dependency.depends_on_task.id is not None
+    ]
+    is_blocked = bool(blocking_task_ids)
+    is_ready = task.status in ACTIONABLE_TASK_STATUSES and not is_blocked
+    return is_ready, is_blocked, blocking_task_ids
+
+
+def _owned_task_hierarchy(
+    session: Session, owner_id: str | UUID, task_ids: set[UUID]
+) -> dict[UUID, tuple[Task, Goal, Project]]:
+    """Load owned tasks and their hierarchy in one query."""
+    if not task_ids:
+        return {}
+    rows = session.exec(
+        select(Task, Goal, Project)
+        .join(Goal, Task.goal_id == Goal.id)
+        .join(Project, Goal.project_id == Project.id)
+        .where(Project.owner_id == UUID(str(owner_id)), Task.id.in_(task_ids))
+    ).all()
+    return {task.id: (task, goal, project) for task, goal, project in rows if task.id}
+
+
+def _context_task(
+    task: Task,
+    goal: Goal,
+    project: Project,
+    dependencies: list[TaskDependency],
+) -> TaskDependencyContextTask:
+    is_ready, is_blocked, _ = _dependency_state(task, dependencies)
+    return TaskDependencyContextTask(
+        id=task.id,
+        title=task.title,
+        status=task.status,
+        project_id=project.id,
+        project_title=project.title,
+        goal_id=goal.id,
+        goal_title=goal.title,
+        is_ready=is_ready,
+        is_blocked=is_blocked,
+    )
+
+
+def _is_overdue(task: Task, now: datetime) -> bool:
+    if task.status not in ACTIONABLE_TASK_STATUSES or task.due_date is None:
+        return False
+    due_date = task.due_date
+    if due_date.tzinfo is None:
+        due_date = due_date.replace(tzinfo=UTC)
+    return due_date < now
+
+
 def build_workspace_items(
     session: Session,
     rows: list[tuple[Task, object, object, int, datetime | None]],
@@ -161,18 +232,18 @@ def build_workspace_items(
         task_response = TaskResponse.model_validate(task)
         task_dependencies = dependencies.get(str(task.id), [])
         dependency_responses = []
-        blocking_task_ids = []
         for dependency in task_dependencies:
             dependency_response = TaskDependencyResponse.model_validate(dependency)
             if dependency.depends_on_task:
                 dependency_response.depends_on_task = (
                     TaskDependencyTaskInfo.model_validate(dependency.depends_on_task)
                 )
-                if dependency.depends_on_task.status != TaskStatus.COMPLETED:
-                    blocking_task_ids.append(dependency.depends_on_task.id)
             dependency_responses.append(dependency_response)
 
         task_response.dependencies = dependency_responses
+        is_ready, is_blocked, blocking_task_ids = _dependency_state(
+            task, task_dependencies
+        )
         remaining = max(
             Decimal("0"),
             task.estimate_hours - (Decimal(str(actual_minutes)) / Decimal("60")),
@@ -184,7 +255,8 @@ def build_workspace_items(
                 project_title=project.title,
                 goal_title=goal.title,
                 remaining_estimate_hours=remaining.quantize(Decimal("0.01")),
-                is_blocked=bool(blocking_task_ids),
+                is_blocked=is_blocked,
+                is_ready=is_ready,
                 blocking_task_ids=blocking_task_ids,
                 last_worked_at=last_worked_at,
                 planned_today=str(task.id) in today_ids,
@@ -256,6 +328,159 @@ async def get_task_workspace(
         total=total,
         skip=skip,
         limit=limit,
+    )
+
+
+@router.get("/summary", response_model=TaskWorkspaceSummary)
+async def get_task_workspace_summary(
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+    project_id: UUID | None = None,
+    goal_id: UUID | None = None,
+    search: Annotated[str | None, Query(max_length=200)] = None,
+) -> TaskWorkspaceSummary:
+    """Return decision-oriented counts for the current workspace scope."""
+    rows, total = task_service.get_workspace_tasks(
+        session,
+        current_user.user_id,
+        limit=1_000_000,
+        project_id=project_id,
+        goal_id=goal_id,
+        search=search,
+    )
+    tasks = [row[0] for row in rows]
+    task_ids = [task.id for task in tasks if task.id]
+    dependencies = task_service.get_task_dependencies_batch(
+        session, task_ids, current_user.user_id
+    )
+    now = datetime.now(UTC)
+    summary = TaskWorkspaceSummary(total=total)
+    for task in tasks:
+        is_ready, is_blocked, _ = _dependency_state(
+            task, dependencies.get(str(task.id), [])
+        )
+        if is_ready:
+            summary.ready += 1
+        if is_blocked and task.status in ACTIONABLE_TASK_STATUSES:
+            summary.blocked += 1
+        if task.status == TaskStatus.IN_PROGRESS:
+            summary.in_progress += 1
+        if _is_overdue(task, now):
+            summary.overdue += 1
+    return summary
+
+
+@router.get("/dependency-graph", response_model=TaskDependencyGraphResponse)
+async def get_task_dependency_graph(
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+    task_statuses: Annotated[list[TaskStatus] | None, Query(alias="status")] = None,
+    project_id: UUID | None = None,
+    goal_id: UUID | None = None,
+    due_before: datetime | None = None,
+    due_after: datetime | None = None,
+    search: Annotated[str | None, Query(max_length=200)] = None,
+    blocked: bool | None = None,
+    plan: TaskWorkspacePlanFilter | None = None,
+) -> TaskDependencyGraphResponse:
+    """Return a bounded filtered graph plus directly connected context tasks."""
+    included_task_ids: set[UUID] | None = None
+    excluded_task_ids: set[UUID] | None = None
+    if plan is not None:
+        today_ids, week_ids = _extract_planned_task_ids(session, current_user.user_id)
+        if plan == TaskWorkspacePlanFilter.TODAY:
+            included_task_ids = _valid_task_uuids(today_ids)
+        elif plan == TaskWorkspacePlanFilter.WEEK:
+            included_task_ids = _valid_task_uuids(week_ids)
+        else:
+            excluded_task_ids = _valid_task_uuids(today_ids | week_ids)
+
+    rows, total = task_service.get_workspace_tasks(
+        session,
+        current_user.user_id,
+        limit=DEPENDENCY_GRAPH_NODE_LIMIT + 1,
+        statuses=task_statuses,
+        project_id=project_id,
+        goal_id=goal_id,
+        due_before=due_before,
+        due_after=due_after,
+        search=search,
+        blocked=blocked,
+        included_task_ids=included_task_ids,
+        excluded_task_ids=excluded_task_ids,
+    )
+    if total > DEPENDENCY_GRAPH_NODE_LIMIT:
+        return TaskDependencyGraphResponse(
+            total=total,
+            node_count=total,
+            exceeds_limit=True,
+            limit=DEPENDENCY_GRAPH_NODE_LIMIT,
+        )
+
+    root_ids = {row[0].id for row in rows if row[0].id}
+    if not root_ids:
+        return TaskDependencyGraphResponse(total=0, node_count=0)
+
+    connected_dependencies = list(
+        session.exec(
+            select(TaskDependency).where(
+                or_(
+                    TaskDependency.task_id.in_(root_ids),
+                    TaskDependency.depends_on_task_id.in_(root_ids),
+                )
+            )
+        ).all()
+    )
+    node_ids = set(root_ids)
+    for dependency in connected_dependencies:
+        node_ids.add(dependency.task_id)
+        node_ids.add(dependency.depends_on_task_id)
+
+    if len(node_ids) > DEPENDENCY_GRAPH_NODE_LIMIT:
+        return TaskDependencyGraphResponse(
+            total=total,
+            node_count=len(node_ids),
+            exceeds_limit=True,
+            limit=DEPENDENCY_GRAPH_NODE_LIMIT,
+        )
+
+    hierarchy = _owned_task_hierarchy(session, current_user.user_id, node_ids)
+    owned_node_ids = set(hierarchy)
+    dependencies_by_task = task_service.get_task_dependencies_batch(
+        session, list(owned_node_ids), current_user.user_id
+    )
+    nodes: list[TaskDependencyGraphNode] = []
+    for task_id, (task, goal, project) in hierarchy.items():
+        context = _context_task(
+            task, goal, project, dependencies_by_task.get(str(task_id), [])
+        )
+        nodes.append(
+            TaskDependencyGraphNode(
+                **context.model_dump(),
+                priority=task.priority,
+                due_date=task.due_date,
+                is_context=task_id not in root_ids,
+            )
+        )
+
+    edges = [
+        TaskDependencyGraphEdge(
+            id=dependency.id,
+            prerequisite_task_id=dependency.depends_on_task_id,
+            dependent_task_id=dependency.task_id,
+            prerequisite_status=hierarchy[dependency.depends_on_task_id][0].status,
+        )
+        for dependency in connected_dependencies
+        if dependency.id
+        and dependency.task_id in owned_node_ids
+        and dependency.depends_on_task_id in owned_node_ids
+    ]
+    return TaskDependencyGraphResponse(
+        nodes=nodes,
+        edges=edges,
+        total=total,
+        node_count=len(nodes),
+        limit=DEPENDENCY_GRAPH_NODE_LIMIT,
     )
 
 
@@ -411,6 +636,71 @@ async def get_task(
         TaskDependencyResponse.model_validate(dep) for dep in dependencies
     ]
     return task_response
+
+
+@router.get(
+    "/{task_id}/dependency-context",
+    response_model=TaskDependencyContext,
+    responses={404: {"model": ErrorResponse, "description": "Task not found"}},
+)
+async def get_task_dependency_context(
+    task_id: UUID,
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+) -> TaskDependencyContext:
+    """Return prerequisite and dependent tasks with hierarchy information."""
+    task = task_service.get_task(session, task_id, current_user.user_id)
+    if not task:
+        return TaskDependencyContext()
+
+    relationships = list(
+        session.exec(
+            select(TaskDependency).where(
+                or_(
+                    TaskDependency.task_id == task_id,
+                    TaskDependency.depends_on_task_id == task_id,
+                )
+            )
+        ).all()
+    )
+    related_ids = {task_id}
+    for relationship in relationships:
+        related_ids.add(relationship.task_id)
+        related_ids.add(relationship.depends_on_task_id)
+
+    hierarchy = _owned_task_hierarchy(session, current_user.user_id, related_ids)
+    dependencies_by_task = task_service.get_task_dependencies_batch(
+        session, list(hierarchy), current_user.user_id
+    )
+
+    def to_context(related_task_id: UUID) -> TaskDependencyContextTask | None:
+        row = hierarchy.get(related_task_id)
+        if not row:
+            return None
+        related_task, goal, project = row
+        return _context_task(
+            related_task,
+            goal,
+            project,
+            dependencies_by_task.get(str(related_task_id), []),
+        )
+
+    prerequisites = [
+        context
+        for relationship in relationships
+        if relationship.task_id == task_id
+        and (context := to_context(relationship.depends_on_task_id)) is not None
+    ]
+    dependents = [
+        context
+        for relationship in relationships
+        if relationship.depends_on_task_id == task_id
+        and (context := to_context(relationship.task_id)) is not None
+    ]
+    return TaskDependencyContext(
+        prerequisites=prerequisites,
+        dependents=dependents,
+    )
 
 
 @router.put(

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -759,6 +759,83 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
         )
         return list(session.exec(statement).all()), total
 
+    def get_workspace_summary_counts(
+        self,
+        session: Session,
+        owner_id: str | UUID,
+        *,
+        project_id: UUID | None = None,
+        goal_id: UUID | None = None,
+        search: str | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, int]:
+        """Count workspace states without hydrating tasks or work aggregates."""
+        owner_uuid = UUID(str(owner_id))
+        conditions = [Project.owner_id == owner_uuid]
+        if project_id:
+            conditions.append(Project.id == project_id)
+        if goal_id:
+            conditions.append(Goal.id == goal_id)
+        if search and search.strip():
+            pattern = f"%{search.strip()}%"
+            conditions.append(
+                Task.title.ilike(pattern)
+                | Task.description.ilike(pattern)
+                | Task.memo.ilike(pattern)
+            )
+
+        prerequisite = aliased(Task)
+        has_blocker = (
+            select(TaskDependency.id)
+            .join(
+                prerequisite,
+                TaskDependency.depends_on_task_id == prerequisite.id,
+            )
+            .where(
+                TaskDependency.task_id == Task.id,
+                prerequisite.status != TaskStatus.COMPLETED,
+            )
+            .correlate(Task)
+            .exists()
+        )
+        is_actionable = Task.status.in_([TaskStatus.PENDING, TaskStatus.IN_PROGRESS])
+        current_time = now or datetime.now(UTC)
+        statement = (
+            select(
+                func.count(Task.id).label("total"),
+                func.count(Task.id)
+                .filter(and_(is_actionable, ~has_blocker))
+                .label("ready"),
+                func.count(Task.id)
+                .filter(and_(is_actionable, has_blocker))
+                .label("blocked"),
+                func.count(Task.id)
+                .filter(Task.status == TaskStatus.IN_PROGRESS)
+                .label("in_progress"),
+                func.count(Task.id)
+                .filter(
+                    and_(
+                        is_actionable,
+                        col(Task.due_date).is_not(None),
+                        col(Task.due_date) < current_time,
+                    )
+                )
+                .label("overdue"),
+            )
+            .select_from(Task)
+            .join(Goal, Task.goal_id == Goal.id)
+            .join(Project, Goal.project_id == Project.id)
+            .where(*conditions)
+        )
+        row = session.exec(statement).one()
+        return {
+            "total": int(row.total or 0),
+            "ready": int(row.ready or 0),
+            "blocked": int(row.blocked or 0),
+            "in_progress": int(row.in_progress or 0),
+            "overdue": int(row.overdue or 0),
+        }
+
     def update_task(
         self,
         session: Session,

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -636,13 +636,10 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
         """Get all tasks for a user across all projects"""
         return self.get_all(session, owner_id, skip, limit)
 
-    def get_workspace_tasks(
+    def _workspace_filter_conditions(
         self,
-        session: Session,
         owner_id: str | UUID,
         *,
-        skip: int = 0,
-        limit: int = 50,
         statuses: list[TaskStatus] | None = None,
         project_id: UUID | None = None,
         project_status: ProjectStatus | None = None,
@@ -653,28 +650,9 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
         blocked: bool | None = None,
         included_task_ids: set[UUID] | None = None,
         excluded_task_ids: set[UUID] | None = None,
-        sort_by: TaskWorkspaceSortBy = TaskWorkspaceSortBy.DUE_DATE,
-        sort_order: SortOrder = SortOrder.ASC,
-    ) -> tuple[list[tuple[Task, Goal, Project, int, datetime | None]], int]:
-        """Fetch one page of user tasks with hierarchy and aggregate work data."""
+    ) -> list:
+        """Build the shared hierarchy and task filters for workspace queries."""
         owner_uuid = UUID(str(owner_id))
-        actual_minutes = (
-            select(
-                Log.task_id,
-                func.coalesce(func.sum(Log.actual_minutes), 0).label("minutes"),
-            )
-            .group_by(Log.task_id)
-            .subquery()
-        )
-        last_worked = (
-            select(
-                WorkSession.task_id,
-                func.max(WorkSession.started_at).label("last_worked_at"),
-            )
-            .group_by(WorkSession.task_id)
-            .subquery()
-        )
-
         conditions = [Project.owner_id == owner_uuid]
         if statuses:
             conditions.append(Task.status.in_(statuses))
@@ -707,6 +685,7 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
                     TaskDependency.task_id == Task.id,
                     prerequisite.status != TaskStatus.COMPLETED,
                 )
+                .correlate(Task)
                 .exists()
             )
             conditions.append(blocking_dependency if blocked else ~blocking_dependency)
@@ -714,6 +693,59 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
             conditions.append(col(Task.id).in_(included_task_ids))
         if excluded_task_ids:
             conditions.append(~col(Task.id).in_(excluded_task_ids))
+        return conditions
+
+    def get_workspace_tasks(
+        self,
+        session: Session,
+        owner_id: str | UUID,
+        *,
+        skip: int = 0,
+        limit: int = 50,
+        statuses: list[TaskStatus] | None = None,
+        project_id: UUID | None = None,
+        project_status: ProjectStatus | None = None,
+        goal_id: UUID | None = None,
+        due_before: datetime | None = None,
+        due_after: datetime | None = None,
+        search: str | None = None,
+        blocked: bool | None = None,
+        included_task_ids: set[UUID] | None = None,
+        excluded_task_ids: set[UUID] | None = None,
+        sort_by: TaskWorkspaceSortBy = TaskWorkspaceSortBy.DUE_DATE,
+        sort_order: SortOrder = SortOrder.ASC,
+    ) -> tuple[list[tuple[Task, Goal, Project, int, datetime | None]], int]:
+        """Fetch one page of user tasks with hierarchy and aggregate work data."""
+        actual_minutes = (
+            select(
+                Log.task_id,
+                func.coalesce(func.sum(Log.actual_minutes), 0).label("minutes"),
+            )
+            .group_by(Log.task_id)
+            .subquery()
+        )
+        last_worked = (
+            select(
+                WorkSession.task_id,
+                func.max(WorkSession.started_at).label("last_worked_at"),
+            )
+            .group_by(WorkSession.task_id)
+            .subquery()
+        )
+
+        conditions = self._workspace_filter_conditions(
+            owner_id,
+            statuses=statuses,
+            project_id=project_id,
+            project_status=project_status,
+            goal_id=goal_id,
+            due_before=due_before,
+            due_after=due_after,
+            search=search,
+            blocked=blocked,
+            included_task_ids=included_task_ids,
+            excluded_task_ids=excluded_task_ids,
+        )
 
         count_statement = (
             select(func.count(Task.id))
@@ -755,6 +787,53 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
         statement = (
             statement.order_by(order_expression, Task.priority.asc(), Task.id.asc())
             .offset(skip)
+            .limit(limit)
+        )
+        return list(session.exec(statement).all()), total
+
+    def get_workspace_graph_tasks(
+        self,
+        session: Session,
+        owner_id: str | UUID,
+        *,
+        limit: int,
+        statuses: list[TaskStatus] | None = None,
+        project_id: UUID | None = None,
+        goal_id: UUID | None = None,
+        due_before: datetime | None = None,
+        due_after: datetime | None = None,
+        search: str | None = None,
+        blocked: bool | None = None,
+        included_task_ids: set[UUID] | None = None,
+        excluded_task_ids: set[UUID] | None = None,
+    ) -> tuple[list[Task], int]:
+        """Fetch graph root tasks without work-log or work-session aggregates."""
+        conditions = self._workspace_filter_conditions(
+            owner_id,
+            statuses=statuses,
+            project_id=project_id,
+            goal_id=goal_id,
+            due_before=due_before,
+            due_after=due_after,
+            search=search,
+            blocked=blocked,
+            included_task_ids=included_task_ids,
+            excluded_task_ids=excluded_task_ids,
+        )
+        count_statement = (
+            select(func.count(Task.id))
+            .select_from(Task)
+            .join(Goal, Task.goal_id == Goal.id)
+            .join(Project, Goal.project_id == Project.id)
+            .where(*conditions)
+        )
+        total = int(session.exec(count_statement).one())
+        statement = (
+            select(Task)
+            .join(Goal, Task.goal_id == Goal.id)
+            .join(Project, Goal.project_id == Project.id)
+            .where(*conditions)
+            .order_by(Task.id.asc())
             .limit(limit)
         )
         return list(session.exec(statement).all()), total
@@ -817,7 +896,7 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
                     and_(
                         is_actionable,
                         col(Task.due_date).is_not(None),
-                        col(Task.due_date) < current_time,
+                        col(Task.due_date) <= current_time,
                     )
                 )
                 .label("overdue"),

--- a/apps/api/tests/test_task_workspace.py
+++ b/apps/api/tests/test_task_workspace.py
@@ -21,16 +21,22 @@ from humancompiler_api.models import (
     UserCreate,
     WorkSession,
 )
+from humancompiler_api.auth import AuthUser
 from humancompiler_api.routers.tasks import (
+    _dependency_state,
     _extract_planned_task_ids,
     _plan_date_windows,
     build_workspace_items,
+    get_task_dependency_context,
+    get_task_dependency_graph,
+    get_task_workspace_summary,
 )
 from humancompiler_api.services import (
     GoalService,
     ProjectService,
     TaskService,
     UserService,
+    task_service as shared_task_service,
 )
 
 
@@ -95,6 +101,7 @@ def test_workspace_lists_and_filters_tasks_across_projects(session, test_user_id
     assert items[0].goal_title == first["goal"].title
     assert items[0].remaining_estimate_hours == Decimal("1.50")
     assert items[0].is_blocked is True
+    assert items[0].is_ready is False
     assert items[0].blocking_task_ids == [prerequisite.id]
 
     blocked_rows, blocked_total = task_service.get_workspace_tasks(
@@ -102,6 +109,162 @@ def test_workspace_lists_and_filters_tasks_across_projects(session, test_user_id
     )
     assert blocked_total == 1
     assert [row[0].id for row in blocked_rows] == [first_task.id]
+
+
+def test_ready_requires_actionable_status_and_completed_dependencies(
+    session, test_user_id
+):
+    data = create_test_data(session, test_user_id)
+    task_service = TaskService()
+    prerequisite = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Prerequisite",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    dependent = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Dependent",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    dependency = TaskDependency(
+        id=uuid4(),
+        task_id=dependent.id,
+        depends_on_task_id=prerequisite.id,
+    )
+    dependency.depends_on_task = prerequisite
+
+    assert _dependency_state(dependent, [dependency])[0:2] == (False, True)
+
+    prerequisite.status = TaskStatus.COMPLETED
+    assert _dependency_state(dependent, [dependency])[0:2] == (True, False)
+
+    dependent.status = TaskStatus.COMPLETED
+    assert _dependency_state(dependent, [dependency])[0:2] == (False, False)
+
+    dependent.status = TaskStatus.PENDING
+    prerequisite.status = TaskStatus.CANCELLED
+    assert _dependency_state(dependent, [dependency])[0:2] == (False, True)
+
+
+@pytest.mark.asyncio
+async def test_workspace_summary_and_dependency_context(session, test_user_id):
+    data = create_test_data(session, test_user_id)
+    task_service = TaskService()
+    prerequisite = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Prepare",
+            estimate_hours=Decimal("1"),
+            status=TaskStatus.IN_PROGRESS,
+        ),
+        test_user_id,
+    )
+    dependent = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Publish",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    session.add(
+        TaskDependency(
+            id=uuid4(),
+            task_id=dependent.id,
+            depends_on_task_id=prerequisite.id,
+        )
+    )
+    session.flush()
+    user = AuthUser(str(test_user_id), "test@example.com")
+
+    summary = await get_task_workspace_summary(session, user)
+    context = await get_task_dependency_context(dependent.id, session, user)
+
+    assert summary.total == 2
+    assert summary.ready == 1
+    assert summary.blocked == 1
+    assert summary.in_progress == 1
+    assert [item.id for item in context.prerequisites] == [prerequisite.id]
+    assert context.prerequisites[0].project_title == data["project"].title
+
+
+@pytest.mark.asyncio
+async def test_dependency_graph_uses_prerequisite_to_dependent_direction(
+    session, test_user_id
+):
+    data = create_test_data(session, test_user_id)
+    task_service = TaskService()
+    prerequisite = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Prepare",
+            estimate_hours=Decimal("1"),
+            status=TaskStatus.COMPLETED,
+        ),
+        test_user_id,
+    )
+    dependent = task_service.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Publish",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    relationship = TaskDependency(
+        id=uuid4(),
+        task_id=dependent.id,
+        depends_on_task_id=prerequisite.id,
+    )
+    session.add(relationship)
+    session.flush()
+
+    graph = await get_task_dependency_graph(
+        session,
+        AuthUser(str(test_user_id), "test@example.com"),
+        search="Publish",
+    )
+
+    assert graph.exceeds_limit is False
+    assert {node.id for node in graph.nodes} == {prerequisite.id, dependent.id}
+    assert len(graph.edges) == 1
+    assert graph.edges[0].prerequisite_task_id == prerequisite.id
+    assert graph.edges[0].dependent_task_id == dependent.id
+    nodes = {node.id: node for node in graph.nodes}
+    assert nodes[prerequisite.id].is_context is True
+    assert nodes[dependent.id].is_context is False
+
+
+@pytest.mark.asyncio
+async def test_dependency_graph_reports_limit_without_partial_graph(
+    session, test_user_id, monkeypatch
+):
+    def oversized_workspace(*args, **kwargs):
+        return [], 201
+
+    monkeypatch.setattr(shared_task_service, "get_workspace_tasks", oversized_workspace)
+
+    graph = await get_task_dependency_graph(
+        session,
+        AuthUser(str(test_user_id), "test@example.com"),
+    )
+
+    assert graph.exceeds_limit is True
+    assert graph.total == 201
+    assert graph.nodes == []
+    assert graph.edges == []
 
 
 def test_workspace_filters_by_project_status_and_plan_membership(session, test_user_id):

--- a/apps/api/tests/test_task_workspace.py
+++ b/apps/api/tests/test_task_workspace.py
@@ -236,6 +236,25 @@ async def test_workspace_summary_uses_lightweight_aggregate_query(
     assert summary.ready == 1
 
 
+def test_workspace_summary_treats_task_due_now_as_overdue(session, test_user_id):
+    data = create_test_data(session, test_user_id)
+    now = datetime(2026, 7, 20, 12, tzinfo=UTC)
+    TaskService().create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Due now",
+            estimate_hours=Decimal("1"),
+            due_date=now,
+        ),
+        test_user_id,
+    )
+
+    summary = TaskService().get_workspace_summary_counts(session, test_user_id, now=now)
+
+    assert summary["overdue"] == 1
+
+
 @pytest.mark.asyncio
 async def test_dependency_context_raises_not_found_for_missing_or_unowned_task(
     session, test_user_id
@@ -323,13 +342,44 @@ async def test_dependency_graph_uses_prerequisite_to_dependent_direction(
 
 
 @pytest.mark.asyncio
+async def test_dependency_graph_skips_workspace_work_aggregates(
+    session, test_user_id, monkeypatch
+):
+    data = create_test_data(session, test_user_id)
+    task = TaskService().create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Graph root",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+
+    def unexpected_workspace_load(*args, **kwargs):
+        raise AssertionError("graph must not load workspace work aggregates")
+
+    monkeypatch.setattr(
+        shared_task_service, "get_workspace_tasks", unexpected_workspace_load
+    )
+
+    graph = await get_task_dependency_graph(
+        session, AuthUser(str(test_user_id), "test@example.com")
+    )
+
+    assert [node.id for node in graph.nodes] == [task.id]
+
+
+@pytest.mark.asyncio
 async def test_dependency_graph_reports_limit_without_partial_graph(
     session, test_user_id, monkeypatch
 ):
     def oversized_workspace(*args, **kwargs):
         return [], 201
 
-    monkeypatch.setattr(shared_task_service, "get_workspace_tasks", oversized_workspace)
+    monkeypatch.setattr(
+        shared_task_service, "get_workspace_graph_tasks", oversized_workspace
+    )
 
     graph = await get_task_dependency_graph(
         session,

--- a/apps/api/tests/test_task_workspace.py
+++ b/apps/api/tests/test_task_workspace.py
@@ -199,6 +199,81 @@ async def test_workspace_summary_and_dependency_context(session, test_user_id):
 
 
 @pytest.mark.asyncio
+async def test_workspace_summary_uses_lightweight_aggregate_query(
+    session, test_user_id, monkeypatch
+):
+    data = create_test_data(session, test_user_id)
+    TaskService().create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Aggregate-only task",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+
+    def unexpected_workspace_load(*args, **kwargs):
+        raise AssertionError("summary must not hydrate workspace task rows")
+
+    def unexpected_dependency_load(*args, **kwargs):
+        raise AssertionError("summary must not hydrate task dependencies")
+
+    monkeypatch.setattr(
+        shared_task_service, "get_workspace_tasks", unexpected_workspace_load
+    )
+    monkeypatch.setattr(
+        shared_task_service,
+        "get_task_dependencies_batch",
+        unexpected_dependency_load,
+    )
+
+    summary = await get_task_workspace_summary(
+        session, AuthUser(str(test_user_id), "test@example.com")
+    )
+
+    assert summary.total == 1
+    assert summary.ready == 1
+
+
+@pytest.mark.asyncio
+async def test_dependency_context_raises_not_found_for_missing_or_unowned_task(
+    session, test_user_id
+):
+    other_user_id = uuid4()
+    UserService().create_user(
+        session, UserCreate(email="dependency-owner@example.com"), other_user_id
+    )
+    other_project = ProjectService().create_project(
+        session, ProjectCreate(title="Other project"), other_user_id
+    )
+    other_goal = GoalService().create_goal(
+        session,
+        GoalCreate(
+            project_id=other_project.id,
+            title="Other goal",
+            estimate_hours=Decimal("1"),
+        ),
+        other_user_id,
+    )
+    other_task = TaskService().create_task(
+        session,
+        TaskCreate(
+            goal_id=other_goal.id,
+            title="Other task",
+            estimate_hours=Decimal("1"),
+        ),
+        other_user_id,
+    )
+    user = AuthUser(str(test_user_id), "test@example.com")
+
+    with pytest.raises(ResourceNotFoundError):
+        await get_task_dependency_context(uuid4(), session, user)
+    with pytest.raises(ResourceNotFoundError):
+        await get_task_dependency_context(other_task.id, session, user)
+
+
+@pytest.mark.asyncio
 async def test_dependency_graph_uses_prerequisite_to_dependent_direction(
     session, test_user_id
 ):

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -65,6 +65,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "d3-scale": "^4.0.2",
+    "d3-selection": "^3.0.0",
     "d3-zoom": "^3.0.0",
     "date-fns": "^4.1.0",
     "html2canvas": "^1.4.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -60,6 +60,7 @@
     "@tiptap/react": "^2.11.5",
     "@tiptap/starter-kit": "^2.11.5",
     "@types/d3-scale": "^4.0.9",
+    "@types/d3-selection": "^3.0.11",
     "@types/d3-zoom": "^3.0.8",
     "autoprefixer": "^10.4.0",
     "class-variance-authority": "^0.7.0",

--- a/apps/web/src/app/projects/[id]/goals/[goalId]/page.tsx
+++ b/apps/web/src/app/projects/[id]/goals/[goalId]/page.tsx
@@ -1,86 +1,26 @@
 'use client';
 
-import React, { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { useAuth } from '@/hooks/use-auth';
-import { useAllTasksByGoal, useUpdateTask } from '@/hooks/use-tasks-query';
+import { useAllTasksByGoal } from '@/hooks/use-tasks-query';
 import { useGoal } from '@/hooks/use-goals-query';
 import { useProject } from '@/hooks/use-project-query';
 import { useGoalNote } from '@/hooks/use-notes';
 import { useQuery } from '@tanstack/react-query';
 import { progressApi } from '@/lib/api';
 import { useBatchLogsQuery } from '@/hooks/use-logs-query';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { SortDropdown } from '@/components/ui/sort-dropdown';
 import { TaskFormDialog } from '@/components/tasks/task-form-dialog';
-import { TaskEditDialog } from '@/components/tasks/task-edit-dialog';
-import { TaskDeleteDialog } from '@/components/tasks/task-delete-dialog';
-import { TaskLogsMemoPanel } from '@/components/tasks/task-logs-memo-panel';
-import { LogFormDialog } from '@/components/logs/log-form-dialog';
+import { GoalTaskList } from '@/components/tasks/goal-task-list';
 import { ContextNotePanel } from '@/components/notes/context-note-panel';
 import { GoalTaskAssistantDialog } from '@/components/ai/goal-task-assistant-dialog';
-import { ArrowLeft, Plus, Clock, Calendar, GitBranch, FileText, Loader2, AlertCircle, Sparkles } from 'lucide-react';
-import { taskStatusLabels, taskStatusColors, workTypeLabels, workTypeColors, taskPriorityLabels, taskPriorityColors } from '@/types/task';
-import type { TaskStatus, Task } from '@/types/task';
+import { ArrowLeft, Plus, Clock, FileText, Loader2, AlertCircle, Sparkles } from 'lucide-react';
 import { SortBy, SortOrder } from '@/types/sort';
 import type { SortOptions } from '@/types/sort';
-import { log } from '@/lib/logger';
 import { AppHeader } from '@/components/layout/app-header';
-import { toast } from '@/hooks/use-toast';
-import { getStatusUpdateError } from '@/lib/status-error-handler';
-
-// Component for inline status editing
-function TaskStatusSelect({ task }: { task: Task }) {
-  const updateTaskMutation = useUpdateTask();
-
-  const handleStatusChange = async (newStatus: TaskStatus) => {
-    try {
-      await updateTaskMutation.mutateAsync({
-        id: task.id,
-        data: { status: newStatus }
-      });
-    } catch (error) {
-      log.error('Failed to update task status', error, {
-        component: 'TaskStatusSelect',
-        taskId: task.id,
-        newStatus
-      });
-
-      const { title, message } = getStatusUpdateError(error as Error, 'task');
-      toast({
-        title,
-        description: message,
-        variant: 'destructive',
-      });
-    }
-  };
-
-  return (
-    <Select value={task.status} onValueChange={handleStatusChange} disabled={updateTaskMutation.isPending}>
-      <SelectTrigger className="w-auto min-w-[100px] h-auto p-1">
-        <SelectValue>
-          <Badge className={taskStatusColors[task.status]}>
-            {taskStatusLabels[task.status]}
-          </Badge>
-        </SelectValue>
-      </SelectTrigger>
-      <SelectContent>
-        {Object.entries(taskStatusLabels).map(([value, label]) => (
-          <SelectItem key={value} value={value}>
-            <Badge className={taskStatusColors[value as TaskStatus]}>
-              {label}
-            </Badge>
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}
 
 export default function GoalDetailPage() {
   const { user, loading: authLoading } = useAuth();
@@ -424,152 +364,15 @@ export default function GoalDetailPage() {
             </CardContent>
           </Card>
         ) : (
-          <Card>
-            <CardContent className="p-0">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>タスク名</TableHead>
-                    <TableHead>作業種別</TableHead>
-                    <TableHead>優先度</TableHead>
-                    <TableHead>依存関係</TableHead>
-                    <TableHead>ステータス</TableHead>
-                    <TableHead>見積時間</TableHead>
-                    <TableHead>実績時間</TableHead>
-                    <TableHead>締切日</TableHead>
-                    <TableHead>作成日</TableHead>
-                    <TableHead>操作</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {tasks.map((task) => (
-                    <React.Fragment key={task.id}>
-                      <TableRow>
-                        <TableCell>
-                          <div>
-                            <Link
-                              href={`/projects/${id}/goals/${goalId}/tasks/${task.id}`}
-                              className="font-medium hover:text-blue-600 hover:underline"
-                            >
-                              {task.title}
-                            </Link>
-                            {task.description && (
-                              <div className="text-sm text-gray-500 line-clamp-1">
-                                {task.description}
-                              </div>
-                            )}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <Badge className={workTypeColors[task.work_type || 'light_work']}>
-                            {workTypeLabels[task.work_type || 'light_work']}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>
-                          <Badge className={taskPriorityColors[task.priority || 3]}>
-                            {taskPriorityLabels[task.priority || 3]}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>
-                          {task.dependencies && task.dependencies.length > 0 ? (
-                            <div className="flex items-center gap-2">
-                              <div className="flex items-center gap-1">
-                                <GitBranch className="h-4 w-4 text-blue-500" />
-                                <span className="text-sm text-muted-foreground">
-                                  {task.dependencies.length}件
-                                </span>
-                              </div>
-                              <div className="flex -space-x-2" title={`依存タスク: ${task.dependencies.map(d => d.depends_on_task?.title || '不明').join(', ')}`}>
-                                {task.dependencies.slice(0, 3).map((dep, index) => (
-                                  <div
-                                    key={dep.id}
-                                    className="flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 border border-white text-xs"
-                                    title={dep.depends_on_task?.title || '不明なタスク'}
-                                  >
-                                    {index + 1}
-                                  </div>
-                                ))}
-                                {task.dependencies.length > 3 && (
-                                  <div className="flex items-center justify-center w-6 h-6 rounded-full bg-gray-100 border border-white text-xs">
-                                    +{task.dependencies.length - 3}
-                                  </div>
-                                )}
-                              </div>
-                            </div>
-                          ) : (
-                            <span className="text-sm text-muted-foreground">なし</span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <TaskStatusSelect task={task} />
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-1">
-                            <Clock className="h-3 w-3" />
-                            {task.estimate_hours}h
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-1">
-                            <Clock className="h-3 w-3 text-green-600" />
-                            {((taskActualMinutesById[task.id] || 0) / 60).toFixed(1)}h
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          {task.due_date ? (
-                            <div className="flex items-center gap-1">
-                              <Calendar className="h-3 w-3" />
-                              {new Date(task.due_date).toLocaleDateString('ja-JP')}
-                            </div>
-                          ) : (
-                            <span className="text-gray-400">未設定</span>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-sm text-gray-500">
-                            {new Date(task.created_at).toLocaleDateString('ja-JP')}
-                          </span>
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex gap-1">
-                            <LogFormDialog
-                              taskId={task.id}
-                              taskTitle={task.title}
-                              trigger={
-                                <Button variant="outline" size="sm">
-                                  時間記録
-                                </Button>
-                              }
-                            />
-                            <TaskEditDialog task={task} availableTasks={tasks}>
-                              <Button variant="outline" size="sm">
-                                編集
-                              </Button>
-                            </TaskEditDialog>
-                            <TaskDeleteDialog task={task}>
-                              <Button variant="outline" size="sm">
-                                削除
-                              </Button>
-                            </TaskDeleteDialog>
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                      <TableRow>
-                        <TableCell colSpan={10} className="p-0">
-                          <TaskLogsMemoPanel
-                            task={task}
-                            logs={logsByTask[task.id] || []}
-                            logsLoading={logsLoading}
-                            logsError={logsError}
-                          />
-                        </TableCell>
-                      </TableRow>
-                    </React.Fragment>
-                  ))}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
+          <GoalTaskList
+            tasks={tasks}
+            projectId={id}
+            goalId={goalId}
+            logsByTask={logsByTask}
+            logsLoading={logsLoading}
+            logsError={logsError}
+            actualMinutesByTask={taskActualMinutesById}
+          />
         )}
         </div>
       </div>

--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -4,20 +4,23 @@ import Link from "next/link";
 import { useDeferredValue, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  AlertTriangle,
   Bot,
-  CalendarDays,
+  CheckCircle2,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
-  Clock,
   Inbox,
   ListTodo,
+  Network,
   Play,
+  Rows3,
   Search,
 } from "lucide-react";
 
 import { AppHeader } from "@/components/layout/app-header";
 import { QuickTaskList } from "@/components/quick-tasks";
+import { TaskDependencyMap } from "@/components/tasks/task-dependency-map";
+import { TaskDependencyPanel } from "@/components/tasks/task-dependency-panel";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -33,11 +36,17 @@ import { useAuth } from "@/hooks/use-auth";
 import { toast } from "@/hooks/use-toast";
 import {
   useTaskRecommendations,
+  useTaskDependencyGraph,
   useTaskWorkspace,
+  useTaskWorkspaceSummary,
   useUpdateTask,
 } from "@/hooks/use-tasks-query";
 import { goalsApi, projectsApi, quickTasksApi } from "@/lib/api";
-import type { Goal } from "@/types/goal";
+import {
+  buildTaskWorkspaceFilters,
+  DEFAULT_TASK_WORKSPACE_PRESET,
+  type TaskWorkspacePreset,
+} from "@/lib/tasks/workspace-filters";
 import type { QuickTask } from "@/types/quick-task";
 import type {
   TaskStatus,
@@ -46,19 +55,10 @@ import type {
 } from "@/types/task";
 import { taskStatusLabels } from "@/types/task";
 
-type Preset =
-  | "next"
-  | "today"
-  | "week"
-  | "in_progress"
-  | "overdue"
-  | "blocked"
-  | "unplanned"
-  | "inbox"
-  | "all";
+type Preset = TaskWorkspacePreset;
 
 const PRESETS: Array<{ id: Preset; label: string }> = [
-  { id: "next", label: "次にやる" },
+  { id: "ready", label: "Ready" },
   { id: "today", label: "今日" },
   { id: "week", label: "今週" },
   { id: "in_progress", label: "作業中" },
@@ -69,22 +69,26 @@ const PRESETS: Array<{ id: Preset; label: string }> = [
   { id: "all", label: "全タスク" },
 ];
 
-const actionableStatuses: TaskStatus[] = ["pending", "in_progress"];
-
-function dateInputValue(value: string | null) {
-  return value ? value.slice(0, 10) : "";
-}
-
 function TaskRow({
   task,
-  goals,
   onOpen,
 }: {
   task: TaskWorkspaceItem;
-  goals: Goal[];
   onOpen: () => void;
 }) {
   const updateTask = useUpdateTask();
+  const [dependenciesOpen, setDependenciesOpen] = useState(false);
+  const dependencies = task.dependencies ?? [];
+  const completedDependencies = dependencies.filter(
+    (dependency) => dependency.depends_on_task?.status === "completed",
+  ).length;
+  const blockingDependencies = dependencies.filter(
+    (dependency) => dependency.depends_on_task?.status !== "completed",
+  );
+  const canStart =
+    !task.is_blocked &&
+    task.status !== "completed" &&
+    task.status !== "cancelled";
 
   const update = async (
     data: Parameters<typeof updateTask.mutateAsync>[0]["data"],
@@ -101,118 +105,149 @@ function TaskRow({
   };
 
   return (
-    <div className="grid gap-3 border-b border-border px-4 py-4 last:border-b-0 xl:grid-cols-[minmax(260px,2fr)_140px_110px_150px_120px_minmax(210px,1fr)_110px] xl:items-center">
-      <div className="min-w-0">
-        <button className="block max-w-full text-left" onClick={onOpen}>
-          <span className="block truncate font-medium hover:text-primary hover:underline">
-            {task.title}
+    <div className="border-b border-border last:border-b-0">
+      <div className="grid gap-3 px-4 py-3 lg:grid-cols-[100px_minmax(240px,2fr)_minmax(180px,1fr)_120px_100px_80px_70px_170px] lg:items-center">
+        <div>
+          {task.status === "completed" ? (
+            <Badge variant="success">完了</Badge>
+          ) : task.status === "cancelled" ? (
+            <Badge variant="secondary">キャンセル</Badge>
+          ) : task.is_blocked ? (
+            <Badge variant="warning">ブロック中</Badge>
+          ) : (
+            <Badge variant="info">Ready</Badge>
+          )}
+        </div>
+
+        <div className="min-w-0">
+          <button className="block max-w-full text-left" onClick={onOpen}>
+            <span className="block truncate font-medium hover:text-primary hover:underline">
+              {task.title}
+            </span>
+          </button>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <span>
+              {task.project_title} › {task.goal_title}
+            </span>
+            {task.planned_today && <Badge variant="info">今日</Badge>}
+            {!task.planned_today && task.planned_this_week && (
+              <Badge variant="secondary">今週</Badge>
+            )}
+          </div>
+        </div>
+
+        <div className="text-sm">
+          {dependencies.length === 0 ? (
+            <span className="text-muted-foreground">依存なし</span>
+          ) : (
+            <button
+              className="flex items-center gap-1 rounded px-1 py-1 text-left hover:bg-muted"
+              aria-expanded={dependenciesOpen}
+              onClick={() => setDependenciesOpen((value) => !value)}
+            >
+              <span>
+                {completedDependencies}/{dependencies.length} 完了
+              </span>
+              <ChevronDown
+                className={`h-4 w-4 transition-transform ${dependenciesOpen ? "rotate-180" : ""}`}
+              />
+            </button>
+          )}
+        </div>
+
+        <label className="text-xs text-muted-foreground">
+          <span className="mb-1 block lg:hidden">ステータス</span>
+          <select
+            aria-label={`${task.title}のステータス`}
+            className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
+            value={task.status}
+            disabled={updateTask.isPending}
+            onChange={(event) =>
+              update({ status: event.target.value as TaskStatus })
+            }
+          >
+            {Object.entries(taskStatusLabels).map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <div className="text-sm">
+          <span className="mr-2 text-xs text-muted-foreground lg:hidden">
+            期限
           </span>
-        </button>
-        <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-          <span>
-            {task.project_title} › {task.goal_title}
+          {task.due_date
+            ? new Date(task.due_date).toLocaleDateString("ja-JP", {
+                month: "numeric",
+                day: "numeric",
+              })
+            : "—"}
+        </div>
+        <div className="text-sm">
+          <span className="mr-2 text-xs text-muted-foreground lg:hidden">
+            残り
           </span>
-          {task.is_blocked && <Badge variant="destructive">ブロック中</Badge>}
-          {task.planned_today && <Badge variant="info">今日</Badge>}
-          {!task.planned_today && task.planned_this_week && (
-            <Badge variant="secondary">今週</Badge>
+          {task.remaining_estimate_hours}h
+        </div>
+        <div className="text-sm">
+          <span className="mr-2 text-xs text-muted-foreground lg:hidden">
+            優先度
+          </span>
+          P{task.priority}
+        </div>
+        <div className="flex gap-2">
+          <Button size="sm" variant="outline" onClick={onOpen}>
+            詳細
+          </Button>
+          {canStart ? (
+            <Button size="sm" asChild>
+              <Link href={`/runner?taskId=${encodeURIComponent(task.id)}`}>
+                <Play className="mr-1 h-4 w-4" />
+                開始
+              </Link>
+            </Button>
+          ) : (
+            <Button size="sm" disabled>
+              <Play className="mr-1 h-4 w-4" />
+              開始
+            </Button>
           )}
         </div>
       </div>
 
-      <label className="text-xs text-muted-foreground">
-        <span className="mb-1 block xl:hidden">ステータス</span>
-        <select
-          aria-label={`${task.title}のステータス`}
-          className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
-          value={task.status}
-          disabled={updateTask.isPending}
-          onChange={(event) =>
-            update({ status: event.target.value as TaskStatus })
-          }
-        >
-          {Object.entries(taskStatusLabels).map(([value, label]) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </select>
-      </label>
-
-      <label className="text-xs text-muted-foreground">
-        <span className="mb-1 block xl:hidden">優先度</span>
-        <select
-          aria-label={`${task.title}の優先度`}
-          className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
-          value={task.priority}
-          disabled={updateTask.isPending}
-          onChange={(event) => update({ priority: Number(event.target.value) })}
-        >
-          {[1, 2, 3, 4, 5].map((priority) => (
-            <option key={priority} value={priority}>
-              {priority}
-            </option>
-          ))}
-        </select>
-      </label>
-
-      <label className="text-xs text-muted-foreground">
-        <span className="mb-1 block xl:hidden">期限</span>
-        <Input
-          aria-label={`${task.title}の期限`}
-          type="date"
-          defaultValue={dateInputValue(task.due_date)}
-          disabled={updateTask.isPending}
-          onChange={(event) =>
-            update({
-              due_date: event.target.value
-                ? new Date(`${event.target.value}T23:59:59`).toISOString()
-                : null,
-            })
-          }
-        />
-      </label>
-
-      <label className="text-xs text-muted-foreground">
-        <span className="mb-1 block xl:hidden">見積時間</span>
-        <Input
-          aria-label={`${task.title}の見積時間`}
-          type="number"
-          min="0.01"
-          step="0.25"
-          defaultValue={task.estimate_hours}
-          disabled={updateTask.isPending}
-          onBlur={(event) => {
-            const value = Number(event.target.value);
-            if (value > 0 && value !== task.estimate_hours)
-              update({ estimate_hours: value });
-          }}
-        />
-      </label>
-
-      <label className="text-xs text-muted-foreground">
-        <span className="mb-1 block xl:hidden">所属ゴール</span>
-        <select
-          aria-label={`${task.title}の所属ゴール`}
-          className="h-9 w-full rounded-md border border-input bg-background px-2 text-sm"
-          value={task.goal_id}
-          disabled={updateTask.isPending}
-          onChange={(event) => update({ goal_id: event.target.value })}
-        >
-          {goals.map((goal) => (
-            <option key={goal.id} value={goal.id}>
-              {goal.title}
-            </option>
-          ))}
-        </select>
-      </label>
-
-      <Button size="sm" asChild>
-        <Link href={`/runner?taskId=${encodeURIComponent(task.id)}`}>
-          <Play className="mr-1 h-4 w-4" />
-          開始
-        </Link>
-      </Button>
+      {dependenciesOpen && dependencies.length > 0 && (
+        <div className="border-t bg-muted/30 px-4 py-3 lg:pl-[336px]">
+          <div className="mb-2 text-xs font-medium text-muted-foreground">
+            先に完了すべきタスク
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {dependencies.map((dependency) => (
+              <button
+                key={dependency.id}
+                className="flex items-center gap-2 rounded-full border bg-background px-3 py-1.5 text-xs hover:border-primary"
+                onClick={onOpen}
+              >
+                {dependency.depends_on_task?.status === "completed" ? (
+                  <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
+                ) : (
+                  <span className="h-2 w-2 rounded-full bg-amber-500" />
+                )}
+                {dependency.depends_on_task?.title ?? "不明なタスク"}
+                {dependency.depends_on_task?.status === "cancelled" && (
+                  <span className="text-destructive">要確認</span>
+                )}
+              </button>
+            ))}
+          </div>
+          {blockingDependencies.length > 0 && (
+            <div className="mt-2 text-xs text-amber-700 dark:text-amber-300">
+              未完了の依存タスクが {blockingDependencies.length} 件あります。
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -220,16 +255,15 @@ function TaskRow({
 export default function TasksPage() {
   const { user, loading: authLoading } = useAuth();
   const queryClient = useQueryClient();
-  const [preset, setPreset] = useState<Preset>("next");
+  const [preset, setPreset] = useState<Preset>(DEFAULT_TASK_WORKSPACE_PRESET);
+  const [view, setView] = useState<"list" | "graph">("list");
   const [search, setSearch] = useState("");
   const deferredSearch = useDeferredValue(search.trim());
   const [projectId, setProjectId] = useState("");
   const [goalId, setGoalId] = useState("");
   const [status, setStatus] = useState<TaskStatus | "">("");
   const [page, setPage] = useState(0);
-  const [selectedTask, setSelectedTask] = useState<TaskWorkspaceItem | null>(
-    null,
-  );
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [convertingTask, setConvertingTask] = useState<QuickTask | null>(null);
   const [convertGoalId, setConvertGoalId] = useState("");
   const [inboxVersion, setInboxVersion] = useState(0);
@@ -258,45 +292,37 @@ export default function TasksPage() {
   });
 
   const filters = useMemo<TaskWorkspaceFilters>(() => {
-    let statuses = status ? [status] : undefined;
-    if (
-      !status &&
-      (preset === "next" ||
-        preset === "overdue" ||
-        preset === "today" ||
-        preset === "week" ||
-        preset === "unplanned")
-    ) {
-      statuses = actionableStatuses;
-    }
-    if (!status && preset === "in_progress") statuses = ["in_progress"];
-
-    return {
-      skip: page * 50,
-      limit: 50,
-      status: statuses,
-      projectId: projectId || undefined,
-      goalId: goalId || undefined,
-      dueBefore: preset === "overdue" ? new Date().toISOString() : undefined,
-      search: deferredSearch || undefined,
-      blocked: preset === "blocked" ? true : undefined,
-      plan:
-        preset === "today" || preset === "week" || preset === "unplanned"
-          ? preset
-          : undefined,
-      sortBy: preset === "next" ? "priority" : "due_date",
-    };
-  }, [
-    deferredSearch,
-    goalId,
-    page,
-    preset,
-    projectId,
-    status,
-  ]);
+    return buildTaskWorkspaceFilters({
+      preset,
+      page,
+      status,
+      projectId,
+      goalId,
+      search: deferredSearch,
+    });
+  }, [deferredSearch, goalId, page, preset, projectId, status]);
 
   const workspace = useTaskWorkspace(filters, Boolean(user));
   const recommendations = useTaskRecommendations(Boolean(user));
+  const summaryFilters = useMemo(
+    () => ({
+      projectId: projectId || undefined,
+      goalId: goalId || undefined,
+      search: deferredSearch || undefined,
+    }),
+    [deferredSearch, goalId, projectId],
+  );
+  const summary = useTaskWorkspaceSummary(summaryFilters, Boolean(user));
+  const dependencyGraph = useTaskDependencyGraph(
+    {
+      ...filters,
+      skip: undefined,
+      limit: undefined,
+      sortBy: undefined,
+      sortOrder: undefined,
+    },
+    Boolean(user) && view === "graph" && preset !== "inbox",
+  );
   const visibleTasks = workspace.data?.items ?? [];
 
   const filteredGoals = projectId
@@ -330,6 +356,77 @@ export default function TasksPage() {
           <p className="mt-1 text-sm text-muted-foreground">
             プロジェクト階層をまたいで、次に取り組むタスクを探して調整できます。
           </p>
+        </div>
+
+        <div className="flex flex-col gap-3 xl:flex-row xl:items-stretch xl:justify-between">
+          <div className="grid flex-1 grid-cols-2 gap-2 sm:grid-cols-5">
+            {[
+              {
+                id: "ready" as Preset,
+                label: "Ready",
+                value: summary.data?.ready ?? 0,
+                tone: "text-blue-600",
+              },
+              {
+                id: "blocked" as Preset,
+                label: "ブロック",
+                value: summary.data?.blocked ?? 0,
+                tone: "text-amber-600",
+              },
+              {
+                id: "in_progress" as Preset,
+                label: "作業中",
+                value: summary.data?.in_progress ?? 0,
+                tone: "text-violet-600",
+              },
+              {
+                id: "overdue" as Preset,
+                label: "期限切れ",
+                value: summary.data?.overdue ?? 0,
+                tone: "text-red-600",
+              },
+              {
+                id: "all" as Preset,
+                label: "全タスク",
+                value: summary.data?.total ?? 0,
+                tone: "text-foreground",
+              },
+            ].map((item) => (
+              <button
+                key={item.id}
+                className={`rounded-lg border bg-card px-3 py-3 text-left transition-colors hover:border-primary/60 ${preset === item.id ? "border-primary ring-1 ring-primary/30" : ""}`}
+                onClick={() => {
+                  setPreset(item.id);
+                  setPage(0);
+                }}
+              >
+                <div className="text-xs text-muted-foreground">
+                  {item.label}
+                </div>
+                <div className={`mt-1 text-xl font-semibold ${item.tone}`}>
+                  {summary.isLoading ? "—" : item.value}
+                </div>
+              </button>
+            ))}
+          </div>
+          <div className="flex self-start rounded-lg border bg-card p-1">
+            <Button
+              size="sm"
+              variant={view === "list" ? "secondary" : "ghost"}
+              onClick={() => setView("list")}
+            >
+              <Rows3 className="mr-2 h-4 w-4" />
+              一覧
+            </Button>
+            <Button
+              size="sm"
+              variant={view === "graph" ? "secondary" : "ghost"}
+              onClick={() => setView("graph")}
+            >
+              <Network className="mr-2 h-4 w-4" />
+              依存マップ
+            </Button>
+          </div>
         </div>
 
         {recommendations.data &&
@@ -457,41 +554,53 @@ export default function TasksPage() {
               </CardContent>
             </Card>
 
-            <Card className="overflow-hidden">
-              <div className="hidden grid-cols-[minmax(260px,2fr)_140px_110px_150px_120px_minmax(210px,1fr)_110px] gap-3 border-b bg-muted/50 px-4 py-2 text-xs font-medium text-muted-foreground xl:grid">
-                <span>タスク</span>
-                <span>ステータス</span>
-                <span>優先度</span>
-                <span>期限</span>
-                <span>見積時間</span>
-                <span>所属ゴール</span>
-                <span>Runner</span>
-              </div>
-              {workspace.isLoading ? (
-                <div className="p-12 text-center text-muted-foreground">
-                  読み込み中...
+            {view === "list" ? (
+              <Card className="overflow-hidden">
+                <div className="sticky top-0 z-10 hidden grid-cols-[100px_minmax(240px,2fr)_minmax(180px,1fr)_120px_100px_80px_70px_170px] gap-3 border-b bg-muted/95 px-4 py-2 text-xs font-medium text-muted-foreground backdrop-blur lg:grid">
+                  <span>実行状態</span>
+                  <span>タスク</span>
+                  <span>依存状況</span>
+                  <span>ステータス</span>
+                  <span>期限</span>
+                  <span>残り</span>
+                  <span>優先度</span>
+                  <span>操作</span>
                 </div>
-              ) : workspace.isError ? (
-                <div className="p-12 text-center text-destructive">
-                  タスクの取得に失敗しました
-                </div>
-              ) : visibleTasks.length === 0 ? (
-                <div className="p-12 text-center text-muted-foreground">
-                  条件に一致するタスクはありません
-                </div>
-              ) : (
-                visibleTasks.map((task) => (
-                  <TaskRow
-                    key={task.id}
-                    task={task}
-                    goals={goals}
-                    onOpen={() => setSelectedTask(task)}
-                  />
-                ))
-              )}
-            </Card>
+                {workspace.isLoading ? (
+                  <div className="p-12 text-center text-muted-foreground">
+                    読み込み中...
+                  </div>
+                ) : workspace.isError ? (
+                  <div className="p-12 text-center text-destructive">
+                    タスクの取得に失敗しました
+                  </div>
+                ) : visibleTasks.length === 0 ? (
+                  <div className="p-12 text-center text-muted-foreground">
+                    条件に一致するタスクはありません
+                  </div>
+                ) : (
+                  visibleTasks.map((task) => (
+                    <TaskRow
+                      key={task.id}
+                      task={task}
+                      onOpen={() => setSelectedTaskId(task.id)}
+                    />
+                  ))
+                )}
+              </Card>
+            ) : (
+              <Card className="overflow-hidden">
+                <TaskDependencyMap
+                  graph={dependencyGraph.data}
+                  isLoading={dependencyGraph.isLoading}
+                  isError={dependencyGraph.isError}
+                  selectedTaskId={selectedTaskId}
+                  onSelectTask={(node) => setSelectedTaskId(node.id)}
+                />
+              </Card>
+            )}
 
-            {(workspace.data?.total ?? 0) > 50 && (
+            {view === "list" && (workspace.data?.total ?? 0) > 50 && (
               <div className="flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">
                   {page * 50 + 1}–
@@ -524,57 +633,12 @@ export default function TasksPage() {
         )}
       </main>
 
-      <Dialog
-        open={Boolean(selectedTask)}
-        onOpenChange={(open) => !open && setSelectedTask(null)}
-      >
-        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
-          {selectedTask && (
-            <>
-              <DialogHeader>
-                <DialogTitle>{selectedTask.title}</DialogTitle>
-                <DialogDescription>
-                  {selectedTask.project_title} › {selectedTask.goal_title}
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-4 text-sm">
-                <p className="whitespace-pre-wrap">
-                  {selectedTask.description || "説明はありません。"}
-                </p>
-                {selectedTask.memo && (
-                  <div className="rounded-md bg-muted p-3 whitespace-pre-wrap">
-                    {selectedTask.memo}
-                  </div>
-                )}
-                <div className="grid gap-3 sm:grid-cols-2">
-                  <div className="flex items-center gap-2">
-                    <Clock className="h-4 w-4" />
-                    残り見積 {selectedTask.remaining_estimate_hours}時間
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <CalendarDays className="h-4 w-4" />
-                    最終作業{" "}
-                    {selectedTask.last_worked_at
-                      ? new Date(selectedTask.last_worked_at).toLocaleString(
-                          "ja-JP",
-                        )
-                      : "なし"}
-                  </div>
-                </div>
-                {selectedTask.is_blocked && (
-                  <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 p-3">
-                    <AlertTriangle className="mt-0.5 h-4 w-4 text-destructive" />
-                    <span>
-                      未完了の依存タスクが{" "}
-                      {selectedTask.blocking_task_ids.length} 件あります。
-                    </span>
-                  </div>
-                )}
-              </div>
-            </>
-          )}
-        </DialogContent>
-      </Dialog>
+      <TaskDependencyPanel
+        taskId={selectedTaskId}
+        availableTasks={visibleTasks}
+        onClose={() => setSelectedTaskId(null)}
+        onSelectTask={setSelectedTaskId}
+      />
 
       <Dialog
         open={Boolean(convertingTask)}

--- a/apps/web/src/components/tasks/__tests__/goal-task-list.test.tsx
+++ b/apps/web/src/components/tasks/__tests__/goal-task-list.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { GoalTaskList } from '../goal-task-list'
+import type { Task, TaskDependency, TaskStatus } from '@/types/task'
+
+jest.mock('@/hooks/use-tasks-query', () => ({
+  useUpdateTask: () => ({ mutateAsync: jest.fn(), isPending: false }),
+}))
+
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}))
+
+jest.mock('@/components/logs/log-form-dialog', () => ({
+  LogFormDialog: ({ trigger }: { trigger: React.ReactNode }) => trigger,
+}))
+
+jest.mock('@/components/tasks/task-edit-dialog', () => ({
+  TaskEditDialog: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+jest.mock('@/components/tasks/task-delete-dialog', () => ({
+  TaskDeleteDialog: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+jest.mock('@/components/tasks/task-logs-memo-panel', () => ({
+  TaskLogsMemoPanel: () => null,
+}))
+
+jest.mock('@/components/tasks/task-dependency-panel', () => ({
+  TaskDependencyPanel: ({ taskId }: { taskId: string | null }) =>
+    taskId ? <div data-testid="dependency-panel">{taskId}</div> : null,
+}))
+
+function dependency(id: string, status: TaskStatus): TaskDependency {
+  return {
+    id,
+    task_id: 'blocked-task',
+    depends_on_task_id: `prerequisite-${id}`,
+    created_at: '2026-07-20T00:00:00Z',
+    depends_on_task: {
+      id: `prerequisite-${id}`,
+      title: `Prerequisite ${id}`,
+      status,
+    },
+  }
+}
+
+function task(overrides: Partial<Task>): Task {
+  return {
+    id: 'ready-task',
+    title: 'Ready task',
+    description: null,
+    estimate_hours: 1,
+    due_date: null,
+    status: 'pending',
+    priority: 3,
+    goal_id: 'goal',
+    created_at: '2026-07-20T00:00:00Z',
+    updated_at: '2026-07-20T00:00:00Z',
+    dependencies: [],
+    ...overrides,
+  }
+}
+
+describe('GoalTaskList', () => {
+  const tasks = [
+    task({}),
+    task({
+      id: 'blocked-task',
+      title: 'Blocked task',
+      dependencies: [
+        dependency('completed', 'completed'),
+        dependency('pending', 'pending'),
+      ],
+    }),
+  ]
+
+  it('filters tasks by decision state and opens dependency details', () => {
+    render(
+      <GoalTaskList
+        tasks={tasks}
+        projectId="project"
+        goalId="goal"
+        logsByTask={{}}
+        logsLoading={false}
+        logsError={null}
+        actualMinutesByTask={{}}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Ready 1' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'ブロック中 1' })).toBeInTheDocument()
+    expect(screen.getAllByText('Ready task')).not.toHaveLength(0)
+    expect(screen.getAllByText('Blocked task')).not.toHaveLength(0)
+
+    fireEvent.click(screen.getByRole('button', { name: 'ブロック中 1' }))
+
+    expect(screen.queryByText('Ready task')).not.toBeInTheDocument()
+    expect(screen.getAllByText('Blocked task')).not.toHaveLength(0)
+    expect(screen.getAllByText('1/2 完了')).not.toHaveLength(0)
+
+    fireEvent.click(screen.getAllByRole('button', { name: /1\/2 完了/ })[0])
+
+    expect(screen.getByTestId('dependency-panel')).toHaveTextContent('blocked-task')
+  })
+})

--- a/apps/web/src/components/tasks/__tests__/task-dependency-map.test.tsx
+++ b/apps/web/src/components/tasks/__tests__/task-dependency-map.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react'
+
+jest.mock('d3-selection', () => ({
+  select: jest.fn(() => ({ call: jest.fn(), on: jest.fn() })),
+}))
+jest.mock('d3-zoom', () => ({
+  zoom: jest.fn(() => ({ scaleExtent: jest.fn().mockReturnThis(), on: jest.fn().mockReturnThis() })),
+  zoomIdentity: {
+    translate: jest.fn().mockReturnThis(),
+    scale: jest.fn().mockReturnThis(),
+    toString: () => '',
+  },
+}))
+
+import { TaskDependencyMap } from '../task-dependency-map'
+
+describe('TaskDependencyMap', () => {
+  it('asks for narrower filters instead of silently truncating a large graph', () => {
+    render(
+      <TaskDependencyMap
+        graph={{
+          nodes: [],
+          edges: [],
+          total: 201,
+          node_count: 214,
+          exceeds_limit: true,
+          limit: 200,
+        }}
+        isLoading={false}
+        isError={false}
+        selectedTaskId={null}
+        onSelectTask={jest.fn()}
+      />,
+    )
+
+    expect(screen.getByText('表示対象が多すぎます')).toBeInTheDocument()
+    expect(screen.getByText(/214 件あります/)).toBeInTheDocument()
+    expect(screen.getByText(/200 件以下/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/components/tasks/goal-task-list.tsx
+++ b/apps/web/src/components/tasks/goal-task-list.tsx
@@ -1,0 +1,463 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import {
+  AlertTriangle,
+  Calendar,
+  CheckCircle2,
+  Clock,
+  GitBranch,
+  ListFilter,
+} from 'lucide-react'
+
+import { LogFormDialog } from '@/components/logs/log-form-dialog'
+import { TaskDeleteDialog } from '@/components/tasks/task-delete-dialog'
+import { TaskDependencyPanel } from '@/components/tasks/task-dependency-panel'
+import { TaskEditDialog } from '@/components/tasks/task-edit-dialog'
+import { TaskLogsMemoPanel } from '@/components/tasks/task-logs-memo-panel'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { useToast } from '@/hooks/use-toast'
+import { useUpdateTask } from '@/hooks/use-tasks-query'
+import { log } from '@/lib/logger'
+import { getStatusUpdateError } from '@/lib/status-error-handler'
+import { getTaskDecisionSummary, type TaskDecisionState } from '@/lib/tasks/task-decision'
+import type { Log } from '@/types/log'
+import {
+  taskPriorityColors,
+  taskPriorityLabels,
+  taskStatusColors,
+  taskStatusLabels,
+  workTypeColors,
+  workTypeLabels,
+} from '@/types/task'
+import type { Task, TaskStatus } from '@/types/task'
+
+type TaskView = 'all' | TaskDecisionState
+
+interface GoalTaskListProps {
+  tasks: Task[]
+  projectId: string
+  goalId: string
+  logsByTask: Record<string, Log[]>
+  logsLoading: boolean
+  logsError: Error | null
+  actualMinutesByTask: Record<string, number>
+}
+
+const stateLabels: Record<TaskDecisionState, string> = {
+  ready: 'Ready',
+  blocked: 'ブロック中',
+  completed: '完了',
+  cancelled: 'キャンセル',
+}
+
+const stateVariants: Record<
+  TaskDecisionState,
+  'info' | 'warning' | 'success' | 'destructive'
+> = {
+  ready: 'info',
+  blocked: 'warning',
+  completed: 'success',
+  cancelled: 'destructive',
+}
+
+function TaskDecisionBadge({ task }: { task: Task }) {
+  const summary = getTaskDecisionSummary(task)
+  return (
+    <Badge variant={stateVariants[summary.state]}>
+      {summary.state === 'ready' && <CheckCircle2 className="mr-1 h-3.5 w-3.5" />}
+      {summary.state === 'blocked' && <AlertTriangle className="mr-1 h-3.5 w-3.5" />}
+      {stateLabels[summary.state]}
+    </Badge>
+  )
+}
+
+function TaskStatusSelect({ task }: { task: Task }) {
+  const updateTaskMutation = useUpdateTask()
+  const { toast } = useToast()
+
+  const handleStatusChange = async (newStatus: TaskStatus) => {
+    try {
+      await updateTaskMutation.mutateAsync({
+        id: task.id,
+        data: { status: newStatus },
+      })
+    } catch (error) {
+      log.error('Failed to update task status', error, {
+        component: 'GoalTaskList',
+        taskId: task.id,
+        newStatus,
+      })
+      const { title, message } = getStatusUpdateError(error as Error, 'task')
+      toast({ title, description: message, variant: 'destructive' })
+    }
+  }
+
+  return (
+    <Select
+      value={task.status}
+      onValueChange={handleStatusChange}
+      disabled={updateTaskMutation.isPending}
+    >
+      <SelectTrigger className="h-8 w-auto min-w-[108px] px-2">
+        <SelectValue>
+          <Badge className={taskStatusColors[task.status]}>
+            {taskStatusLabels[task.status]}
+          </Badge>
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent>
+        {Object.entries(taskStatusLabels).map(([value, label]) => (
+          <SelectItem key={value} value={value}>
+            <Badge className={taskStatusColors[value as TaskStatus]}>{label}</Badge>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+function DependencyButton({
+  task,
+  onClick,
+}: {
+  task: Task
+  onClick: () => void
+}) {
+  const summary = getTaskDecisionSummary(task)
+  const progress = summary.dependencyTotal
+    ? `${summary.completedDependencies}/${summary.dependencyTotal} 完了`
+    : '依存なし'
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      className="h-auto justify-start gap-2 px-1 py-1 text-left"
+      onClick={onClick}
+    >
+      <GitBranch className="h-4 w-4 shrink-0 text-blue-500" />
+      <span>
+        <span className="block text-sm font-medium">{progress}</span>
+        {summary.hasCancelledDependency ? (
+          <span className="block text-xs text-amber-700 dark:text-amber-300">
+            依存関係の見直しが必要
+          </span>
+        ) : summary.blockingDependencies.length > 0 ? (
+          <span className="block text-xs text-muted-foreground">
+            未完了 {summary.blockingDependencies.length}件
+          </span>
+        ) : (
+          <span className="block text-xs text-muted-foreground">詳細を見る</span>
+        )}
+      </span>
+    </Button>
+  )
+}
+
+function TaskActions({ task, tasks }: { task: Task; tasks: Task[] }) {
+  return (
+    <div className="flex flex-wrap gap-1">
+      <LogFormDialog
+        taskId={task.id}
+        taskTitle={task.title}
+        trigger={
+          <Button variant="outline" size="sm">
+            時間記録
+          </Button>
+        }
+      />
+      <TaskEditDialog task={task} availableTasks={tasks}>
+        <Button variant="outline" size="sm">編集</Button>
+      </TaskEditDialog>
+      <TaskDeleteDialog task={task}>
+        <Button variant="outline" size="sm">削除</Button>
+      </TaskDeleteDialog>
+    </div>
+  )
+}
+
+export function GoalTaskList({
+  tasks,
+  projectId,
+  goalId,
+  logsByTask,
+  logsLoading,
+  logsError,
+  actualMinutesByTask,
+}: GoalTaskListProps) {
+  const [view, setView] = useState<TaskView>('all')
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
+  const summaries = useMemo(
+    () => new Map(tasks.map((task) => [task.id, getTaskDecisionSummary(task)])),
+    [tasks],
+  )
+  const counts = useMemo(
+    () => ({
+      all: tasks.length,
+      ready: tasks.filter((task) => summaries.get(task.id)?.state === 'ready').length,
+      blocked: tasks.filter((task) => summaries.get(task.id)?.state === 'blocked').length,
+      completed: tasks.filter((task) => summaries.get(task.id)?.state === 'completed').length,
+      cancelled: tasks.filter((task) => summaries.get(task.id)?.state === 'cancelled').length,
+    }),
+    [summaries, tasks],
+  )
+  const visibleTasks = useMemo(
+    () =>
+      view === 'all'
+        ? tasks
+        : tasks.filter((task) => summaries.get(task.id)?.state === view),
+    [summaries, tasks, view],
+  )
+  const views: { value: TaskView; label: string; count: number }[] = [
+    { value: 'all', label: 'すべて', count: counts.all },
+    { value: 'ready', label: 'Ready', count: counts.ready },
+    { value: 'blocked', label: 'ブロック中', count: counts.blocked },
+    { value: 'completed', label: '完了', count: counts.completed },
+    { value: 'cancelled', label: 'キャンセル', count: counts.cancelled },
+  ]
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center gap-2 rounded-xl border bg-card p-3">
+        <span className="mr-1 flex items-center gap-1 text-sm font-medium text-muted-foreground">
+          <ListFilter className="h-4 w-4" />
+          表示
+        </span>
+        {views.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            aria-pressed={view === item.value}
+            className={`rounded-full border px-3 py-1.5 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+              view === item.value
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'bg-background hover:bg-muted'
+            }`}
+            onClick={() => setView(item.value)}
+          >
+            {item.label} {item.count}
+          </button>
+        ))}
+      </div>
+
+      {visibleTasks.length === 0 ? (
+        <Card className="border-dashed">
+          <CardContent className="py-10 text-center text-sm text-muted-foreground">
+            この条件に一致するタスクはありません。
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          <Card className="hidden lg:block">
+            <CardContent className="p-0">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>実行状態</TableHead>
+                    <TableHead>タスク</TableHead>
+                    <TableHead>依存状況</TableHead>
+                    <TableHead>ステータス</TableHead>
+                    <TableHead>実績 / 見積</TableHead>
+                    <TableHead>期限</TableHead>
+                    <TableHead>操作</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {visibleTasks.map((task) => (
+                    <TaskDesktopRows
+                      key={task.id}
+                      task={task}
+                      tasks={tasks}
+                      projectId={projectId}
+                      goalId={goalId}
+                      logs={logsByTask[task.id] ?? []}
+                      logsLoading={logsLoading}
+                      logsError={logsError}
+                      actualMinutes={actualMinutesByTask[task.id] ?? 0}
+                      onOpenDependencies={() => setSelectedTaskId(task.id)}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          <div className="grid gap-3 lg:hidden">
+            {visibleTasks.map((task) => (
+              <TaskMobileCard
+                key={task.id}
+                task={task}
+                tasks={tasks}
+                projectId={projectId}
+                goalId={goalId}
+                logs={logsByTask[task.id] ?? []}
+                logsLoading={logsLoading}
+                logsError={logsError}
+                actualMinutes={actualMinutesByTask[task.id] ?? 0}
+                onOpenDependencies={() => setSelectedTaskId(task.id)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
+      <TaskDependencyPanel
+        taskId={selectedTaskId}
+        availableTasks={tasks}
+        onClose={() => setSelectedTaskId(null)}
+        onSelectTask={setSelectedTaskId}
+      />
+    </>
+  )
+}
+
+interface TaskDisplayProps {
+  task: Task
+  tasks: Task[]
+  projectId: string
+  goalId: string
+  logs: Log[]
+  logsLoading: boolean
+  logsError: Error | null
+  actualMinutes: number
+  onOpenDependencies: () => void
+}
+
+function TaskDesktopRows({
+  task,
+  tasks,
+  projectId,
+  goalId,
+  logs,
+  logsLoading,
+  logsError,
+  actualMinutes,
+  onOpenDependencies,
+}: TaskDisplayProps) {
+  return (
+    <>
+      <TableRow>
+        <TableCell><TaskDecisionBadge task={task} /></TableCell>
+        <TableCell className="max-w-[340px]">
+          <Link
+            href={`/projects/${projectId}/goals/${goalId}/tasks/${task.id}`}
+            className="font-medium hover:text-blue-600 hover:underline"
+          >
+            {task.title}
+          </Link>
+          {task.description && (
+            <div className="mt-1 line-clamp-1 text-sm text-muted-foreground">
+              {task.description}
+            </div>
+          )}
+          <div className="mt-2 flex flex-wrap gap-1">
+            <Badge className={workTypeColors[task.work_type ?? 'light_work']}>
+              {workTypeLabels[task.work_type ?? 'light_work']}
+            </Badge>
+            <Badge className={taskPriorityColors[task.priority ?? 3]}>
+              {taskPriorityLabels[task.priority ?? 3]}
+            </Badge>
+          </div>
+        </TableCell>
+        <TableCell><DependencyButton task={task} onClick={onOpenDependencies} /></TableCell>
+        <TableCell><TaskStatusSelect task={task} /></TableCell>
+        <TableCell>
+          <div className="flex items-center gap-1 text-sm">
+            <Clock className="h-3.5 w-3.5 text-green-600" />
+            {(actualMinutes / 60).toFixed(1)}h / {task.estimate_hours}h
+          </div>
+        </TableCell>
+        <TableCell>
+          {task.due_date ? (
+            <div className="flex items-center gap-1 text-sm">
+              <Calendar className="h-3.5 w-3.5" />
+              {new Date(task.due_date).toLocaleDateString('ja-JP')}
+            </div>
+          ) : (
+            <span className="text-sm text-muted-foreground">未設定</span>
+          )}
+        </TableCell>
+        <TableCell><TaskActions task={task} tasks={tasks} /></TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell colSpan={7} className="p-0">
+          <TaskLogsMemoPanel
+            task={task}
+            logs={logs}
+            logsLoading={logsLoading}
+            logsError={logsError}
+          />
+        </TableCell>
+      </TableRow>
+    </>
+  )
+}
+
+function TaskMobileCard({
+  task,
+  tasks,
+  projectId,
+  goalId,
+  logs,
+  logsLoading,
+  logsError,
+  actualMinutes,
+  onOpenDependencies,
+}: TaskDisplayProps) {
+  return (
+    <Card>
+      <CardContent className="space-y-4 p-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <TaskDecisionBadge task={task} />
+            <Link
+              href={`/projects/${projectId}/goals/${goalId}/tasks/${task.id}`}
+              className="mt-2 block font-semibold hover:text-blue-600 hover:underline"
+            >
+              {task.title}
+            </Link>
+            {task.description && (
+              <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                {task.description}
+              </p>
+            )}
+          </div>
+          <TaskStatusSelect task={task} />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 rounded-lg bg-muted/50 p-3 text-sm">
+          <div>
+            <div className="text-xs text-muted-foreground">実績 / 見積</div>
+            <div className="mt-1 font-medium">
+              {(actualMinutes / 60).toFixed(1)}h / {task.estimate_hours}h
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">期限</div>
+            <div className="mt-1 font-medium">
+              {task.due_date
+                ? new Date(task.due_date).toLocaleDateString('ja-JP')
+                : '未設定'}
+            </div>
+          </div>
+        </div>
+
+        <DependencyButton task={task} onClick={onOpenDependencies} />
+        <TaskActions task={task} tasks={tasks} />
+        <TaskLogsMemoPanel
+          task={task}
+          logs={logs}
+          logsLoading={logsLoading}
+          logsError={logsError}
+        />
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/components/tasks/task-dependency-map.tsx
+++ b/apps/web/src/components/tasks/task-dependency-map.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { select } from "d3-selection";
+import {
+  zoom,
+  zoomIdentity,
+  type ZoomBehavior,
+  type ZoomTransform,
+} from "d3-zoom";
+import { AlertTriangle, Maximize2, Minus, Plus } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  collectConnectedTaskIds,
+  layoutTaskDependencyGraph,
+  TASK_GRAPH_NODE_HEIGHT,
+  TASK_GRAPH_NODE_WIDTH,
+} from "@/lib/tasks/dependency-graph-layout";
+import type {
+  TaskDependencyGraphNode,
+  TaskDependencyGraphResponse,
+} from "@/types/task";
+
+interface TaskDependencyMapProps {
+  graph?: TaskDependencyGraphResponse;
+  isLoading: boolean;
+  isError: boolean;
+  selectedTaskId: string | null;
+  onSelectTask: (node: TaskDependencyGraphNode) => void;
+}
+
+function compactTitle(title: string) {
+  return title.length > 27 ? `${title.slice(0, 26)}…` : title;
+}
+
+function stateLabel(node: TaskDependencyGraphNode) {
+  if (node.status === "completed") return "完了";
+  if (node.status === "cancelled") return "キャンセル";
+  if (node.is_blocked) return "ブロック中";
+  if (node.is_ready) return "Ready";
+  return "未着手";
+}
+
+function stateColor(node: TaskDependencyGraphNode) {
+  if (node.status === "completed") return "#16a34a";
+  if (node.status === "cancelled") return "#94a3b8";
+  if (node.is_blocked) return "#f59e0b";
+  if (node.is_ready) return "#2563eb";
+  return "#64748b";
+}
+
+export function TaskDependencyMap({
+  graph,
+  isLoading,
+  isError,
+  selectedTaskId,
+  onSelectTask,
+}: TaskDependencyMapProps) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const svgRef = useRef<SVGSVGElement>(null);
+  const behaviorRef = useRef<ZoomBehavior<SVGSVGElement, unknown> | null>(null);
+  const [transform, setTransform] = useState<ZoomTransform>(zoomIdentity);
+  const layout = useMemo(
+    () => layoutTaskDependencyGraph(graph?.nodes ?? [], graph?.edges ?? []),
+    [graph],
+  );
+  const nodeById = useMemo(
+    () => new Map(layout.nodes.map((node) => [node.id, node])),
+    [layout.nodes],
+  );
+  const connectedIds = useMemo(
+    () => collectConnectedTaskIds(selectedTaskId, graph?.edges ?? []),
+    [graph?.edges, selectedTaskId],
+  );
+
+  const fitGraph = useCallback(() => {
+    const svg = svgRef.current;
+    const viewport = viewportRef.current;
+    const behavior = behaviorRef.current;
+    if (
+      !svg ||
+      !viewport ||
+      !behavior ||
+      layout.width === 0 ||
+      layout.height === 0
+    )
+      return;
+    const width = viewport.clientWidth;
+    const height = viewport.clientHeight;
+    const scale = Math.min(
+      1.25,
+      Math.max(
+        0.2,
+        Math.min((width - 48) / layout.width, (height - 48) / layout.height),
+      ),
+    );
+    const next = zoomIdentity
+      .translate(
+        (width - layout.width * scale) / 2,
+        (height - layout.height * scale) / 2,
+      )
+      .scale(scale);
+    select(svg).call(behavior.transform, next);
+  }, [layout.height, layout.width]);
+
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const behavior = zoom<SVGSVGElement, unknown>()
+      .scaleExtent([0.2, 2.5])
+      .on("zoom", (event) => setTransform(event.transform));
+    behaviorRef.current = behavior;
+    select(svg).call(behavior);
+    return () => {
+      select(svg).on(".zoom", null);
+      behaviorRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    fitGraph();
+  }, [fitGraph]);
+
+  const zoomBy = (factor: number) => {
+    const svg = svgRef.current;
+    const behavior = behaviorRef.current;
+    if (svg && behavior) select(svg).call(behavior.scaleBy, factor);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex h-[560px] items-center justify-center text-muted-foreground">
+        依存マップを読み込み中...
+      </div>
+    );
+  }
+  if (isError) {
+    return (
+      <div className="flex h-[560px] items-center justify-center text-destructive">
+        依存マップを取得できませんでした
+      </div>
+    );
+  }
+  if (graph?.exceeds_limit) {
+    return (
+      <div className="flex h-[560px] flex-col items-center justify-center gap-3 px-6 text-center">
+        <AlertTriangle className="h-8 w-8 text-amber-500" />
+        <div className="font-medium">表示対象が多すぎます</div>
+        <p className="max-w-lg text-sm text-muted-foreground">
+          直結タスクを含めて {graph.node_count} 件あります。{graph.limit}{" "}
+          件以下になるよう、プロジェクト・ゴール・検索条件で絞り込んでください。
+        </p>
+      </div>
+    );
+  }
+  if (!graph || graph.nodes.length === 0) {
+    return (
+      <div className="flex h-[560px] items-center justify-center text-muted-foreground">
+        条件に一致するタスクはありません
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        ref={viewportRef}
+        className="relative h-[560px] overflow-hidden bg-muted/20"
+      >
+        <div className="absolute right-3 top-3 z-10 flex gap-1 rounded-md border bg-background/95 p-1 shadow-sm">
+          <Button
+            size="icon"
+            variant="ghost"
+            aria-label="拡大"
+            onClick={() => zoomBy(1.25)}
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            aria-label="縮小"
+            onClick={() => zoomBy(0.8)}
+          >
+            <Minus className="h-4 w-4" />
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            aria-label="全体を表示"
+            onClick={fitGraph}
+          >
+            <Maximize2 className="h-4 w-4" />
+          </Button>
+        </div>
+        <svg
+          ref={svgRef}
+          className="h-full w-full touch-none"
+          aria-label="タスク依存マップ"
+        >
+          <defs>
+            <marker
+              id="task-dependency-arrow"
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="7"
+              markerHeight="7"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="currentColor" />
+            </marker>
+          </defs>
+          <g transform={transform.toString()}>
+            {(graph.edges ?? []).map((edge) => {
+              const from = nodeById.get(edge.prerequisite_task_id);
+              const to = nodeById.get(edge.dependent_task_id);
+              if (!from || !to) return null;
+              const active =
+                selectedTaskId === null ||
+                (connectedIds.has(from.id) && connectedIds.has(to.id));
+              const x1 = from.x + TASK_GRAPH_NODE_WIDTH;
+              const y1 = from.y + TASK_GRAPH_NODE_HEIGHT / 2;
+              const x2 = to.x;
+              const y2 = to.y + TASK_GRAPH_NODE_HEIGHT / 2;
+              const bend = Math.max(36, (x2 - x1) / 2);
+              return (
+                <path
+                  key={edge.id}
+                  d={`M ${x1} ${y1} C ${x1 + bend} ${y1}, ${x2 - bend} ${y2}, ${x2} ${y2}`}
+                  fill="none"
+                  stroke={active ? "#64748b" : "#cbd5e1"}
+                  strokeWidth={active ? 2 : 1}
+                  opacity={active ? 0.9 : 0.3}
+                  markerEnd="url(#task-dependency-arrow)"
+                  className="text-slate-500"
+                />
+              );
+            })}
+            {layout.nodes.map((node) => {
+              const selected = node.id === selectedTaskId;
+              const dimmed =
+                selectedTaskId !== null && !connectedIds.has(node.id);
+              return (
+                <g
+                  key={node.id}
+                  transform={`translate(${node.x} ${node.y})`}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`${node.title}、${stateLabel(node)}`}
+                  onClick={() => onSelectTask(node)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ")
+                      onSelectTask(node);
+                  }}
+                  className="cursor-pointer outline-none"
+                  opacity={dimmed ? 0.28 : node.is_context ? 0.68 : 1}
+                >
+                  <rect
+                    width={TASK_GRAPH_NODE_WIDTH}
+                    height={TASK_GRAPH_NODE_HEIGHT}
+                    rx={10}
+                    fill="hsl(var(--background))"
+                    stroke={
+                      selected
+                        ? "#2563eb"
+                        : node.is_context
+                          ? "#94a3b8"
+                          : "#cbd5e1"
+                    }
+                    strokeWidth={selected ? 3 : 1.5}
+                    strokeDasharray={node.is_context ? "6 4" : undefined}
+                  />
+                  <circle cx={16} cy={20} r={5} fill={stateColor(node)} />
+                  <text
+                    x={28}
+                    y={24}
+                    fontSize={12}
+                    fontWeight={600}
+                    fill="currentColor"
+                  >
+                    {stateLabel(node)}
+                  </text>
+                  <text
+                    x={14}
+                    y={52}
+                    fontSize={14}
+                    fontWeight={600}
+                    fill="currentColor"
+                  >
+                    {compactTitle(node.title)}
+                  </text>
+                  <text x={14} y={76} fontSize={11} fill="#64748b">
+                    {compactTitle(`${node.project_title} › ${node.goal_title}`)}
+                  </text>
+                  <text x={14} y={94} fontSize={10} fill="#64748b">
+                    優先度 {node.priority}
+                    {node.is_context ? " · フィルター外" : ""}
+                  </text>
+                </g>
+              );
+            })}
+          </g>
+        </svg>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 border-t px-4 py-3 text-xs text-muted-foreground">
+        <span>矢印: 前提タスク → 後続タスク</span>
+        <Badge variant="outline" className="border-dashed">
+          フィルター外の直結タスク
+        </Badge>
+        <span>ノードを選択すると上流・下流を強調します</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/tasks/task-dependency-panel.tsx
+++ b/apps/web/src/components/tasks/task-dependency-panel.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import Link from "next/link";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  Clock,
+  ExternalLink,
+  Loader2,
+  Pencil,
+  Play,
+  X,
+} from "lucide-react";
+
+import { TaskEditDialog } from "@/components/tasks/task-edit-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useTask, useTaskDependencyContext } from "@/hooks/use-tasks-query";
+import type { Task, TaskDependencyContextTask } from "@/types/task";
+import { taskStatusLabels } from "@/types/task";
+
+interface TaskDependencyPanelProps {
+  taskId: string | null;
+  availableTasks: Task[];
+  onClose: () => void;
+  onSelectTask: (taskId: string) => void;
+}
+
+function DependencyItem({
+  item,
+  onSelect,
+}: {
+  item: TaskDependencyContextTask;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      className="w-full rounded-lg border p-3 text-left transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      onClick={onSelect}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="line-clamp-2 text-sm font-medium">{item.title}</span>
+        <Badge
+          variant={
+            item.status === "completed"
+              ? "success"
+              : item.status === "cancelled"
+                ? "destructive"
+                : item.is_blocked
+                  ? "warning"
+                  : "outline"
+          }
+        >
+          {item.status === "cancelled"
+            ? "要確認"
+            : taskStatusLabels[item.status]}
+        </Badge>
+      </div>
+      <div className="mt-1 truncate text-xs text-muted-foreground">
+        {item.project_title} › {item.goal_title}
+      </div>
+    </button>
+  );
+}
+
+export function TaskDependencyPanel({
+  taskId,
+  availableTasks,
+  onClose,
+  onSelectTask,
+}: TaskDependencyPanelProps) {
+  const taskQuery = useTask(taskId ?? "");
+  const contextQuery = useTaskDependencyContext(taskId ?? undefined);
+  if (!taskId) return null;
+
+  const task = taskQuery.data;
+  const context = contextQuery.data;
+  const hasCancelledPrerequisite = context?.prerequisites.some(
+    (item) => item.status === "cancelled",
+  );
+  const canStart =
+    Boolean(context) &&
+    (task?.status === "pending" || task?.status === "in_progress") &&
+    context?.prerequisites.every((item) => item.status === "completed");
+
+  return (
+    <div className="fixed inset-0 z-50" role="presentation">
+      <button
+        aria-label="詳細パネルを閉じる"
+        className="absolute inset-0 bg-black/20"
+        onClick={onClose}
+      />
+      <aside
+        aria-label="タスク詳細"
+        className="absolute inset-y-0 right-0 w-full overflow-y-auto border-l bg-background shadow-2xl sm:w-[460px]"
+      >
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b bg-background/95 px-5 py-4 backdrop-blur">
+          <div>
+            <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Task details
+            </div>
+            <div className="text-sm font-medium">依存関係と実行情報</div>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="閉じる"
+            onClick={onClose}
+          >
+            <X className="h-5 w-5" />
+          </Button>
+        </div>
+
+        {taskQuery.isLoading ? (
+          <div className="flex h-64 items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : !task ? (
+          <div className="p-6 text-sm text-destructive">
+            タスクを読み込めませんでした。
+          </div>
+        ) : (
+          <div className="space-y-6 p-5">
+            <div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge
+                  variant={task.status === "completed" ? "success" : "outline"}
+                >
+                  {taskStatusLabels[task.status]}
+                </Badge>
+                {context?.prerequisites.every(
+                  (item) => item.status === "completed",
+                ) &&
+                  (task.status === "pending" ||
+                    task.status === "in_progress") && (
+                    <Badge variant="info">Ready</Badge>
+                  )}
+              </div>
+              <h2 className="mt-3 text-xl font-semibold">{task.title}</h2>
+              {task.description && (
+                <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                  {task.description}
+                </p>
+              )}
+              <div className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
+                <span className="flex items-center gap-1">
+                  <Clock className="h-3.5 w-3.5" />
+                  {task.estimate_hours}時間
+                </span>
+                <span>優先度 {task.priority}</span>
+                {task.due_date && (
+                  <span>
+                    期限 {new Date(task.due_date).toLocaleDateString("ja-JP")}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {hasCancelledPrerequisite && (
+              <div className="flex gap-2 rounded-lg border border-amber-400/50 bg-amber-50 p-3 text-sm text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                キャンセルされた前提タスクがあります。依存関係を見直すまで、このタスクはブロックされます。
+              </div>
+            )}
+
+            <section>
+              <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
+                <ArrowLeft className="h-4 w-4" />
+                先に必要なタスク
+              </h3>
+              {contextQuery.isLoading ? (
+                <div className="text-sm text-muted-foreground">
+                  読み込み中...
+                </div>
+              ) : context?.prerequisites.length ? (
+                <div className="space-y-2">
+                  {context.prerequisites.map((item) => (
+                    <DependencyItem
+                      key={item.id}
+                      item={item}
+                      onSelect={() => onSelectTask(item.id)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 rounded-lg border border-dashed p-3 text-sm text-muted-foreground">
+                  <CheckCircle2 className="h-4 w-4 text-green-600" />
+                  前提タスクはありません
+                </div>
+              )}
+            </section>
+
+            <section>
+              <h3 className="mb-2 flex items-center gap-2 text-sm font-semibold">
+                <ArrowRight className="h-4 w-4" />
+                このタスクを待っているタスク
+              </h3>
+              {context?.dependents.length ? (
+                <div className="space-y-2">
+                  {context.dependents.map((item) => (
+                    <DependencyItem
+                      key={item.id}
+                      item={item}
+                      onSelect={() => onSelectTask(item.id)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-lg border border-dashed p-3 text-sm text-muted-foreground">
+                  後続タスクはありません
+                </div>
+              )}
+            </section>
+
+            <div className="grid gap-2 border-t pt-5 sm:grid-cols-2">
+              {canStart ? (
+                <Button asChild>
+                  <Link href={`/runner?taskId=${encodeURIComponent(task.id)}`}>
+                    <Play className="mr-2 h-4 w-4" />
+                    Runnerで開始
+                  </Link>
+                </Button>
+              ) : (
+                <Button disabled>
+                  <Play className="mr-2 h-4 w-4" />
+                  Runnerで開始
+                </Button>
+              )}
+              <TaskEditDialog task={task} availableTasks={availableTasks}>
+                <Button variant="outline">
+                  <Pencil className="mr-2 h-4 w-4" />
+                  編集・依存設定
+                </Button>
+              </TaskEditDialog>
+              <Button variant="ghost" className="sm:col-span-2" asChild>
+                <Link href={`/projects`}>
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                  プロジェクト画面を開く
+                </Link>
+              </Button>
+            </div>
+          </div>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-tasks-query.ts
+++ b/apps/web/src/hooks/use-tasks-query.ts
@@ -16,13 +16,14 @@ export const taskKeys = {
   byProject: (projectId: string) => [...taskKeys.all, 'project', projectId] as const,
   workspace: (filters: TaskWorkspaceFilters) => [...taskKeys.all, 'workspace', filters] as const,
   recommendations: () => [...taskKeys.all, 'recommendations'] as const,
+  summary: (filters: Pick<TaskWorkspaceFilters, 'projectId' | 'goalId' | 'search'>) => [...taskKeys.all, 'summary', filters] as const,
+  dependencyGraph: (filters: TaskWorkspaceFilters) => [...taskKeys.all, 'dependency-graph', filters] as const,
+  dependencyContext: (taskId: string) => [...taskKeys.detail(taskId), 'dependency-context'] as const,
 }
 
-const isTaskGoalQuery = (query: Query) =>
-  query.queryKey[0] === taskKeys.all[0] && query.queryKey[1] === 'goal'
+const isTaskGoalQuery = (query: Query) => query.queryKey[0] === taskKeys.all[0] && query.queryKey[1] === 'goal'
 
-const isTaskProjectQuery = (query: Query) =>
-  query.queryKey[0] === taskKeys.all[0] && query.queryKey[1] === 'project'
+const isTaskProjectQuery = (query: Query) => query.queryKey[0] === taskKeys.all[0] && query.queryKey[1] === 'project'
 
 const invalidateTaskCollections = (queryClient: QueryClient, goalId?: string) => {
   if (goalId) {
@@ -34,6 +35,13 @@ const invalidateTaskCollections = (queryClient: QueryClient, goalId?: string) =>
   queryClient.invalidateQueries({ predicate: isTaskProjectQuery })
   queryClient.invalidateQueries({ queryKey: [...taskKeys.all, 'workspace'] })
   queryClient.invalidateQueries({ queryKey: taskKeys.recommendations() })
+  queryClient.invalidateQueries({ queryKey: [...taskKeys.all, 'summary'] })
+  queryClient.invalidateQueries({
+    queryKey: [...taskKeys.all, 'dependency-graph'],
+  })
+  queryClient.invalidateQueries({
+    predicate: (query) => query.queryKey.includes('dependency-context'),
+  })
 }
 
 export function useTaskWorkspace(filters: TaskWorkspaceFilters, enabled = true) {
@@ -54,11 +62,34 @@ export function useTaskRecommendations(enabled = true) {
   })
 }
 
-const updateTaskInList = (
-  data: unknown,
-  taskId: string,
-  updateTask: (task: Task) => Task
-) => {
+export function useTaskWorkspaceSummary(filters: Pick<TaskWorkspaceFilters, 'projectId' | 'goalId' | 'search'>, enabled = true) {
+  return useQuery({
+    queryKey: taskKeys.summary(filters),
+    queryFn: () => tasksApi.getSummary(filters),
+    enabled,
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useTaskDependencyGraph(filters: TaskWorkspaceFilters, enabled = true) {
+  return useQuery({
+    queryKey: taskKeys.dependencyGraph(filters),
+    queryFn: () => tasksApi.getDependencyGraph(filters),
+    enabled,
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useTaskDependencyContext(taskId?: string) {
+  return useQuery({
+    queryKey: taskKeys.dependencyContext(taskId ?? ''),
+    queryFn: () => tasksApi.getDependencyContext(taskId as string),
+    enabled: Boolean(taskId),
+    staleTime: 30 * 1000,
+  })
+}
+
+const updateTaskInList = (data: unknown, taskId: string, updateTask: (task: Task) => Task) => {
   if (!Array.isArray(data)) {
     return data
   }
@@ -72,24 +103,12 @@ const updateTaskInList = (
   })
 }
 
-const updateTaskCaches = (
-  queryClient: QueryClient,
-  task: Task,
-  updateTask: (task: Task) => Task
-) => {
-  queryClient.setQueryData<Task>(taskKeys.detail(task.id), (cachedTask) =>
-    updateTask(cachedTask ?? task)
-  )
+const updateTaskCaches = (queryClient: QueryClient, task: Task, updateTask: (task: Task) => Task) => {
+  queryClient.setQueryData<Task>(taskKeys.detail(task.id), (cachedTask) => updateTask(cachedTask ?? task))
 
-  queryClient.setQueriesData(
-    { queryKey: taskKeys.byGoal(task.goal_id) },
-    (data) => updateTaskInList(data, task.id, updateTask)
-  )
+  queryClient.setQueriesData({ queryKey: taskKeys.byGoal(task.goal_id) }, (data) => updateTaskInList(data, task.id, updateTask))
 
-  queryClient.setQueriesData(
-    { predicate: isTaskProjectQuery },
-    (data) => updateTaskInList(data, task.id, updateTask)
-  )
+  queryClient.setQueriesData({ predicate: isTaskProjectQuery }, (data) => updateTaskInList(data, task.id, updateTask))
 }
 
 /**
@@ -102,7 +121,7 @@ const updateTaskCaches = (
  * @returns UseQueryResult with task array
  */
 export function useTasksByGoal(goalId: string, skip = 0, limit = DEFAULT_TASK_PAGE_LIMIT, sortOptions?: SortOptions) {
-  const sortKey = sortOptions ? `sort-${sortOptions.sortBy}-${sortOptions.sortOrder}` : 'default';
+  const sortKey = sortOptions ? `sort-${sortOptions.sortBy}-${sortOptions.sortOrder}` : 'default'
   return useQuery({
     queryKey: [...taskKeys.byGoal(goalId), 'page', skip, limit, sortKey],
     queryFn: () => tasksApi.getByGoal(goalId, skip, limit, sortOptions),
@@ -120,23 +139,23 @@ export function useTasksByGoal(goalId: string, skip = 0, limit = DEFAULT_TASK_PA
  * @returns UseQueryResult with the complete task array
  */
 export function useAllTasksByGoal(goalId: string, sortOptions?: SortOptions) {
-  const sortKey = sortOptions ? `sort-${sortOptions.sortBy}-${sortOptions.sortOrder}` : 'default';
+  const sortKey = sortOptions ? `sort-${sortOptions.sortBy}-${sortOptions.sortOrder}` : 'default'
 
   return useQuery({
     queryKey: [...taskKeys.byGoal(goalId), 'all', DEFAULT_TASK_PAGE_LIMIT, sortKey],
     queryFn: async () => {
-      const tasks: Task[] = [];
-      let skip = 0;
+      const tasks: Task[] = []
+      let skip = 0
 
       while (true) {
-        const page = await tasksApi.getByGoal(goalId, skip, DEFAULT_TASK_PAGE_LIMIT, sortOptions);
-        tasks.push(...page);
+        const page = await tasksApi.getByGoal(goalId, skip, DEFAULT_TASK_PAGE_LIMIT, sortOptions)
+        tasks.push(...page)
 
         if (page.length < DEFAULT_TASK_PAGE_LIMIT) {
-          return tasks;
+          return tasks
         }
 
-        skip += DEFAULT_TASK_PAGE_LIMIT;
+        skip += DEFAULT_TASK_PAGE_LIMIT
       }
     },
     enabled: !!goalId,
@@ -155,7 +174,7 @@ export function useAllTasksByGoal(goalId: string, sortOptions?: SortOptions) {
  * @returns UseQueryResult with task array
  */
 export function useTasksByProject(projectId: string, skip = 0, limit = DEFAULT_TASK_PAGE_LIMIT, sortOptions?: SortOptions) {
-  const sortKey = sortOptions ? `sort-${sortOptions.sortBy}-${sortOptions.sortOrder}` : 'default';
+  const sortKey = sortOptions ? `sort-${sortOptions.sortBy}-${sortOptions.sortOrder}` : 'default'
   return useQuery({
     queryKey: [...taskKeys.byProject(projectId), 'page', skip, limit, sortKey],
     queryFn: () => tasksApi.getByProject(projectId, skip, limit, sortOptions),
@@ -196,10 +215,7 @@ export function useCreateTask() {
       invalidateTaskCollections(queryClient, newTask.goal_id)
 
       // Add the new task to cache
-      queryClient.setQueryData(
-        taskKeys.detail(newTask.id),
-        newTask
-      )
+      queryClient.setQueryData(taskKeys.detail(newTask.id), newTask)
     },
   })
 }
@@ -214,20 +230,13 @@ export function useUpdateTask() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: ({ id, data }: { id: string; data: TaskUpdate }) =>
-      tasksApi.update(id, data),
+    mutationFn: ({ id, data }: { id: string; data: TaskUpdate }) => tasksApi.update(id, data),
     onSuccess: (updatedTask: Task, variables) => {
       // Update the cached task
-      queryClient.setQueryData(
-        taskKeys.detail(updatedTask.id),
-        updatedTask
-      )
+      queryClient.setQueryData(taskKeys.detail(updatedTask.id), updatedTask)
 
       // Invalidate task collections to reflect changes in goal and project views.
-      invalidateTaskCollections(
-        queryClient,
-        variables.data.goal_id ? undefined : updatedTask.goal_id
-      )
+      invalidateTaskCollections(queryClient, variables.data.goal_id ? undefined : updatedTask.goal_id)
     },
   })
 }
@@ -269,23 +278,20 @@ export function useAddTaskDependency(task: Task, availableTasks: Task[] = []) {
       const dependsOnTask = availableTasks.find((availableTask) => availableTask.id === dependsOnTaskId)
       const hydratedDependency: TaskDependency = {
         ...dependency,
-        depends_on_task: dependency.depends_on_task ?? (dependsOnTask
-          ? {
-              id: dependsOnTask.id,
-              title: dependsOnTask.title,
-              status: dependsOnTask.status,
-            }
-          : null),
+        depends_on_task:
+          dependency.depends_on_task ??
+          (dependsOnTask
+            ? {
+                id: dependsOnTask.id,
+                title: dependsOnTask.title,
+                status: dependsOnTask.status,
+              }
+            : null),
       }
 
       updateTaskCaches(queryClient, task, (cachedTask) => ({
         ...cachedTask,
-        dependencies: [
-          ...(cachedTask.dependencies ?? []).filter(
-            (existingDependency) => existingDependency.id !== hydratedDependency.id
-          ),
-          hydratedDependency,
-        ],
+        dependencies: [...(cachedTask.dependencies ?? []).filter((existingDependency) => existingDependency.id !== hydratedDependency.id), hydratedDependency],
       }))
 
       queryClient.invalidateQueries({ queryKey: taskKeys.detail(task.id) })
@@ -306,9 +312,7 @@ export function useDeleteTaskDependency(task: Task) {
     onSuccess: (_, dependencyId) => {
       updateTaskCaches(queryClient, task, (cachedTask) => ({
         ...cachedTask,
-        dependencies: (cachedTask.dependencies ?? []).filter(
-          (dependency) => dependency.id !== dependencyId
-        ),
+        dependencies: (cachedTask.dependencies ?? []).filter((dependency) => dependency.id !== dependencyId),
       }))
 
       queryClient.invalidateQueries({ queryKey: taskKeys.detail(task.id) })

--- a/apps/web/src/lib/__tests__/tasks-api.test.ts
+++ b/apps/web/src/lib/__tests__/tasks-api.test.ts
@@ -83,25 +83,15 @@ describe('tasksApi', () => {
   })
 
   it('normalizes string estimate_hours from task list responses', async () => {
-    mockFetchWithFallback.mockResolvedValueOnce(
-      mockJsonResponse([
-        rawTask({ id: 'task-1', estimate_hours: '2.50' }),
-        rawTask({ id: 'task-2', estimate_hours: 1.25 }),
-      ])
-    )
+    mockFetchWithFallback.mockResolvedValueOnce(mockJsonResponse([rawTask({ id: 'task-1', estimate_hours: '2.50' }), rawTask({ id: 'task-2', estimate_hours: 1.25 })]))
 
     const tasks = await tasksApi.getByGoal('goal-1')
 
-    expect(tasks).toEqual([
-      expect.objectContaining({ id: 'task-1', estimate_hours: 2.5 }),
-      expect.objectContaining({ id: 'task-2', estimate_hours: 1.25 }),
-    ])
+    expect(tasks).toEqual([expect.objectContaining({ id: 'task-1', estimate_hours: 2.5 }), expect.objectContaining({ id: 'task-2', estimate_hours: 1.25 })])
   })
 
   it('normalizes string estimate_hours from single task responses', async () => {
-    mockFetchWithFallback.mockResolvedValueOnce(
-      mockJsonResponse(rawTask({ estimate_hours: '3.75' }))
-    )
+    mockFetchWithFallback.mockResolvedValueOnce(mockJsonResponse(rawTask({ estimate_hours: '3.75' })))
 
     const task = await tasksApi.getById('task-1')
 
@@ -109,9 +99,7 @@ describe('tasksApi', () => {
   })
 
   it('normalizes invalid estimate_hours values to zero at the API boundary', async () => {
-    mockFetchWithFallback.mockResolvedValueOnce(
-      mockJsonResponse(rawTask({ estimate_hours: 'not-a-number' }))
-    )
+    mockFetchWithFallback.mockResolvedValueOnce(mockJsonResponse(rawTask({ estimate_hours: 'not-a-number' })))
 
     const task = await tasksApi.update('task-1', { title: 'Updated' })
 
@@ -129,6 +117,7 @@ describe('tasksApi', () => {
             project_title: 'Project 1',
             goal_title: 'Goal 1',
             is_blocked: false,
+            is_ready: true,
             blocking_task_ids: [],
             last_worked_at: null,
             planned_today: true,
@@ -138,7 +127,7 @@ describe('tasksApi', () => {
         total: 1,
         skip: 0,
         limit: 50,
-      })
+      }),
     )
 
     const page = await tasksApi.getWorkspace({
@@ -150,11 +139,65 @@ describe('tasksApi', () => {
     })
 
     expect(mockFetchWithFallback).toHaveBeenCalledTimes(1)
-    expect(mockFetchWithFallback.mock.calls[0]?.[0]).toContain(
-      '/api/tasks?status=pending&status=in_progress&project_id=project-1&project_status=in_progress&search=workspace&plan=today'
-    )
+    expect(mockFetchWithFallback.mock.calls[0]?.[0]).toContain('/api/tasks?status=pending&status=in_progress&project_id=project-1&project_status=in_progress&search=workspace&plan=today')
     expect(page.items[0]).toEqual(
-      expect.objectContaining({ estimate_hours: 3.5, remaining_estimate_hours: 2.25 })
+      expect.objectContaining({
+        estimate_hours: 3.5,
+        remaining_estimate_hours: 2.25,
+        is_ready: true,
+      }),
     )
+  })
+
+  it('loads workspace summary for the active hierarchy scope', async () => {
+    mockFetchWithFallback.mockResolvedValueOnce(
+      mockJsonResponse({
+        total: 8,
+        ready: 4,
+        blocked: 2,
+        in_progress: 1,
+        overdue: 1,
+      }),
+    )
+
+    const summary = await tasksApi.getSummary({
+      projectId: 'project-1',
+      goalId: 'goal-1',
+      search: 'publish',
+    })
+
+    expect(mockFetchWithFallback.mock.calls[0]?.[0]).toContain('/api/tasks/summary?project_id=project-1&goal_id=goal-1&search=publish')
+    expect(summary.ready).toBe(4)
+  })
+
+  it('loads the dependency graph with the workspace filters', async () => {
+    mockFetchWithFallback.mockResolvedValueOnce(
+      mockJsonResponse({
+        nodes: [],
+        edges: [],
+        total: 0,
+        node_count: 0,
+        exceeds_limit: false,
+        limit: 200,
+      }),
+    )
+
+    await tasksApi.getDependencyGraph({
+      status: ['pending', 'in_progress'],
+      projectId: 'project-1',
+      blocked: false,
+      plan: 'today',
+    })
+
+    expect(mockFetchWithFallback.mock.calls[0]?.[0]).toContain('/api/tasks/dependency-graph?status=pending&status=in_progress&project_id=project-1&blocked=false&plan=today')
+  })
+
+  it('loads both directions of dependency context', async () => {
+    mockFetchWithFallback.mockResolvedValueOnce(mockJsonResponse({ prerequisites: [], dependents: [] }))
+
+    const context = await tasksApi.getDependencyContext('task-1')
+
+    expect(mockFetchWithFallback.mock.calls[0]?.[0]).toContain('/api/tasks/task-1/dependency-context')
+    expect(context).toEqual({ prerequisites: [], dependents: [] })
   })
 })

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -15,10 +15,13 @@ import type {
   TaskCreate,
   TaskUpdate,
   TaskDependency,
+  TaskDependencyContext,
+  TaskDependencyGraphResponse,
   TaskRecommendation,
   TaskWorkspaceFilters,
   TaskWorkspaceItem,
   TaskWorkspacePage,
+  TaskWorkspaceSummary,
 } from "@/types/task";
 import type { Log, LogCreate, LogUpdate } from "@/types/log";
 import type {
@@ -580,6 +583,44 @@ class ApiClient {
       ...recommendation,
       task: normalizeWorkspaceItem(recommendation.task),
     }));
+  }
+
+  async getTaskWorkspaceSummary(
+    filters: Pick<TaskWorkspaceFilters, "projectId" | "goalId" | "search"> = {},
+  ): Promise<TaskWorkspaceSummary> {
+    const params = new URLSearchParams();
+    if (filters.projectId) params.set("project_id", filters.projectId);
+    if (filters.goalId) params.set("goal_id", filters.goalId);
+    if (filters.search) params.set("search", filters.search);
+    return this.request<TaskWorkspaceSummary>(
+      `/api/tasks/summary?${params.toString()}`,
+    );
+  }
+
+  async getTaskDependencyGraph(
+    filters: TaskWorkspaceFilters = {},
+  ): Promise<TaskDependencyGraphResponse> {
+    const params = new URLSearchParams();
+    filters.status?.forEach((status) => params.append("status", status));
+    if (filters.projectId) params.set("project_id", filters.projectId);
+    if (filters.goalId) params.set("goal_id", filters.goalId);
+    if (filters.dueBefore) params.set("due_before", filters.dueBefore);
+    if (filters.dueAfter) params.set("due_after", filters.dueAfter);
+    if (filters.search) params.set("search", filters.search);
+    if (filters.blocked !== undefined)
+      params.set("blocked", String(filters.blocked));
+    if (filters.plan) params.set("plan", filters.plan);
+    return this.request<TaskDependencyGraphResponse>(
+      `/api/tasks/dependency-graph?${params.toString()}`,
+    );
+  }
+
+  async getTaskDependencyContext(
+    taskId: string,
+  ): Promise<TaskDependencyContext> {
+    return this.request<TaskDependencyContext>(
+      `/api/tasks/${taskId}/dependency-context`,
+    );
   }
 
   async getTask(taskId: string): Promise<Task> {
@@ -1585,9 +1626,7 @@ class ApiClient {
     return this.request<HookToken[]>("/api/user/hook-tokens");
   }
 
-  async createHookToken(
-    tokenData: HookTokenCreate,
-  ): Promise<HookTokenCreated> {
+  async createHookToken(tokenData: HookTokenCreate): Promise<HookTokenCreated> {
     return this.request<HookTokenCreated>("/api/user/hook-tokens", {
       method: "POST",
       body: JSON.stringify(tokenData),
@@ -1754,6 +1793,13 @@ export const tasksApi = {
   getWorkspace: (filters?: TaskWorkspaceFilters) =>
     apiClient.getTaskWorkspace(filters),
   getRecommendations: () => apiClient.getTaskRecommendations(),
+  getSummary: (
+    filters?: Pick<TaskWorkspaceFilters, "projectId" | "goalId" | "search">,
+  ) => apiClient.getTaskWorkspaceSummary(filters),
+  getDependencyGraph: (filters?: TaskWorkspaceFilters) =>
+    apiClient.getTaskDependencyGraph(filters),
+  getDependencyContext: (taskId: string) =>
+    apiClient.getTaskDependencyContext(taskId),
   getByGoal: (
     goalId: string,
     skip?: number,

--- a/apps/web/src/lib/tasks/__tests__/dependency-graph-layout.test.ts
+++ b/apps/web/src/lib/tasks/__tests__/dependency-graph-layout.test.ts
@@ -1,0 +1,75 @@
+import {
+  collectConnectedTaskIds,
+  layoutTaskDependencyGraph,
+} from "../dependency-graph-layout";
+import type {
+  TaskDependencyGraphEdge,
+  TaskDependencyGraphNode,
+} from "@/types/task";
+
+const node = (id: string): TaskDependencyGraphNode => ({
+  id,
+  title: `Task ${id}`,
+  status: "pending",
+  project_id: "project-1",
+  project_title: "Project",
+  goal_id: "goal-1",
+  goal_title: "Goal",
+  is_ready: true,
+  is_blocked: false,
+  priority: 3,
+  due_date: null,
+  is_context: false,
+});
+
+const edge = (
+  id: string,
+  prerequisite: string,
+  dependent: string,
+): TaskDependencyGraphEdge => ({
+  id,
+  prerequisite_task_id: prerequisite,
+  dependent_task_id: dependent,
+  prerequisite_status: "pending",
+});
+
+describe("task dependency graph layout", () => {
+  it("places prerequisites to the left of their dependents", () => {
+    const layout = layoutTaskDependencyGraph(
+      [node("prepare"), node("write"), node("publish")],
+      [edge("e1", "prepare", "write"), edge("e2", "write", "publish")],
+    );
+    const positions = new Map(layout.nodes.map((item) => [item.id, item]));
+
+    expect(positions.get("prepare")?.level).toBe(0);
+    expect(positions.get("write")?.level).toBe(1);
+    expect(positions.get("publish")?.level).toBe(2);
+    expect(positions.get("prepare")?.x).toBeLessThan(
+      positions.get("publish")?.x ?? 0,
+    );
+  });
+
+  it("highlights the complete upstream and downstream neighborhood", () => {
+    const edges = [
+      edge("e1", "prepare", "write"),
+      edge("e2", "write", "publish"),
+      edge("e3", "unrelated", "other"),
+    ];
+
+    expect([...collectConnectedTaskIds("write", edges)].sort()).toEqual([
+      "prepare",
+      "publish",
+      "write",
+    ]);
+  });
+
+  it("keeps malformed cyclic legacy nodes visible", () => {
+    const layout = layoutTaskDependencyGraph(
+      [node("a"), node("b")],
+      [edge("e1", "a", "b"), edge("e2", "b", "a")],
+    );
+
+    expect(layout.nodes).toHaveLength(2);
+    expect(layout.nodes.every((item) => item.level > 0)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/tasks/__tests__/task-decision.test.ts
+++ b/apps/web/src/lib/tasks/__tests__/task-decision.test.ts
@@ -1,0 +1,77 @@
+import { getTaskDecisionSummary } from '../task-decision'
+import type { Task, TaskDependency, TaskStatus } from '@/types/task'
+
+function dependency(status: TaskStatus): TaskDependency {
+  return {
+    id: `dependency-${status}`,
+    task_id: 'task',
+    depends_on_task_id: `prerequisite-${status}`,
+    created_at: '2026-07-20T00:00:00Z',
+    depends_on_task: {
+      id: `prerequisite-${status}`,
+      title: status,
+      status,
+    },
+  }
+}
+
+function task(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task',
+    title: 'Task',
+    description: null,
+    estimate_hours: 1,
+    due_date: null,
+    status: 'pending',
+    priority: 3,
+    goal_id: 'goal',
+    created_at: '2026-07-20T00:00:00Z',
+    updated_at: '2026-07-20T00:00:00Z',
+    dependencies: [],
+    ...overrides,
+  }
+}
+
+describe('getTaskDecisionSummary', () => {
+  it('marks an actionable task without dependencies as ready', () => {
+    expect(getTaskDecisionSummary(task()).state).toBe('ready')
+  })
+
+  it('marks an actionable task with all dependencies completed as ready', () => {
+    const summary = getTaskDecisionSummary(
+      task({ dependencies: [dependency('completed')] }),
+    )
+
+    expect(summary.state).toBe('ready')
+    expect(summary.completedDependencies).toBe(1)
+  })
+
+  it('reports dependency progress and blockers', () => {
+    const summary = getTaskDecisionSummary(
+      task({ dependencies: [dependency('completed'), dependency('in_progress')] }),
+    )
+
+    expect(summary.state).toBe('blocked')
+    expect(summary.completedDependencies).toBe(1)
+    expect(summary.dependencyTotal).toBe(2)
+    expect(summary.blockingDependencies).toHaveLength(1)
+  })
+
+  it('keeps cancelled dependencies blocked and flags them for review', () => {
+    const summary = getTaskDecisionSummary(
+      task({ dependencies: [dependency('cancelled')] }),
+    )
+
+    expect(summary.state).toBe('blocked')
+    expect(summary.hasCancelledDependency).toBe(true)
+  })
+
+  it('preserves terminal task states', () => {
+    expect(getTaskDecisionSummary(task({ status: 'completed' })).state).toBe(
+      'completed',
+    )
+    expect(getTaskDecisionSummary(task({ status: 'cancelled' })).state).toBe(
+      'cancelled',
+    )
+  })
+})

--- a/apps/web/src/lib/tasks/__tests__/workspace-filters.test.ts
+++ b/apps/web/src/lib/tasks/__tests__/workspace-filters.test.ts
@@ -1,0 +1,40 @@
+import {
+  buildTaskWorkspaceFilters,
+  DEFAULT_TASK_WORKSPACE_PRESET,
+} from "../workspace-filters";
+
+describe("task workspace filters", () => {
+  it("uses Ready as the default workspace intent", () => {
+    expect(DEFAULT_TASK_WORKSPACE_PRESET).toBe("ready");
+  });
+
+  it("defines Ready as actionable and not blocked", () => {
+    const filters = buildTaskWorkspaceFilters({
+      preset: "ready",
+      page: 0,
+      status: "",
+      projectId: "",
+      goalId: "",
+      search: "",
+    });
+
+    expect(filters.status).toEqual(["pending", "in_progress"]);
+    expect(filters.blocked).toBe(false);
+    expect(filters.sortBy).toBe("priority");
+  });
+
+  it("keeps blocked and cancelled-prerequisite tasks in the blocked view", () => {
+    const filters = buildTaskWorkspaceFilters({
+      preset: "blocked",
+      page: 0,
+      status: "",
+      projectId: "project-1",
+      goalId: "",
+      search: "publish",
+    });
+
+    expect(filters.blocked).toBe(true);
+    expect(filters.projectId).toBe("project-1");
+    expect(filters.search).toBe("publish");
+  });
+});

--- a/apps/web/src/lib/tasks/dependency-graph-layout.ts
+++ b/apps/web/src/lib/tasks/dependency-graph-layout.ts
@@ -1,0 +1,147 @@
+import type {
+  TaskDependencyGraphEdge,
+  TaskDependencyGraphNode,
+} from "@/types/task";
+
+export const TASK_GRAPH_NODE_WIDTH = 224;
+export const TASK_GRAPH_NODE_HEIGHT = 104;
+const HORIZONTAL_GAP = 96;
+const VERTICAL_GAP = 32;
+const PADDING = 40;
+
+export interface PositionedTaskGraphNode extends TaskDependencyGraphNode {
+  x: number;
+  y: number;
+  level: number;
+}
+
+export interface TaskGraphLayout {
+  nodes: PositionedTaskGraphNode[];
+  width: number;
+  height: number;
+}
+
+export function layoutTaskDependencyGraph(
+  nodes: TaskDependencyGraphNode[],
+  edges: TaskDependencyGraphEdge[],
+): TaskGraphLayout {
+  if (nodes.length === 0) return { nodes: [], width: 0, height: 0 };
+
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const incoming = new Map(nodes.map((node) => [node.id, 0]));
+  const outgoing = new Map(nodes.map((node) => [node.id, [] as string[]]));
+  const levels = new Map(nodes.map((node) => [node.id, 0]));
+
+  for (const edge of edges) {
+    if (
+      !nodeIds.has(edge.prerequisite_task_id) ||
+      !nodeIds.has(edge.dependent_task_id)
+    ) {
+      continue;
+    }
+    incoming.set(
+      edge.dependent_task_id,
+      (incoming.get(edge.dependent_task_id) ?? 0) + 1,
+    );
+    outgoing.get(edge.prerequisite_task_id)?.push(edge.dependent_task_id);
+  }
+
+  const queue = nodes
+    .filter((node) => incoming.get(node.id) === 0)
+    .map((node) => node.id)
+    .sort();
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const current = queue.shift() as string;
+    visited.add(current);
+    for (const dependent of outgoing.get(current) ?? []) {
+      levels.set(
+        dependent,
+        Math.max(levels.get(dependent) ?? 0, (levels.get(current) ?? 0) + 1),
+      );
+      const remaining = (incoming.get(dependent) ?? 1) - 1;
+      incoming.set(dependent, remaining);
+      if (remaining === 0) queue.push(dependent);
+    }
+  }
+
+  // The API prevents cycles, but keep malformed legacy data visible and inspectable.
+  const fallbackLevel = Math.max(0, ...levels.values()) + 1;
+  for (const node of nodes) {
+    if (!visited.has(node.id)) levels.set(node.id, fallbackLevel);
+  }
+
+  const groups = new Map<number, TaskDependencyGraphNode[]>();
+  for (const node of nodes) {
+    const level = levels.get(node.id) ?? 0;
+    groups.set(level, [...(groups.get(level) ?? []), node]);
+  }
+
+  const positioned: PositionedTaskGraphNode[] = [];
+  let maxRows = 1;
+  for (const [level, levelNodes] of [...groups.entries()].sort(
+    ([a], [b]) => a - b,
+  )) {
+    levelNodes.sort(
+      (a, b) =>
+        Number(a.is_context) - Number(b.is_context) ||
+        a.project_title.localeCompare(b.project_title, "ja") ||
+        a.title.localeCompare(b.title, "ja"),
+    );
+    maxRows = Math.max(maxRows, levelNodes.length);
+    levelNodes.forEach((node, index) => {
+      positioned.push({
+        ...node,
+        level,
+        x: PADDING + level * (TASK_GRAPH_NODE_WIDTH + HORIZONTAL_GAP),
+        y: PADDING + index * (TASK_GRAPH_NODE_HEIGHT + VERTICAL_GAP),
+      });
+    });
+  }
+
+  const maxLevel = Math.max(...positioned.map((node) => node.level));
+  return {
+    nodes: positioned,
+    width:
+      PADDING * 2 +
+      (maxLevel + 1) * TASK_GRAPH_NODE_WIDTH +
+      maxLevel * HORIZONTAL_GAP,
+    height:
+      PADDING * 2 +
+      maxRows * TASK_GRAPH_NODE_HEIGHT +
+      (maxRows - 1) * VERTICAL_GAP,
+  };
+}
+
+export function collectConnectedTaskIds(
+  selectedId: string | null,
+  edges: TaskDependencyGraphEdge[],
+): Set<string> {
+  if (!selectedId) return new Set();
+
+  const connected = new Set([selectedId]);
+  const walk = (direction: "upstream" | "downstream") => {
+    const queue = [selectedId];
+    while (queue.length > 0) {
+      const current = queue.shift() as string;
+      for (const edge of edges) {
+        const next =
+          direction === "upstream"
+            ? edge.dependent_task_id === current
+              ? edge.prerequisite_task_id
+              : null
+            : edge.prerequisite_task_id === current
+              ? edge.dependent_task_id
+              : null;
+        if (next && !connected.has(next)) {
+          connected.add(next);
+          queue.push(next);
+        }
+      }
+    }
+  };
+  walk("upstream");
+  walk("downstream");
+  return connected;
+}

--- a/apps/web/src/lib/tasks/task-decision.ts
+++ b/apps/web/src/lib/tasks/task-decision.ts
@@ -1,0 +1,42 @@
+import type { Task, TaskDependency } from '@/types/task'
+
+export type TaskDecisionState = 'ready' | 'blocked' | 'completed' | 'cancelled'
+
+export interface TaskDecisionSummary {
+  state: TaskDecisionState
+  dependencyTotal: number
+  completedDependencies: number
+  blockingDependencies: TaskDependency[]
+  hasCancelledDependency: boolean
+}
+
+export function getTaskDecisionSummary(task: Task): TaskDecisionSummary {
+  const dependencies = task.dependencies ?? []
+  const completedDependencies = dependencies.filter(
+    (dependency) => dependency.depends_on_task?.status === 'completed',
+  ).length
+  const blockingDependencies = dependencies.filter(
+    (dependency) => dependency.depends_on_task?.status !== 'completed',
+  )
+
+  let state: TaskDecisionState
+  if (task.status === 'completed') {
+    state = 'completed'
+  } else if (task.status === 'cancelled') {
+    state = 'cancelled'
+  } else if (blockingDependencies.length > 0) {
+    state = 'blocked'
+  } else {
+    state = 'ready'
+  }
+
+  return {
+    state,
+    dependencyTotal: dependencies.length,
+    completedDependencies,
+    blockingDependencies,
+    hasCancelledDependency: blockingDependencies.some(
+      (dependency) => dependency.depends_on_task?.status === 'cancelled',
+    ),
+  }
+}

--- a/apps/web/src/lib/tasks/workspace-filters.ts
+++ b/apps/web/src/lib/tasks/workspace-filters.ts
@@ -1,0 +1,60 @@
+import type { TaskStatus, TaskWorkspaceFilters } from "@/types/task";
+
+export type TaskWorkspacePreset =
+  | "ready"
+  | "today"
+  | "week"
+  | "in_progress"
+  | "overdue"
+  | "blocked"
+  | "unplanned"
+  | "inbox"
+  | "all";
+
+export const DEFAULT_TASK_WORKSPACE_PRESET: TaskWorkspacePreset = "ready";
+const actionableStatuses: TaskStatus[] = ["pending", "in_progress"];
+
+interface BuildTaskWorkspaceFiltersInput {
+  preset: TaskWorkspacePreset;
+  page: number;
+  status: TaskStatus | "";
+  projectId: string;
+  goalId: string;
+  search: string;
+  now?: Date;
+}
+
+export function buildTaskWorkspaceFilters({
+  preset,
+  page,
+  status,
+  projectId,
+  goalId,
+  search,
+  now = new Date(),
+}: BuildTaskWorkspaceFiltersInput): TaskWorkspaceFilters {
+  let statuses = status ? [status] : undefined;
+  if (
+    !status &&
+    ["ready", "overdue", "today", "week", "unplanned"].includes(preset)
+  ) {
+    statuses = actionableStatuses;
+  }
+  if (!status && preset === "in_progress") statuses = ["in_progress"];
+
+  return {
+    skip: page * 50,
+    limit: 50,
+    status: statuses,
+    projectId: projectId || undefined,
+    goalId: goalId || undefined,
+    dueBefore: preset === "overdue" ? now.toISOString() : undefined,
+    search: search || undefined,
+    blocked:
+      preset === "blocked" ? true : preset === "ready" ? false : undefined,
+    plan: ["today", "week", "unplanned"].includes(preset)
+      ? (preset as "today" | "week" | "unplanned")
+      : undefined,
+    sortBy: preset === "ready" ? "priority" : "due_date",
+  };
+}

--- a/apps/web/src/types/task.ts
+++ b/apps/web/src/types/task.ts
@@ -133,10 +133,58 @@ export interface TaskWorkspaceItem extends Task {
   goal_title: string;
   remaining_estimate_hours: number;
   is_blocked: boolean;
+  is_ready: boolean;
   blocking_task_ids: string[];
   last_worked_at: string | null;
   planned_today: boolean;
   planned_this_week: boolean;
+}
+
+export interface TaskWorkspaceSummary {
+  total: number;
+  ready: number;
+  blocked: number;
+  in_progress: number;
+  overdue: number;
+}
+
+export interface TaskDependencyContextTask {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  project_id: string;
+  project_title: string;
+  goal_id: string;
+  goal_title: string;
+  is_ready: boolean;
+  is_blocked: boolean;
+}
+
+export interface TaskDependencyContext {
+  prerequisites: TaskDependencyContextTask[];
+  dependents: TaskDependencyContextTask[];
+}
+
+export interface TaskDependencyGraphNode extends TaskDependencyContextTask {
+  priority: number;
+  due_date: string | null;
+  is_context: boolean;
+}
+
+export interface TaskDependencyGraphEdge {
+  id: string;
+  prerequisite_task_id: string;
+  dependent_task_id: string;
+  prerequisite_status: TaskStatus;
+}
+
+export interface TaskDependencyGraphResponse {
+  nodes: TaskDependencyGraphNode[];
+  edges: TaskDependencyGraphEdge[];
+  total: number;
+  node_count: number;
+  exceeds_limit: boolean;
+  limit: number;
 }
 
 export interface TaskWorkspacePage {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       '@types/d3-scale':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/d3-selection':
+        specifier: ^3.0.11
+        version: 3.0.11
       '@types/d3-zoom':
         specifier: ^3.0.8
         version: 3.0.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       d3-scale:
         specifier: ^4.0.2
         version: 4.0.2
+      d3-selection:
+        specifier: ^3.0.0
+        version: 3.0.0
       d3-zoom:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1942,6 +1945,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.9.2':
     resolution: {integrity: sha512-tS+lqTU3N0kkthU+rYp0spAYq15DU8ld9kXkaKg9sbQqJNF+WPMuNHZQGCgdxrUOEO0j22RKMwRVhF1HTl+X8A==}
@@ -2950,11 +2954,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
@@ -3607,6 +3612,7 @@ packages:
   next@15.5.7:
     resolution: {integrity: sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -4535,6 +4541,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}


### PR DESCRIPTION
## 概要

タスク一覧を、編集フォーム中心の画面から Ready 判定と依存状況をすぐ確認できる高密度ビューへ改善します。

## 主な変更

- 初期表示を「Ready（次にやる）」へ変更
- Ready／ブロック中／作業中／期限切れ／全件のサマリーと絞り込みを追加
- 一覧行に依存進捗を表示し、未完了・キャンセル済みブロッカーをインライン展開
- 詳細を右側パネル化し、前提タスクと後続タスクを分けて表示
- 一覧とフィルターを共有する依存マップを追加
  - 前提タスク → 後続タスクの方向で表示
  - トポロジカルな左右配置
  - パン、ズーム、全体表示、凡例、選択ノードの上流・下流強調
  - フィルター外の直結タスクをコンテキストノードとして表示
  - 200ノード超過時は絞り込みを案内
- モバイルでは重要情報を優先したカード表示
- TaskWorkspaceItem.is_ready、サマリー、依存コンテキスト、依存マップAPIを追加
- 一覧・依存取得をバッチ化し、DBスキーマは変更なし

## 検証

- `cd apps/api && uv run pytest -s -q`
  - 422 passed / 5 skipped
- `pnpm --filter @human-compiler/web type-check`
  - 成功
- `pnpm --filter @human-compiler/web build`
  - 成功
- 対象フロントエンドテスト
  - 5 suites / 38 tests passed
- フロントエンド全体テスト
  - 22 suites / 280 tests passed
  - 今回の変更対象外にある既存6 suites・28 testsの失敗を確認（Responseモック、タイムライン旧期待値、既存hookの非同期期待値、window.location/config関連）

## 補足

- DBマイグレーションはありません。
- 375px／768px／1440px、ダークモード、キーボード操作のブラウザー目視確認は、ローカル環境とアプリ内ブラウザーのWSLパス連携制約により未実施です。
