### PR TITLE
fix: hide production error diagnostics

### DIFF
--- a/apps/api/src/humancompiler_api/common/error_handlers.py
+++ b/apps/api/src/humancompiler_api/common/error_handlers.py
@@ -18,6 +18,7 @@ from humancompiler_api.exceptions import (
     ValidationError as ApiValidationError,
     build_error_content,
     include_debug_error_details,
+    public_server_error_detail,
 )
 from humancompiler_api.models import ErrorResponse
 
@@ -90,11 +91,7 @@ async def service_exception_handler(request: Request, exc: ServiceError):
 
     detail = exc.message
     if is_server_error and not include_debug_error_details():
-        detail = (
-            "Service temporarily unavailable"
-            if status_code == status.HTTP_503_SERVICE_UNAVAILABLE
-            else "Internal server error"
-        )
+        detail = public_server_error_detail(status_code)
 
     return JSONResponse(
         status_code=status_code,

--- a/apps/api/src/humancompiler_api/common/error_handlers.py
+++ b/apps/api/src/humancompiler_api/common/error_handlers.py
@@ -16,6 +16,8 @@ from humancompiler_api.exceptions import (
     HumanCompilerException,
     ResourceNotFoundError as ApiResourceNotFoundError,
     ValidationError as ApiValidationError,
+    build_error_content,
+    include_debug_error_details,
 )
 from humancompiler_api.models import ErrorResponse
 
@@ -77,13 +79,32 @@ async def service_exception_handler(request: Request, exc: ServiceError):
     elif isinstance(exc, ExternalServiceError):
         status_code = status.HTTP_503_SERVICE_UNAVAILABLE
 
+    is_server_error = status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR
+    if is_server_error:
+        logger.error(
+            "Service error during %s %s",
+            request.method,
+            request.url.path,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+
+    detail = exc.message
+    if is_server_error and not include_debug_error_details():
+        detail = (
+            "Service temporarily unavailable"
+            if status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+            else "Internal server error"
+        )
+
     return JSONResponse(
         status_code=status_code,
-        content={
-            "detail": exc.message,
-            "error_code": exc.error_code,
-            "path": str(request.url),
-        },
+        content=build_error_content(
+            detail=detail,
+            error_code=exc.error_code
+            or ("INTERNAL_ERROR" if is_server_error else None),
+            request=request,
+            exception=exc if is_server_error else None,
+        ),
     )
 
 
@@ -128,7 +149,9 @@ def handle_service_error(error: Exception) -> HTTPException:
             detail=ErrorResponse.create(
                 code="INTERNAL_SERVER_ERROR",
                 message="Internal server error",
-                details={"error_type": type(error).__name__},
+                details={"error_type": type(error).__name__}
+                if include_debug_error_details()
+                else None,
             ).model_dump(),
         )
 

--- a/apps/api/src/humancompiler_api/exceptions.py
+++ b/apps/api/src/humancompiler_api/exceptions.py
@@ -15,6 +15,13 @@ def include_debug_error_details() -> bool:
     return settings.environment == "development" and settings.debug
 
 
+def public_server_error_detail(status_code: int) -> str:
+    """Return the safe public message for a server-side HTTP error."""
+    if status_code == status.HTTP_503_SERVICE_UNAVAILABLE:
+        return "Service temporarily unavailable"
+    return "Internal server error"
+
+
 def build_error_content(
     *,
     detail: Any,
@@ -98,7 +105,7 @@ async def http_exception_handler(request: Request, exc: HTTPException):
 
     detail = exc.detail
     if is_server_error and not include_debug_error_details():
-        detail = "Internal server error"
+        detail = public_server_error_detail(exc.status_code)
 
     return JSONResponse(
         status_code=exc.status_code,

--- a/apps/api/src/humancompiler_api/exceptions.py
+++ b/apps/api/src/humancompiler_api/exceptions.py
@@ -1,7 +1,52 @@
+import logging
+from typing import Any
+
 from fastapi import HTTPException, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
-# from pydantic import ValidationError as PydanticValidationError  # Unused but may be needed
+
+from humancompiler_api.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def include_debug_error_details() -> bool:
+    """Return whether diagnostic fields may be exposed to API clients."""
+    return settings.environment == "development" and settings.debug
+
+
+def build_error_content(
+    *,
+    detail: Any,
+    error_code: str | None,
+    request: Request | None = None,
+    exception: Exception | None = None,
+) -> dict[str, Any]:
+    """Build an error payload without exposing diagnostics outside local debug mode."""
+    content: dict[str, Any] = {
+        "detail": detail,
+        "error_code": error_code,
+    }
+
+    if include_debug_error_details():
+        if request is not None:
+            # Keep query parameters out of responses even in development because they
+            # can contain tokens or other credentials.
+            content["path"] = request.url.path
+        if exception is not None:
+            content["error_type"] = type(exception).__name__
+            content["debug_message"] = str(exception) or "No details available"
+
+    return content
+
+
+def _log_server_error(request: Request, exc: Exception) -> None:
+    logger.error(
+        "Unhandled error during %s %s",
+        request.method,
+        request.url.path,
+        exc_info=(type(exc), exc, exc.__traceback__),
+    )
 
 
 class HumanCompilerException(Exception):
@@ -47,13 +92,22 @@ TaskAgentException = HumanCompilerException
 
 async def http_exception_handler(request: Request, exc: HTTPException):
     """Handle HTTP exceptions"""
+    is_server_error = exc.status_code >= status.HTTP_500_INTERNAL_SERVER_ERROR
+    if is_server_error:
+        _log_server_error(request, exc)
+
+    detail = exc.detail
+    if is_server_error and not include_debug_error_details():
+        detail = "Internal server error"
+
     return JSONResponse(
         status_code=exc.status_code,
-        content={
-            "detail": exc.detail,
-            "error_code": getattr(exc, "error_code", None),
-            "path": str(request.url),
-        },
+        content=build_error_content(
+            detail=detail,
+            error_code=getattr(exc, "error_code", None)
+            or ("INTERNAL_ERROR" if is_server_error else None),
+            request=request,
+        ),
     )
 
 
@@ -69,14 +123,14 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
             }
         )
 
+    content = build_error_content(
+        detail="Request validation failed",
+        error_code="VALIDATION_ERROR",
+        request=request,
+    )
+    content["errors"] = errors
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-        content={
-            "detail": "Request validation failed",
-            "error_code": "VALIDATION_ERROR",
-            "errors": errors,
-            "path": str(request.url),
-        },
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content=content
     )
 
 
@@ -92,14 +146,14 @@ async def pydantic_validation_exception_handler(request: Request, exc: Validatio
             }
         )
 
+    content = build_error_content(
+        detail="Data validation failed",
+        error_code="VALIDATION_ERROR",
+        request=request,
+    )
+    content["errors"] = errors
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-        content={
-            "detail": "Data validation failed",
-            "error_code": "VALIDATION_ERROR",
-            "errors": errors,
-            "path": str(request.url),
-        },
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content=content
     )
 
 
@@ -118,21 +172,23 @@ async def humancompiler_exception_handler(
 
     return JSONResponse(
         status_code=status_code,
-        content={
-            "detail": exc.message,
-            "error_code": exc.error_code,
-            "path": str(request.url),
-        },
+        content=build_error_content(
+            detail=exc.message,
+            error_code=exc.error_code,
+            request=request,
+        ),
     )
 
 
 async def general_exception_handler(request: Request, exc: Exception):
     """Handle general exceptions"""
+    _log_server_error(request, exc)
     return JSONResponse(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        content={
-            "detail": "Internal server error",
-            "error_code": "INTERNAL_ERROR",
-            "path": str(request.url),
-        },
+        content=build_error_content(
+            detail="Internal server error",
+            error_code="INTERNAL_ERROR",
+            request=request,
+            exception=exc,
+        ),
     )

--- a/apps/api/src/humancompiler_api/main.py
+++ b/apps/api/src/humancompiler_api/main.py
@@ -228,35 +228,12 @@ async def cors_middleware(request, call_next):
         response = await call_next(request)
         status_code = response.status_code
     except Exception as e:
-        # Create error response with CORS headers
-        from fastapi import HTTPException
-        from fastapi.responses import JSONResponse
-
-        logger = logging.getLogger(__name__)
-
-        # Preserve original status code for HTTPException
+        # Preserve exception handler behavior while still adding CORS headers.
         if isinstance(e, HTTPException):
-            logger.warning(f"HTTP {e.status_code} error: {e.detail}")
             status_code = e.status_code
-            response = JSONResponse(
-                status_code=e.status_code,
-                content={"detail": e.detail, "error_code": None},
-            )
+            response = await http_exception_handler(request, e)
         else:
-            # Only use 500 for unexpected errors
-            import traceback
-
-            logger.error(f"Unexpected error: {type(e).__name__}: {e}")
-            logger.error(f"Full traceback: {traceback.format_exc()}")
-            response = JSONResponse(
-                status_code=500,
-                content={
-                    "detail": "Internal server error",
-                    "error_code": None,
-                    "error_type": type(e).__name__,
-                    "debug_message": str(e) if str(e) else "No details available",
-                },
-            )
+            response = await general_exception_handler(request, e)
 
     # Log request timing
     duration = time.monotonic() - start_time

--- a/apps/api/tests/test_error_handlers.py
+++ b/apps/api/tests/test_error_handlers.py
@@ -112,6 +112,25 @@ async def test_http_exception_handler_hides_server_details_in_production(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_http_exception_handler_uses_service_message_for_503(monkeypatch):
+    monkeypatch.setattr(settings, "environment", "production")
+    monkeypatch.setattr(settings, "debug", False)
+
+    response = await http_exception_handler(
+        make_request(),
+        HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="postgres connection failed at internal-db:5432",
+        ),
+    )
+
+    assert json.loads(response.body) == {
+        "detail": "Service temporarily unavailable",
+        "error_code": "INTERNAL_ERROR",
+    }
+
+
+@pytest.mark.asyncio
 async def test_http_exception_handler_preserves_client_message_in_production(
     monkeypatch,
 ):

--- a/apps/api/tests/test_error_handlers.py
+++ b/apps/api/tests/test_error_handlers.py
@@ -1,15 +1,22 @@
 import json
 
 import pytest
-from fastapi import status
+from fastapi import HTTPException, status
 from starlette.requests import Request
 
 from humancompiler_api.common.error_handlers import (
+    ExternalServiceError,
     ResourceNotFoundError,
     ServiceError,
     ValidationError,
     service_exception_handler,
 )
+from humancompiler_api.config import settings
+from humancompiler_api.exceptions import (
+    general_exception_handler,
+    http_exception_handler,
+)
+from humancompiler_api.main import cors_middleware
 
 
 def make_request() -> Request:
@@ -20,7 +27,7 @@ def make_request() -> Request:
             "method": "GET",
             "path": "/test",
             "headers": [],
-            "query_string": b"",
+            "query_string": b"token=secret",
             "server": ("testserver", 80),
             "scheme": "http",
             "client": ("testclient", 50000),
@@ -29,17 +36,28 @@ def make_request() -> Request:
 
 
 @pytest.mark.asyncio
-async def test_service_exception_handler_returns_500_for_plain_service_error():
+async def test_service_exception_handler_hides_plain_service_error_in_production(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "environment", "production")
+    monkeypatch.setattr(settings, "debug", False)
+
     response = await service_exception_handler(
-        make_request(), ServiceError("Database operation failed")
+        make_request(), ServiceError("postgres://user:password@internal/db failed")
     )
 
     assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
-    assert json.loads(response.body)["detail"] == "Database operation failed"
+    assert json.loads(response.body) == {
+        "detail": "Internal server error",
+        "error_code": "INTERNAL_ERROR",
+    }
 
 
 @pytest.mark.asyncio
-async def test_service_exception_handler_maps_known_client_errors():
+async def test_service_exception_handler_maps_known_client_errors(monkeypatch):
+    monkeypatch.setattr(settings, "environment", "production")
+    monkeypatch.setattr(settings, "debug", False)
+
     not_found_response = await service_exception_handler(
         make_request(), ResourceNotFoundError("Task", "missing-id")
     )
@@ -49,3 +67,120 @@ async def test_service_exception_handler_maps_known_client_errors():
 
     assert not_found_response.status_code == status.HTTP_404_NOT_FOUND
     assert validation_response.status_code == status.HTTP_400_BAD_REQUEST
+    assert json.loads(not_found_response.body) == {
+        "detail": "Task not found with ID: missing-id",
+        "error_code": "RESOURCE_NOT_FOUND",
+    }
+
+
+@pytest.mark.asyncio
+async def test_service_exception_handler_hides_external_error_in_production(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "environment", "production")
+    monkeypatch.setattr(settings, "debug", False)
+
+    response = await service_exception_handler(
+        make_request(),
+        ExternalServiceError("postgres", "connection failed at internal-db:5432"),
+    )
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert json.loads(response.body) == {
+        "detail": "Service temporarily unavailable",
+        "error_code": "EXTERNAL_SERVICE_ERROR",
+    }
+
+
+@pytest.mark.asyncio
+async def test_http_exception_handler_hides_server_details_in_production(monkeypatch):
+    monkeypatch.setattr(settings, "environment", "production")
+    monkeypatch.setattr(settings, "debug", False)
+
+    response = await http_exception_handler(
+        make_request(),
+        HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="File not found: /app/src/secret.py",
+        ),
+    )
+
+    assert json.loads(response.body) == {
+        "detail": "Internal server error",
+        "error_code": "INTERNAL_ERROR",
+    }
+
+
+@pytest.mark.asyncio
+async def test_http_exception_handler_preserves_client_message_in_production(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "environment", "production")
+    monkeypatch.setattr(settings, "debug", False)
+
+    response = await http_exception_handler(
+        make_request(),
+        HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        ),
+    )
+
+    assert json.loads(response.body) == {
+        "detail": "Task not found",
+        "error_code": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_general_exception_handler_hides_diagnostics_in_production(monkeypatch):
+    monkeypatch.setattr(settings, "environment", "production")
+    monkeypatch.setattr(settings, "debug", False)
+
+    response = await general_exception_handler(
+        make_request(), RuntimeError("database password was exposed")
+    )
+
+    assert json.loads(response.body) == {
+        "detail": "Internal server error",
+        "error_code": "INTERNAL_ERROR",
+    }
+
+
+@pytest.mark.asyncio
+async def test_general_exception_handler_includes_safe_debug_fields_in_development(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "environment", "development")
+    monkeypatch.setattr(settings, "debug", True)
+
+    response = await general_exception_handler(
+        make_request(), RuntimeError("development diagnostic")
+    )
+
+    assert json.loads(response.body) == {
+        "detail": "Internal server error",
+        "error_code": "INTERNAL_ERROR",
+        "path": "/test",
+        "error_type": "RuntimeError",
+        "debug_message": "development diagnostic",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cors_middleware_hides_unexpected_error_details_in_production(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "environment", "production")
+    monkeypatch.setattr(settings, "debug", False)
+
+    async def raise_internal_error(_request):
+        raise RuntimeError("postgres://user:password@internal-db/app")
+
+    response = await cors_middleware(make_request(), raise_internal_error)
+
+    assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+    assert json.loads(response.body) == {
+        "detail": "Internal server error",
+        "error_code": "INTERNAL_ERROR",
+    }

--- a/apps/api/tests/test_simple_backup_api.py
+++ b/apps/api/tests/test_simple_backup_api.py
@@ -163,8 +163,8 @@ class TestSimpleBackupAPI:
             assert response.status_code == 500
 
             data = response.json()
-            assert "detail" in data
-            assert "Failed to retrieve backup status" in data["detail"]
+            assert data["detail"] == "Internal server error"
+            assert data["error_code"] == "INTERNAL_ERROR"
 
     def test_backup_info_endpoint_error(self, client):
         """Test backup info endpoint error handling"""
@@ -177,8 +177,8 @@ class TestSimpleBackupAPI:
             assert response.status_code == 500
 
             data = response.json()
-            assert "detail" in data
-            assert "Failed to retrieve backup information" in data["detail"]
+            assert data["detail"] == "Internal server error"
+            assert data["error_code"] == "INTERNAL_ERROR"
 
     def test_rate_limiting(self, client):
         """Test rate limiting on endpoints"""


### PR DESCRIPTION
## Summary

- centralize API error payload construction and omit diagnostic fields outside local debug mode
- replace 5xx exception details with stable public messages while retaining full server-side logging
- route middleware failures through the same exception handlers and keep query strings out of debug paths
- add production/development coverage and update backup API expectations for the safe 5xx contract

## Root cause

Several exception paths built responses independently. The CORS middleware returned exception types and messages directly, while common handlers always included full request URLs and could expose service or database details through 5xx responses.

## Impact

Production, staging, and test clients now receive only a generic 5xx message and error code. Intended 4xx messages remain available. Developers still get diagnostic fields when both `ENVIRONMENT=development` and `DEBUG=true`; full exceptions remain in server logs in every environment.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/humancompiler_api/exceptions.py src/humancompiler_api/common/error_handlers.py src/humancompiler_api/main.py --config-file pyproject.toml`
- `uv run bandit -q src/humancompiler_api/exceptions.py src/humancompiler_api/common/error_handlers.py src/humancompiler_api/main.py`
- `uv run pytest -s -q` (`433 passed`, `5 skipped`)

Closes #58