### PR TITLE
Issue #318の残存機能を実装

### DIFF
--- a/apps/api/migrations/025_add_work_session_switch_context.sql
+++ b/apps/api/migrations/025_add_work_session_switch_context.sql
@@ -1,0 +1,24 @@
+-- SPDX-License-Identifier: AGPL-3.0-or-later
+-- Preserve why a task was interrupted when Runner switches atomically.
+
+ALTER TABLE work_sessions
+    ADD COLUMN IF NOT EXISTS switch_disposition VARCHAR(16);
+
+ALTER TABLE work_sessions
+    ADD COLUMN IF NOT EXISTS interruption_note VARCHAR(2000);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'work_sessions_switch_disposition_check'
+    ) THEN
+        ALTER TABLE work_sessions
+            ADD CONSTRAINT work_sessions_switch_disposition_check
+            CHECK (
+                switch_disposition IS NULL
+                OR switch_disposition IN ('complete', 'pause', 'defer')
+            );
+    END IF;
+END $$;

--- a/apps/api/src/humancompiler_api/models.py
+++ b/apps/api/src/humancompiler_api/models.py
@@ -100,6 +100,7 @@ class TaskWorkspaceSortBy(StrEnum):
     STATUS = "status"
     TITLE = "title"
     UPDATED_AT = "updated_at"
+    LAST_WORKED_AT = "last_worked_at"
 
 
 class TaskWorkspacePlanFilter(StrEnum):
@@ -126,6 +127,14 @@ class SessionDecision(StrEnum):
     SWITCH = "switch"
     BREAK = "break"
     COMPLETE = "complete"
+
+
+class SwitchDisposition(StrEnum):
+    """How the current task is left when atomically switching tasks."""
+
+    COMPLETE = "complete"
+    PAUSE = "pause"
+    DEFER = "defer"
 
 
 class ContinueReason(StrEnum):
@@ -675,6 +684,13 @@ class WorkSession(WorkSessionBase, table=True):  # type: ignore[call-arg]
             SQLEnum(ContinueReason, values_callable=lambda x: [e.value for e in x])
         ),
     )
+    switch_disposition: SwitchDisposition | None = SQLField(
+        default=None,
+        sa_column=Column(
+            SQLEnum(SwitchDisposition, values_callable=lambda x: [e.value for e in x])
+        ),
+    )
+    interruption_note: str | None = SQLField(default=None, max_length=2000)
 
     # KPT reflection
     kpt_keep: str | None = SQLField(default=None, max_length=500)
@@ -1092,6 +1108,7 @@ class TaskWorkspaceItem(TaskResponse):
     blocking_task_ids: list[UUID] = Field(default_factory=list)
     last_worked_at: datetime | None = None
     planned_today: bool = False
+    planned_today_unplaced: bool = False
     planned_this_week: bool = False
 
     @field_serializer("remaining_estimate_hours")
@@ -1379,6 +1396,39 @@ class WorkSessionCheckoutRequest(BaseModel):
     next_task_id: UUID | None = None
 
 
+class WorkSessionSwitchRequest(BaseModel):
+    """Atomically close the active session and start another task."""
+
+    next_task_id: UUID
+    disposition: SwitchDisposition
+    interruption_note: str | None = Field(None, max_length=2000)
+    planned_checkout_at: datetime
+    planned_outcome: str | None = Field(None, max_length=500)
+    remaining_estimate_hours: Decimal | None = Field(None, ge=0)
+
+    @model_validator(mode="after")
+    def require_interruption_note(self):
+        if self.disposition != SwitchDisposition.COMPLETE and not (
+            self.interruption_note and self.interruption_note.strip()
+        ):
+            raise ValueError(
+                "An interruption note is required when pausing or deferring"
+            )
+        return self
+
+
+class WorkSessionResumeContextResponse(BaseModel):
+    """Most recent interruption context for restarting a task."""
+
+    task_id: UUID
+    interruption_note: str
+    interrupted_at: datetime
+    disposition: SwitchDisposition
+    remaining_estimate_hours: Decimal | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class WorkSessionUpdate(BaseModel):
     """Request model for updating a work session's KPT fields.
 
@@ -1419,6 +1469,8 @@ class WorkSessionResponse(WorkSessionBase):
     checkout_type: CheckoutType | None
     decision: SessionDecision | None
     continue_reason: ContinueReason | None
+    switch_disposition: SwitchDisposition | None = None
+    interruption_note: str | None = None
     kpt_keep: str | None
     kpt_problem: str | None
     kpt_try: str | None
@@ -1466,6 +1518,14 @@ class WorkSessionWithLogResponse(WorkSessionResponse):
     """Work session response with generated log"""
 
     generated_log: LogResponse | None = None
+
+
+class WorkSessionSwitchResponse(BaseModel):
+    """Previous and newly active sessions returned by an atomic switch."""
+
+    previous_session: WorkSessionResponse
+    current_session: WorkSessionResponse
+    generated_log: LogResponse
 
 
 class UserSettingsCreate(BaseModel):

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -434,6 +434,28 @@ def _apply_weekly_membership(
     selected = list(payload.get("selected_tasks", []))
     assigned = dict(payload.get("assigned_task_hours", {}))
     pinned = list(payload.get("pinned_task_ids", []))
+    selected_ids = {
+        str(
+            (item.get("task_id") or item.get("taskId"))
+            if isinstance(item, dict)
+            else item
+        )
+        for item in selected
+    }
+    for legacy_task_id in payload.get("selected_task_ids", []):
+        legacy_task_id = str(legacy_task_id)
+        if legacy_task_id in selected_ids:
+            continue
+        selected.append(
+            {
+                "task_id": legacy_task_id,
+                "task_title": f"タスク {legacy_task_id[:8]}",
+                "estimated_hours": float(assigned.get(legacy_task_id, 1)),
+                "priority": 3,
+                "rationale": "旧形式の週次計画から復元",
+            }
+        )
+        selected_ids.add(legacy_task_id)
     selected = [
         item
         for item in selected
@@ -779,12 +801,9 @@ def _extract_planned_task_ids(
         for task_id in (schedule.plan_json or {}).get("planned_task_ids", [])
         if task_id
     )
-    week_ids = {
-        str(task.get("task_id") or task.get("taskId"))
-        for schedule in weekly_schedules
-        for task in (schedule.schedule_json or {}).get("selected_tasks", [])
-        if task.get("task_id") or task.get("taskId")
-    }
+    week_ids: set[str] = set()
+    for schedule in weekly_schedules:
+        week_ids.update(_weekly_members(schedule))
     return today_ids, week_ids, placed_today_ids
 
 

--- a/apps/api/src/humancompiler_api/routers/tasks.py
+++ b/apps/api/src/humancompiler_api/routers/tasks.py
@@ -1,12 +1,15 @@
+import json
 import logging
 from collections.abc import Generator
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from typing import Annotated
-from uuid import UUID
+from typing import Annotated, Literal
+from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from openai import OpenAI
+from pydantic import BaseModel, Field
 from sqlmodel import Session, or_, select
 
 from humancompiler_api.auth import AuthUser, get_current_user
@@ -40,7 +43,9 @@ from humancompiler_api.models import (
     WeeklySchedule,
     Goal,
     Project,
+    UserSettings,
 )
+from humancompiler_api.crypto import get_crypto_service
 from humancompiler_api.services import task_service
 
 logger = logging.getLogger(__name__)
@@ -52,9 +57,646 @@ ACTIONABLE_TASK_STATUSES = {TaskStatus.PENDING, TaskStatus.IN_PROGRESS}
 
 
 def get_session() -> Generator[Session, None, None]:
-    """Database session dependency"""
+    """Database session dependency."""
     with Session(db.get_engine()) as session:
         yield session
+
+
+class BulkTaskPatch(BaseModel):
+    """Whitelisted fields supported by manual and AI bulk changes."""
+
+    status: TaskStatus | None = None
+    priority: int | None = Field(None, ge=1, le=5)
+    due_date: datetime | None = None
+    goal_id: UUID | None = None
+
+
+class PlanMembershipMutation(BaseModel):
+    scope: Literal["daily", "weekly"]
+    action: Literal["add", "remove"]
+    target_date: str = Field(pattern=r"^\d{4}-\d{2}-\d{2}$")
+
+
+class BulkTaskMutation(BaseModel):
+    task_id: UUID
+    patch: BulkTaskPatch = Field(default_factory=BulkTaskPatch)
+    plans: list[PlanMembershipMutation] = Field(default_factory=list, max_length=4)
+
+
+class BulkTaskRequest(BaseModel):
+    mutations: list[BulkTaskMutation] = Field(min_length=1, max_length=100)
+
+
+class BulkTaskApplyRequest(BulkTaskRequest):
+    expected_task_versions: dict[str, str]
+    expected_plan_versions: dict[str, str | None] = Field(default_factory=dict)
+
+
+class BulkFieldDiff(BaseModel):
+    field: str
+    before: object | None = None
+    after: object | None = None
+
+
+class BulkTaskPreviewItem(BaseModel):
+    task_id: UUID
+    title: str
+    diffs: list[BulkFieldDiff]
+
+
+class BulkTaskPreviewResponse(BaseModel):
+    mutations: list[BulkTaskMutation]
+    items: list[BulkTaskPreviewItem]
+    affected_count: int
+    warnings: list[str] = Field(default_factory=list)
+    expected_task_versions: dict[str, str]
+    expected_plan_versions: dict[str, str | None]
+    interpretation: str | None = None
+
+
+class NaturalLanguageBulkRequest(BaseModel):
+    instruction: str = Field(min_length=1, max_length=2000)
+    task_ids: list[UUID] = Field(min_length=1, max_length=100)
+
+
+def _version_value(value: datetime | None) -> str:
+    if value is None:
+        return ""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.isoformat()
+
+
+def _parse_plan_date(value: str) -> datetime:
+    try:
+        return datetime.strptime(value, "%Y-%m-%d")
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail="Invalid plan date") from exc
+
+
+def _load_bulk_tasks(
+    session: Session, owner_id: str | UUID, mutations: list[BulkTaskMutation]
+) -> dict[UUID, tuple[Task, Goal, Project]]:
+    task_ids = {mutation.task_id for mutation in mutations}
+    rows = _owned_task_hierarchy(session, owner_id, task_ids)
+    if len(rows) != len(task_ids):
+        raise HTTPException(status_code=404, detail="One or more tasks were not found")
+
+    goal_ids = {
+        mutation.patch.goal_id
+        for mutation in mutations
+        if mutation.patch.goal_id is not None
+    }
+    if goal_ids:
+        owned_goal_ids = set(
+            session.exec(
+                select(Goal.id)
+                .join(Project, Goal.project_id == Project.id)
+                .where(
+                    Project.owner_id == UUID(str(owner_id)),
+                    Goal.id.in_(goal_ids),
+                )
+            ).all()
+        )
+        if owned_goal_ids != goal_ids:
+            raise HTTPException(status_code=404, detail="Target goal was not found")
+    return rows
+
+
+def _get_plan(
+    session: Session, owner_id: UUID, scope: str, target_date: str
+) -> Schedule | WeeklySchedule | None:
+    parsed = _parse_plan_date(target_date)
+    model = Schedule if scope == "daily" else WeeklySchedule
+    date_column = Schedule.date if scope == "daily" else WeeklySchedule.week_start_date
+    return session.exec(
+        select(model).where(model.user_id == owner_id, date_column == parsed)
+    ).first()
+
+
+def _plan_key(scope: str, target_date: str) -> str:
+    return f"{scope}:{target_date}"
+
+
+def _daily_members(plan: Schedule | None) -> set[str]:
+    payload = (plan.plan_json if plan else {}) or {}
+    members = {str(task_id) for task_id in payload.get("planned_task_ids", [])}
+    members.update(
+        str(item.get("task_id") or item.get("taskId"))
+        for item in payload.get("assignments", [])
+        if item.get("task_id") or item.get("taskId")
+    )
+    return members
+
+
+def _weekly_members(plan: WeeklySchedule | None) -> set[str]:
+    payload = (plan.schedule_json if plan else {}) or {}
+    members = {str(task_id) for task_id in payload.get("selected_task_ids", [])}
+    for item in payload.get("selected_tasks", []):
+        if isinstance(item, dict):
+            task_id = item.get("task_id") or item.get("taskId")
+        else:
+            task_id = item
+        if task_id:
+            members.add(str(task_id))
+    return members
+
+
+def _preview_bulk(
+    session: Session,
+    owner_id: str | UUID,
+    request: BulkTaskRequest,
+    *,
+    interpretation: str | None = None,
+    initial_warnings: list[str] | None = None,
+) -> BulkTaskPreviewResponse:
+    rows = _load_bulk_tasks(session, owner_id, request.mutations)
+    expected_plan_versions: dict[str, str | None] = {}
+    items: list[BulkTaskPreviewItem] = []
+    warnings = list(initial_warnings or [])
+    plan_cache: dict[str, Schedule | WeeklySchedule | None] = {}
+
+    for mutation in request.mutations:
+        task, _goal, _project = rows[mutation.task_id]
+        diffs: list[BulkFieldDiff] = []
+        patch_values = mutation.patch.model_dump(exclude_unset=True)
+        for field_name, after in patch_values.items():
+            before = getattr(task, field_name)
+            before_value = before.value if hasattr(before, "value") else before
+            after_value = after.value if hasattr(after, "value") else after
+            if str(before_value) != str(after_value):
+                diffs.append(
+                    BulkFieldDiff(
+                        field=field_name, before=before_value, after=after_value
+                    )
+                )
+
+        for plan_change in mutation.plans:
+            key = _plan_key(plan_change.scope, plan_change.target_date)
+            if key not in plan_cache:
+                plan_cache[key] = _get_plan(
+                    session,
+                    UUID(str(owner_id)),
+                    plan_change.scope,
+                    plan_change.target_date,
+                )
+                plan = plan_cache[key]
+                expected_plan_versions[key] = (
+                    _version_value(plan.updated_at) if plan else None
+                )
+            plan = plan_cache[key]
+            members = (
+                _daily_members(plan if isinstance(plan, Schedule) else None)
+                if plan_change.scope == "daily"
+                else _weekly_members(plan if isinstance(plan, WeeklySchedule) else None)
+            )
+            is_member = str(task.id) in members
+            after_member = plan_change.action == "add"
+            if is_member == after_member:
+                warnings.append(
+                    f"{task.title}: {plan_change.target_date} の{plan_change.scope}計画は変更不要です"
+                )
+            else:
+                diffs.append(
+                    BulkFieldDiff(
+                        field=f"plan:{plan_change.scope}:{plan_change.target_date}",
+                        before=is_member,
+                        after=after_member,
+                    )
+                )
+
+        items.append(
+            BulkTaskPreviewItem(task_id=mutation.task_id, title=task.title, diffs=diffs)
+        )
+
+    return BulkTaskPreviewResponse(
+        mutations=request.mutations,
+        items=items,
+        affected_count=sum(bool(item.diffs) for item in items),
+        warnings=warnings,
+        expected_task_versions={
+            str(task_id): _version_value(task.updated_at)
+            for task_id, (task, _goal, _project) in rows.items()
+        },
+        expected_plan_versions=expected_plan_versions,
+        interpretation=interpretation,
+    )
+
+
+def _sanitize_ai_bulk_mutations(
+    payload: object,
+    allowed_task_ids: set[UUID],
+    allowed_goal_ids: set[UUID],
+) -> tuple[list[BulkTaskMutation], list[str]]:
+    """Discard unsafe AI output field-by-field while preserving valid changes."""
+    warnings: list[str] = []
+    if not isinstance(payload, dict):
+        return [], ["AI応答がJSONオブジェクトではないため、変更を破棄しました"]
+    raw_mutations = payload.get("mutations", [])
+    if not isinstance(raw_mutations, list):
+        return [], ["AI応答のmutationsが配列ではないため、変更を破棄しました"]
+
+    allowed_task_id_strings = {str(task_id) for task_id in allowed_task_ids}
+    allowed_goal_id_strings = {str(goal_id) for goal_id in allowed_goal_ids}
+    merged: dict[str, dict[str, object]] = {}
+    allowed_patch_fields = {"status", "priority", "due_date", "goal_id"}
+    for index, raw in enumerate(raw_mutations, start=1):
+        if not isinstance(raw, dict):
+            warnings.append(f"AI変更案{index}: オブジェクトではないため破棄しました")
+            continue
+        for field_name in set(raw) - {"task_id", "patch", "plans"}:
+            warnings.append(f"AI変更案{index}: 未許可項目 {field_name} を破棄しました")
+        task_id = str(raw.get("task_id") or "")
+        if task_id not in allowed_task_id_strings:
+            warnings.append(f"AI変更案{index}: 選択範囲外のタスクIDを破棄しました")
+            continue
+
+        clean_patch: dict[str, object] = {}
+        raw_patch = raw.get("patch", {})
+        if not isinstance(raw_patch, dict):
+            warnings.append(f"AI変更案{index}: patchが不正なため破棄しました")
+            raw_patch = {}
+        for field_name, value in raw_patch.items():
+            if field_name not in allowed_patch_fields:
+                warnings.append(
+                    f"AI変更案{index}: 未許可の変更項目 {field_name} を破棄しました"
+                )
+                continue
+            try:
+                validated_patch = BulkTaskPatch.model_validate({field_name: value})
+                validated_value = validated_patch.model_dump(exclude_unset=True)[
+                    field_name
+                ]
+            except Exception:
+                warnings.append(
+                    f"AI変更案{index}: {field_name} の値が不正なため破棄しました"
+                )
+                continue
+            if (
+                field_name == "goal_id"
+                and str(validated_value) not in allowed_goal_id_strings
+            ):
+                warnings.append(
+                    f"AI変更案{index}: 所有していないゴールIDを破棄しました"
+                )
+                continue
+            clean_patch[field_name] = validated_value
+
+        clean_plans: list[PlanMembershipMutation] = []
+        raw_plans = raw.get("plans", [])
+        if not isinstance(raw_plans, list):
+            warnings.append(f"AI変更案{index}: plansが不正なため破棄しました")
+            raw_plans = []
+        for plan_index, raw_plan in enumerate(raw_plans, start=1):
+            try:
+                plan_change = PlanMembershipMutation.model_validate(raw_plan)
+                _parse_plan_date(plan_change.target_date)
+            except Exception:
+                warnings.append(
+                    f"AI変更案{index}の計画変更{plan_index}: 値が不正なため破棄しました"
+                )
+                continue
+            if plan_change not in clean_plans:
+                clean_plans.append(plan_change)
+
+        if not clean_patch and not clean_plans:
+            continue
+        target = merged.setdefault(
+            task_id,
+            {"task_id": task_id, "patch": {}, "plans": []},
+        )
+        target_patch = target["patch"]
+        if isinstance(target_patch, dict):
+            target_patch.update(clean_patch)
+        target_plans = target["plans"]
+        if isinstance(target_plans, list):
+            for plan_change in clean_plans:
+                serialized = plan_change.model_dump()
+                if serialized not in target_plans:
+                    target_plans.append(serialized)
+
+    mutations = [BulkTaskMutation.model_validate(item) for item in merged.values()]
+    return mutations, warnings
+
+
+def _apply_daily_membership(
+    session: Session,
+    owner_id: UUID,
+    target_date: str,
+    task: Task,
+    action: str,
+) -> None:
+    plan = _get_plan(session, owner_id, "daily", target_date)
+    if plan is None:
+        plan = Schedule(
+            id=uuid4(),
+            user_id=owner_id,
+            date=_parse_plan_date(target_date),
+            plan_json={"assignments": [], "planned_task_ids": []},
+        )
+    payload = dict(plan.plan_json or {})
+    assignments = list(payload.get("assignments", []))
+    members = list(dict.fromkeys([*_daily_members(plan), str(task.id)]))
+    if action == "remove":
+        members = [task_id for task_id in members if task_id != str(task.id)]
+        assignments = [
+            assignment
+            for assignment in assignments
+            if str(assignment.get("task_id") or assignment.get("taskId"))
+            != str(task.id)
+        ]
+    payload["planned_task_ids"] = members
+    payload["assignments"] = assignments
+    payload["total_scheduled_hours"] = sum(
+        float(assignment.get("duration_hours", 0) or 0) for assignment in assignments
+    )
+    plan.plan_json = payload
+    plan.updated_at = datetime.now(UTC)
+    session.add(plan)
+
+
+def _apply_weekly_membership(
+    session: Session,
+    owner_id: UUID,
+    target_date: str,
+    task: Task,
+    action: str,
+) -> None:
+    plan = _get_plan(session, owner_id, "weekly", target_date)
+    if plan is None:
+        plan = WeeklySchedule(
+            id=uuid4(),
+            user_id=owner_id,
+            week_start_date=_parse_plan_date(target_date),
+            schedule_json={"selected_tasks": [], "assigned_task_hours": {}},
+        )
+    payload = dict(plan.schedule_json or {})
+    selected = list(payload.get("selected_tasks", []))
+    assigned = dict(payload.get("assigned_task_hours", {}))
+    pinned = list(payload.get("pinned_task_ids", []))
+    selected = [
+        item
+        for item in selected
+        if str(
+            (item.get("task_id") or item.get("taskId"))
+            if isinstance(item, dict)
+            else item
+        )
+        != str(task.id)
+    ]
+    if action == "add":
+        selected.append(
+            {
+                "task_id": str(task.id),
+                "task_title": task.title,
+                "estimated_hours": float(task.estimate_hours),
+                "priority": task.priority,
+                "rationale": "タスクワークスペースから手動追加",
+            }
+        )
+        assigned[str(task.id)] = float(task.estimate_hours)
+    else:
+        assigned.pop(str(task.id), None)
+        pinned = [task_id for task_id in pinned if str(task_id) != str(task.id)]
+    payload["selected_tasks"] = selected
+    if "selected_task_ids" in payload:
+        payload["selected_task_ids"] = [
+            str(item.get("task_id") or item.get("taskId"))
+            if isinstance(item, dict)
+            else str(item)
+            for item in selected
+        ]
+    payload["assigned_task_hours"] = assigned
+    payload["pinned_task_ids"] = pinned
+    payload["total_allocated_hours"] = sum(float(value) for value in assigned.values())
+    plan.schedule_json = payload
+    plan.updated_at = datetime.now(UTC)
+    session.add(plan)
+
+
+@router.post("/bulk/preview", response_model=BulkTaskPreviewResponse)
+async def preview_bulk_task_changes(
+    request: BulkTaskRequest,
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+) -> BulkTaskPreviewResponse:
+    """Validate a bulk change and return its exact, non-mutating diff."""
+    return _preview_bulk(session, current_user.user_id, request)
+
+
+@router.post("/bulk/apply", response_model=BulkTaskPreviewResponse)
+async def apply_bulk_task_changes(
+    request: BulkTaskApplyRequest,
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+) -> BulkTaskPreviewResponse:
+    """Apply a previously previewed bulk change atomically."""
+    owner_id = UUID(str(current_user.user_id))
+    preview_request = BulkTaskRequest(mutations=request.mutations)
+    preview = _preview_bulk(session, owner_id, preview_request)
+    if preview.expected_task_versions != request.expected_task_versions:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="One or more tasks changed after the preview",
+        )
+    if preview.expected_plan_versions != request.expected_plan_versions:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A daily or weekly plan changed after the preview",
+        )
+
+    rows = _load_bulk_tasks(session, owner_id, request.mutations)
+    now = datetime.now(UTC)
+    try:
+        for mutation in request.mutations:
+            task = rows[mutation.task_id][0]
+            for field_name, value in mutation.patch.model_dump(
+                exclude_unset=True
+            ).items():
+                setattr(task, field_name, value)
+            if mutation.patch.model_fields_set:
+                task.updated_at = now
+                session.add(task)
+
+            for plan_change in mutation.plans:
+                existing = _get_plan(
+                    session,
+                    owner_id,
+                    plan_change.scope,
+                    plan_change.target_date,
+                )
+                members = (
+                    _daily_members(existing if isinstance(existing, Schedule) else None)
+                    if plan_change.scope == "daily"
+                    else _weekly_members(
+                        existing if isinstance(existing, WeeklySchedule) else None
+                    )
+                )
+                should_add = plan_change.action == "add"
+                if (str(task.id) in members) == should_add:
+                    continue
+                if plan_change.scope == "daily":
+                    _apply_daily_membership(
+                        session,
+                        owner_id,
+                        plan_change.target_date,
+                        task,
+                        plan_change.action,
+                    )
+                else:
+                    _apply_weekly_membership(
+                        session,
+                        owner_id,
+                        plan_change.target_date,
+                        task,
+                        plan_change.action,
+                    )
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+
+    return preview
+
+
+@router.post("/bulk/natural-language/preview", response_model=BulkTaskPreviewResponse)
+async def preview_natural_language_bulk_changes(
+    request: NaturalLanguageBulkRequest,
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+) -> BulkTaskPreviewResponse:
+    """Translate a bounded natural-language instruction into a safe bulk preview."""
+    owner_id = UUID(str(current_user.user_id))
+    placeholder_mutations = [
+        BulkTaskMutation(task_id=task_id) for task_id in request.task_ids
+    ]
+    rows = _load_bulk_tasks(session, owner_id, placeholder_mutations)
+    settings = session.exec(
+        select(UserSettings).where(UserSettings.user_id == owner_id)
+    ).first()
+    if not settings or not settings.openai_api_key_encrypted:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="OpenAI API key is not configured",
+        )
+    try:
+        api_key = get_crypto_service().decrypt(settings.openai_api_key_encrypted)
+        if not api_key:
+            raise ValueError("OpenAI API key could not be decrypted")
+        goals = session.exec(
+            select(Goal, Project)
+            .join(Project, Goal.project_id == Project.id)
+            .where(Project.owner_id == owner_id)
+        ).all()
+        allowed_goal_ids = {goal.id for goal, _project in goals if goal.id is not None}
+        client = OpenAI(api_key=api_key, timeout=30.0)
+        model = settings.openai_model or "gpt-5.5"
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Return JSON only. Never invent task or goal IDs. Only use the "
+                        "allowed fields and task IDs supplied by the user. Omit unchanged tasks."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": json.dumps(
+                        {
+                            "instruction": request.instruction,
+                            "today_jst": datetime.now(UTC)
+                            .astimezone(APP_TIMEZONE)
+                            .date()
+                            .isoformat(),
+                            "schema": {
+                                "interpretation": "short Japanese summary",
+                                "mutations": [
+                                    {
+                                        "task_id": "one supplied UUID",
+                                        "patch": {
+                                            "status": "pending|in_progress|completed|cancelled",
+                                            "priority": "integer 1..5",
+                                            "due_date": "ISO datetime or null",
+                                            "goal_id": "one supplied goal UUID",
+                                        },
+                                        "plans": [
+                                            {
+                                                "scope": "daily|weekly",
+                                                "action": "add|remove",
+                                                "target_date": "YYYY-MM-DD",
+                                            }
+                                        ],
+                                    }
+                                ],
+                            },
+                            "tasks": [
+                                {
+                                    "id": str(task.id),
+                                    "title": task.title,
+                                    "status": task.status.value,
+                                    "priority": task.priority,
+                                    "due_date": task.due_date.isoformat()
+                                    if task.due_date
+                                    else None,
+                                    "goal_id": str(task.goal_id),
+                                }
+                                for task, _goal, _project in rows.values()
+                            ],
+                            "goals": [
+                                {
+                                    "id": str(goal.id),
+                                    "title": goal.title,
+                                    "project": project.title,
+                                }
+                                for goal, project in goals
+                            ],
+                        },
+                        ensure_ascii=False,
+                    ),
+                },
+            ],
+            response_format={"type": "json_object"},
+            max_completion_tokens=2500,
+            **(
+                {"reasoning_effort": "high"}
+                if model.startswith(("gpt-5.5", "gpt-5.4"))
+                else {}
+            ),
+        )
+        payload = json.loads(response.choices[0].message.content or "{}")
+        mutations, ai_warnings = _sanitize_ai_bulk_mutations(
+            payload,
+            set(request.task_ids),
+            allowed_goal_ids,
+        )
+        if not mutations:
+            mutations = [
+                BulkTaskMutation(task_id=task_id)
+                for task_id in dict.fromkeys(request.task_ids)
+            ]
+        bulk_request = BulkTaskRequest(mutations=mutations)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("Natural language bulk preview failed: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="AI instruction could not be converted into safe changes",
+        ) from exc
+
+    return _preview_bulk(
+        session,
+        owner_id,
+        bulk_request,
+        interpretation=str(
+            payload.get("interpretation")
+            if isinstance(payload, dict) and payload.get("interpretation")
+            else request.instruction
+        )[:1000],
+        initial_warnings=ai_warnings,
+    )
 
 
 def build_task_responses_with_dependencies(
@@ -104,8 +746,8 @@ def _plan_date_windows(
 
 def _extract_planned_task_ids(
     session: Session, owner_id: str | UUID
-) -> tuple[set[str], set[str]]:
-    """Return task IDs in today's daily plan and the current weekly plan."""
+) -> tuple[set[str], set[str], set[str]]:
+    """Return today's plan IDs, weekly IDs, and today's placed assignment IDs."""
     owner_uuid = UUID(str(owner_id))
     day_start, day_end, week_start, week_end = _plan_date_windows()
 
@@ -124,19 +766,26 @@ def _extract_planned_task_ids(
         )
     ).all()
 
-    today_ids = {
+    placed_today_ids = {
         str(assignment.get("task_id") or assignment.get("taskId"))
         for schedule in daily_schedules
         for assignment in (schedule.plan_json or {}).get("assignments", [])
         if assignment.get("task_id") or assignment.get("taskId")
     }
+    today_ids = set(placed_today_ids)
+    today_ids.update(
+        str(task_id)
+        for schedule in daily_schedules
+        for task_id in (schedule.plan_json or {}).get("planned_task_ids", [])
+        if task_id
+    )
     week_ids = {
         str(task.get("task_id") or task.get("taskId"))
         for schedule in weekly_schedules
         for task in (schedule.schedule_json or {}).get("selected_tasks", [])
         if task.get("task_id") or task.get("taskId")
     }
-    return today_ids, week_ids
+    return today_ids, week_ids, placed_today_ids
 
 
 def _valid_task_uuids(task_ids: set[str]) -> set[UUID]:
@@ -207,6 +856,7 @@ def build_workspace_items(
     owner_id: str | UUID,
     today_ids: set[str] | None = None,
     week_ids: set[str] | None = None,
+    placed_today_ids: set[str] | None = None,
 ) -> list[TaskWorkspaceItem]:
     """Hydrate workspace query rows without per-task database calls."""
     if not rows:
@@ -215,8 +865,10 @@ def build_workspace_items(
     tasks = [row[0] for row in rows]
     task_ids = [task.id for task in tasks if task.id is not None]
     dependencies = task_service.get_task_dependencies_batch(session, task_ids, owner_id)
-    if today_ids is None or week_ids is None:
-        today_ids, week_ids = _extract_planned_task_ids(session, owner_id)
+    if today_ids is None or week_ids is None or placed_today_ids is None:
+        today_ids, week_ids, placed_today_ids = _extract_planned_task_ids(
+            session, owner_id
+        )
 
     items: list[TaskWorkspaceItem] = []
     for task, goal, project, actual_minutes, last_worked_at in rows:
@@ -251,6 +903,9 @@ def build_workspace_items(
                 blocking_task_ids=blocking_task_ids,
                 last_worked_at=last_worked_at,
                 planned_today=str(task.id) in today_ids,
+                planned_today_unplaced=(
+                    str(task.id) in today_ids and str(task.id) not in placed_today_ids
+                ),
                 planned_this_week=str(task.id) in week_ids,
             )
         )
@@ -281,8 +936,11 @@ async def get_task_workspace(
     excluded_task_ids: set[UUID] | None = None
     today_ids: set[str] | None = None
     week_ids: set[str] | None = None
+    placed_today_ids: set[str] | None = None
     if plan is not None:
-        today_ids, week_ids = _extract_planned_task_ids(session, current_user.user_id)
+        today_ids, week_ids, placed_today_ids = _extract_planned_task_ids(
+            session, current_user.user_id
+        )
         if plan == TaskWorkspacePlanFilter.TODAY:
             included_task_ids = _valid_task_uuids(today_ids)
         elif plan == TaskWorkspacePlanFilter.WEEK:
@@ -315,6 +973,7 @@ async def get_task_workspace(
             current_user.user_id,
             today_ids=today_ids,
             week_ids=week_ids,
+            placed_today_ids=placed_today_ids,
         ),
         total=total,
         skip=skip,
@@ -358,7 +1017,9 @@ async def get_task_dependency_graph(
     included_task_ids: set[UUID] | None = None
     excluded_task_ids: set[UUID] | None = None
     if plan is not None:
-        today_ids, week_ids = _extract_planned_task_ids(session, current_user.user_id)
+        today_ids, week_ids, _placed_today_ids = _extract_planned_task_ids(
+            session, current_user.user_id
+        )
         if plan == TaskWorkspacePlanFilter.TODAY:
             included_task_ids = _valid_task_uuids(today_ids)
         elif plan == TaskWorkspacePlanFilter.WEEK:

--- a/apps/api/src/humancompiler_api/routers/weekly_schedule.py
+++ b/apps/api/src/humancompiler_api/routers/weekly_schedule.py
@@ -4,7 +4,7 @@ Weekly schedule API endpoints for storing and retrieving weekly task selections.
 
 import json
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -377,7 +377,7 @@ async def update_weekly_schedule_draft(
                 status_code=409, detail="Weekly plan changed after loading"
             )
 
-    now = datetime.now()
+    now = datetime.now(UTC)
     if existing is None:
         existing = WeeklySchedule(
             id=uuid4(),

--- a/apps/api/src/humancompiler_api/routers/weekly_schedule.py
+++ b/apps/api/src/humancompiler_api/routers/weekly_schedule.py
@@ -34,6 +34,13 @@ class WeeklyScheduleSaveRequest(BaseModel):
     )
 
 
+class WeeklyScheduleDraftUpdate(BaseModel):
+    """Concurrency-safe update for an editable weekly-plan draft."""
+
+    schedule_data: dict = Field(..., description="Edited weekly schedule data")
+    expected_updated_at: datetime | None = None
+
+
 def validate_week_start_date(date_str: str) -> datetime:
     """
     Validate and parse week start date.
@@ -334,6 +341,60 @@ async def get_weekly_schedule(
                 },
             ).model_dump(),
         )
+
+
+@router.put("/{week_start_date}", response_model=WeeklyScheduleResponse)
+async def update_weekly_schedule_draft(
+    week_start_date: str,
+    request: WeeklyScheduleDraftUpdate,
+    user_id: str = Depends(get_current_user_id),
+    session: Session = Depends(db.get_session),
+):
+    """Merge and save an editable weekly plan without dropping legacy fields."""
+    week_start = validate_week_start_date(week_start_date)
+    user_uuid = UUID(user_id) if isinstance(user_id, str) else user_id
+    existing = session.exec(
+        select(WeeklySchedule).where(
+            WeeklySchedule.user_id == user_uuid,
+            WeeklySchedule.week_start_date == week_start,
+        )
+    ).first()
+    if existing is None and request.expected_updated_at is not None:
+        raise HTTPException(status_code=409, detail="Weekly plan no longer exists")
+    if existing is not None:
+        if request.expected_updated_at is None or existing.updated_at is None:
+            raise HTTPException(
+                status_code=409, detail="Weekly plan changed after loading"
+            )
+        expected = request.expected_updated_at
+        actual = existing.updated_at
+        if expected.tzinfo is not None:
+            expected = expected.replace(tzinfo=None)
+        if actual.tzinfo is not None:
+            actual = actual.replace(tzinfo=None)
+        if actual != expected:
+            raise HTTPException(
+                status_code=409, detail="Weekly plan changed after loading"
+            )
+
+    now = datetime.now()
+    if existing is None:
+        existing = WeeklySchedule(
+            id=uuid4(),
+            user_id=user_uuid,
+            week_start_date=week_start,
+            schedule_json=request.schedule_data,
+        )
+    else:
+        existing.schedule_json = {
+            **(existing.schedule_json or {}),
+            **request.schedule_data,
+        }
+        existing.updated_at = now
+    session.add(existing)
+    session.commit()
+    session.refresh(existing)
+    return WeeklyScheduleResponse.model_validate(existing)
 
 
 @router.delete("/{week_start_date}")

--- a/apps/api/src/humancompiler_api/routers/work_sessions.py
+++ b/apps/api/src/humancompiler_api/routers/work_sessions.py
@@ -29,6 +29,9 @@ from humancompiler_api.models import (
     WorkSessionUpdate,
     WorkSessionPauseRequest,
     WorkSessionResumeRequest,
+    WorkSessionSwitchRequest,
+    WorkSessionResumeContextResponse,
+    WorkSessionSwitchResponse,
     WorkSessionResponse,
     WorkSessionWithLogResponse,
     WorkSessionWithRescheduleResponse,
@@ -139,6 +142,30 @@ async def checkout_session(
 
 
 @router.post(
+    "/switch",
+    response_model=WorkSessionSwitchResponse,
+    responses={
+        404: {"model": ErrorResponse, "description": "Session or task not found"},
+        409: {"model": ErrorResponse, "description": "Target task is unavailable"},
+    },
+)
+async def switch_session(
+    switch_data: WorkSessionSwitchRequest,
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+) -> WorkSessionSwitchResponse:
+    """End the current work item and start another in one transaction."""
+    previous, current, log = work_session_service.switch_session(
+        session, current_user.user_id, switch_data
+    )
+    return WorkSessionSwitchResponse(
+        previous_session=WorkSessionResponse.model_validate(previous),
+        current_session=WorkSessionResponse.model_validate(current),
+        generated_log=LogResponse.model_validate(log),
+    )
+
+
+@router.post(
     "/pause",
     response_model=WorkSessionResponse,
     responses={
@@ -217,6 +244,34 @@ async def get_session_history(
         session, current_user.user_id, skip, limit
     )
     return [WorkSessionResponse.model_validate(s) for s in sessions]
+
+
+@router.get(
+    "/task/{task_id}/resume-context",
+    response_model=WorkSessionResumeContextResponse | None,
+)
+async def get_resume_context(
+    task_id: str,
+    session: Annotated[Session, Depends(get_session)],
+    current_user: Annotated[AuthUser, Depends(get_current_user)],
+) -> WorkSessionResumeContextResponse | None:
+    """Return the latest saved interruption note for a task."""
+    context = work_session_service.get_resume_context(
+        session, current_user.user_id, task_id
+    )
+    if (
+        context is None
+        or context.ended_at is None
+        or context.switch_disposition is None
+    ):
+        return None
+    return WorkSessionResumeContextResponse(
+        task_id=context.task_id,
+        interruption_note=context.interruption_note or "",
+        interrupted_at=context.ended_at,
+        disposition=context.switch_disposition,
+        remaining_estimate_hours=context.remaining_estimate_hours,
+    )
 
 
 @router.get(

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -50,9 +50,11 @@ from humancompiler_api.models import (
     WorkSessionUpdate,
     WorkSessionPauseRequest,
     WorkSessionResumeRequest,
+    WorkSessionSwitchRequest,
     CheckoutType,
     SessionDecision,
     ContinueReason,
+    SwitchDisposition,
     SortBy,
     SortOrder,
     QuickTask,
@@ -777,6 +779,7 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
             TaskWorkspaceSortBy.STATUS: Task.status,
             TaskWorkspaceSortBy.TITLE: Task.title,
             TaskWorkspaceSortBy.UPDATED_AT: Task.updated_at,
+            TaskWorkspaceSortBy.LAST_WORKED_AT: last_worked.c.last_worked_at,
         }
         sort_column = sort_columns[sort_by]
         order_expression = (
@@ -1600,6 +1603,142 @@ class WorkSessionService(
         session.refresh(current_session)
 
         return current_session, new_log
+
+    def switch_session(
+        self,
+        session: Session,
+        user_id: str | UUID,
+        switch_data: WorkSessionSwitchRequest,
+    ) -> tuple[WorkSession, WorkSession, Log]:
+        """Atomically end the current session and start the requested task."""
+        user_uuid = validate_uuid(user_id, "user_id")
+        current = self.get_current_session(session, user_uuid)
+        if not current:
+            raise HTTPException(status_code=404, detail="No active session found")
+        if current.task_id == switch_data.next_task_id:
+            raise HTTPException(status_code=400, detail="Next task must be different")
+
+        next_task = self.task_service.get_task(
+            session, switch_data.next_task_id, user_uuid
+        )
+        if next_task.status not in {TaskStatus.PENDING, TaskStatus.IN_PROGRESS}:
+            raise HTTPException(status_code=409, detail="Next task is not actionable")
+        dependencies = self.task_service.get_task_dependencies_batch(
+            session, [switch_data.next_task_id], user_uuid
+        ).get(str(switch_data.next_task_id), [])
+        if any(
+            dependency.depends_on_task
+            and dependency.depends_on_task.status != TaskStatus.COMPLETED
+            for dependency in dependencies
+        ):
+            raise HTTPException(status_code=409, detail="Next task is blocked")
+
+        current_task = self.task_service.get_task(session, current.task_id, user_uuid)
+        ended_at = datetime.now(UTC)
+        total_paused_seconds = current.total_paused_seconds or 0
+        if current.paused_at is not None:
+            paused_at = current.paused_at
+            if paused_at.tzinfo is None:
+                paused_at = paused_at.replace(tzinfo=UTC)
+            total_paused_seconds += max(0, int((ended_at - paused_at).total_seconds()))
+            current.paused_at = None
+        started_at = current.started_at
+        if started_at.tzinfo is None:
+            started_at = started_at.replace(tzinfo=UTC)
+        actual_seconds = max(
+            0, int((ended_at - started_at).total_seconds()) - total_paused_seconds
+        )
+        actual_minutes = max(1, actual_seconds // 60)
+        prior_minutes = session.exec(
+            select(func.coalesce(func.sum(Log.actual_minutes), 0)).where(
+                Log.task_id == current.task_id
+            )
+        ).one()
+        calculated_remaining = max(
+            Decimal("0"),
+            current_task.estimate_hours
+            - (Decimal(int(prior_minutes or 0) + actual_minutes) / Decimal("60")),
+        ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+        current.ended_at = ended_at
+        current.total_paused_seconds = total_paused_seconds
+        current.checkout_type = CheckoutType.INTERRUPTED
+        current.decision = (
+            SessionDecision.COMPLETE
+            if switch_data.disposition == SwitchDisposition.COMPLETE
+            else SessionDecision.SWITCH
+        )
+        current.switch_disposition = switch_data.disposition
+        current.interruption_note = (
+            switch_data.interruption_note.strip()
+            if switch_data.interruption_note
+            else None
+        )
+        current.remaining_estimate_hours = (
+            switch_data.remaining_estimate_hours
+            if switch_data.remaining_estimate_hours is not None
+            else calculated_remaining
+        )
+        current.updated_at = ended_at
+
+        current_task.status = {
+            SwitchDisposition.COMPLETE: TaskStatus.COMPLETED,
+            SwitchDisposition.PAUSE: TaskStatus.IN_PROGRESS,
+            SwitchDisposition.DEFER: TaskStatus.PENDING,
+        }[switch_data.disposition]
+        current_task.updated_at = ended_at
+
+        log = Log(
+            id=uuid4(),
+            task_id=current.task_id,
+            actual_minutes=actual_minutes,
+            comment=current.interruption_note,
+        )
+        next_session = WorkSession(
+            id=uuid4(),
+            user_id=user_uuid,
+            task_id=next_task.id,
+            planned_checkout_at=switch_data.planned_checkout_at,
+            planned_outcome=switch_data.planned_outcome,
+            is_manual_execution=True,
+        )
+        if next_task.status == TaskStatus.PENDING:
+            next_task.status = TaskStatus.IN_PROGRESS
+            next_task.updated_at = ended_at
+
+        try:
+            session.add(current)
+            session.add(current_task)
+            session.add(next_task)
+            session.add(log)
+            session.add(next_session)
+            session.commit()
+            session.refresh(current)
+            session.refresh(next_session)
+            session.refresh(log)
+        except Exception:
+            session.rollback()
+            raise
+        return current, next_session, log
+
+    def get_resume_context(
+        self, session: Session, user_id: str | UUID, task_id: str | UUID
+    ) -> WorkSession | None:
+        """Return the newest recorded interruption for an owned task."""
+        user_uuid = validate_uuid(user_id, "user_id")
+        task_uuid = validate_uuid(task_id, "task_id")
+        self.task_service.get_task(session, task_uuid, user_uuid)
+        return session.exec(
+            select(WorkSession)
+            .where(
+                WorkSession.user_id == user_uuid,
+                WorkSession.task_id == task_uuid,
+                WorkSession.interruption_note.is_not(None),
+                WorkSession.switch_disposition.is_not(None),
+            )
+            .order_by(WorkSession.ended_at.desc())
+            .limit(1)
+        ).first()
 
     def get_sessions_by_task(
         self,

--- a/apps/api/src/humancompiler_api/services.py
+++ b/apps/api/src/humancompiler_api/services.py
@@ -785,7 +785,10 @@ class TaskService(BaseService[Task, TaskCreate, TaskUpdate]):
         order_expression = (
             sort_column.desc() if sort_order == SortOrder.DESC else sort_column.asc()
         )
-        if sort_by == TaskWorkspaceSortBy.DUE_DATE:
+        if sort_by in {
+            TaskWorkspaceSortBy.DUE_DATE,
+            TaskWorkspaceSortBy.LAST_WORKED_AT,
+        }:
             order_expression = order_expression.nulls_last()
         statement = (
             statement.order_by(order_expression, Task.priority.asc(), Task.id.asc())
@@ -1692,7 +1695,7 @@ class WorkSessionService(
             id=uuid4(),
             task_id=current.task_id,
             actual_minutes=actual_minutes,
-            comment=current.interruption_note,
+            comment=(current.interruption_note or "")[:500] or None,
         )
         next_session = WorkSession(
             id=uuid4(),

--- a/apps/api/tests/test_task_bulk_and_runner_switch.py
+++ b/apps/api/tests/test_task_bulk_and_runner_switch.py
@@ -195,6 +195,58 @@ def test_runner_switch_is_atomic_and_saves_resume_context(
         assert context.remaining_estimate_hours is not None
 
 
+def test_runner_switch_keeps_long_resume_note_and_truncates_log_comment(
+    session, test_user_id
+):
+    data = create_test_data(session, test_user_id)
+    tasks = TaskService()
+    current_task = tasks.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Long note current",
+            estimate_hours=Decimal("2"),
+        ),
+        test_user_id,
+    )
+    next_task = tasks.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Long note next",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    service = WorkSessionService()
+    service.start_session(
+        session,
+        WorkSessionStartRequest(
+            task_id=current_task.id,
+            planned_checkout_at=datetime.now(UTC) + timedelta(hours=1),
+        ),
+        test_user_id,
+    )
+    note = "再" * 1000
+
+    previous, _current, log = service.switch_session(
+        session,
+        test_user_id,
+        WorkSessionSwitchRequest(
+            next_task_id=next_task.id,
+            disposition=SwitchDisposition.PAUSE,
+            interruption_note=note,
+            planned_checkout_at=datetime.now(UTC) + timedelta(hours=1),
+        ),
+    )
+
+    assert previous.interruption_note == note
+    assert log.comment == note[:500]
+    context = service.get_resume_context(session, test_user_id, current_task.id)
+    assert context is not None
+    assert context.interruption_note == note
+
+
 def test_bulk_request_rejects_more_than_one_hundred_items():
     mutation = {
         "task_id": "12345678-1234-1234-1234-123456789012",
@@ -375,6 +427,94 @@ async def test_daily_remove_deletes_assignment_and_recalculates_total(
     assert str(task.id) not in plan.plan_json["planned_task_ids"]
     assert len(plan.plan_json["assignments"]) == 1
     assert plan.plan_json["total_scheduled_hours"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_weekly_membership_preserves_legacy_selected_task_ids(
+    session, test_user_id
+):
+    data = create_test_data(session, test_user_id)
+    tasks = TaskService()
+    removed_task = tasks.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Remove legacy task",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    untouched_task = tasks.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Keep legacy task",
+            estimate_hours=Decimal("2"),
+        ),
+        test_user_id,
+    )
+    added_task = tasks.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Add current task",
+            estimate_hours=Decimal("3"),
+        ),
+        test_user_id,
+    )
+    plan = WeeklySchedule(
+        id=uuid4(),
+        user_id=test_user_id,
+        week_start_date=datetime(2030, 1, 7),
+        schedule_json={
+            "selected_task_ids": [
+                str(removed_task.id),
+                str(untouched_task.id),
+            ],
+            "assigned_task_hours": {
+                str(removed_task.id): 1,
+                str(untouched_task.id): 2,
+            },
+        },
+    )
+    session.add(plan)
+    session.commit()
+
+    for task, action in [
+        (removed_task, "remove"),
+        (added_task, "add"),
+    ]:
+        request = BulkTaskRequest(
+            mutations=[
+                BulkTaskMutation(
+                    task_id=task.id,
+                    plans=[
+                        PlanMembershipMutation(
+                            scope="weekly",
+                            action=action,
+                            target_date="2030-01-07",
+                        )
+                    ],
+                )
+            ]
+        )
+        preview = _preview_bulk(session, test_user_id, request)
+        await apply_bulk_task_changes(
+            BulkTaskApplyRequest(
+                mutations=request.mutations,
+                expected_task_versions=preview.expected_task_versions,
+                expected_plan_versions=preview.expected_plan_versions,
+            ),
+            session,
+            _auth(test_user_id),
+        )
+
+    session.refresh(plan)
+    expected_ids = {str(untouched_task.id), str(added_task.id)}
+    assert set(plan.schedule_json["selected_task_ids"]) == expected_ids
+    assert {
+        str(item["task_id"]) for item in plan.schedule_json["selected_tasks"]
+    } == expected_ids
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/test_task_bulk_and_runner_switch.py
+++ b/apps/api/tests/test_task_bulk_and_runner_switch.py
@@ -1,0 +1,417 @@
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from conftest import create_test_data
+from humancompiler_api.models import (
+    Schedule,
+    SwitchDisposition,
+    TaskCreate,
+    TaskStatus,
+    WeeklySchedule,
+    WorkSessionStartRequest,
+    WorkSessionSwitchRequest,
+)
+from humancompiler_api.routers.tasks import (
+    BulkTaskApplyRequest,
+    BulkTaskMutation,
+    BulkTaskPatch,
+    BulkTaskRequest,
+    PlanMembershipMutation,
+    NaturalLanguageBulkRequest,
+    _preview_bulk,
+    _sanitize_ai_bulk_mutations,
+    apply_bulk_task_changes,
+    preview_natural_language_bulk_changes,
+)
+from humancompiler_api.routers.weekly_schedule import (
+    WeeklyScheduleDraftUpdate,
+    update_weekly_schedule_draft,
+)
+from humancompiler_api.auth import AuthUser
+from humancompiler_api.services import TaskService, WorkSessionService
+from sqlmodel import select
+from pydantic import ValidationError
+
+
+def _auth(user_id):
+    return AuthUser(user_id=user_id, email="test@example.com")
+
+
+@pytest.mark.asyncio
+async def test_bulk_preview_and_apply_updates_task_and_plan_membership(
+    session, test_user_id
+):
+    data = create_test_data(session, test_user_id)
+    task = TaskService().create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Bulk task",
+            estimate_hours=Decimal("2.5"),
+        ),
+        test_user_id,
+    )
+    request = BulkTaskRequest(
+        mutations=[
+            BulkTaskMutation(
+                task_id=task.id,
+                patch=BulkTaskPatch(priority=1, status=TaskStatus.IN_PROGRESS),
+                plans=[
+                    PlanMembershipMutation(
+                        scope="daily", action="add", target_date="2030-01-02"
+                    ),
+                    PlanMembershipMutation(
+                        scope="weekly", action="add", target_date="2029-12-31"
+                    ),
+                ],
+            )
+        ]
+    )
+    preview = _preview_bulk(session, test_user_id, request)
+    assert preview.affected_count == 1
+    assert {diff.field for diff in preview.items[0].diffs} == {
+        "priority",
+        "status",
+        "plan:daily:2030-01-02",
+        "plan:weekly:2029-12-31",
+    }
+
+    applied = await apply_bulk_task_changes(
+        BulkTaskApplyRequest(
+            mutations=request.mutations,
+            expected_task_versions=preview.expected_task_versions,
+            expected_plan_versions=preview.expected_plan_versions,
+        ),
+        session,
+        _auth(test_user_id),
+    )
+    assert applied.affected_count == 1
+    session.refresh(task)
+    assert task.priority == 1
+    assert task.status == TaskStatus.IN_PROGRESS
+    daily = session.exec(select(Schedule)).one()
+    weekly = session.exec(select(WeeklySchedule)).one()
+    assert str(task.id) in daily.plan_json["planned_task_ids"]
+    assert weekly.schedule_json["selected_tasks"][0]["task_id"] == str(task.id)
+
+
+@pytest.mark.asyncio
+async def test_bulk_apply_rejects_stale_task_version(session, test_user_id):
+    data = create_test_data(session, test_user_id)
+    task = TaskService().create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Concurrent task",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    request = BulkTaskRequest(
+        mutations=[BulkTaskMutation(task_id=task.id, patch=BulkTaskPatch(priority=2))]
+    )
+    preview = _preview_bulk(session, test_user_id, request)
+    task.updated_at = datetime.now(UTC) + timedelta(seconds=1)
+    session.add(task)
+    session.commit()
+
+    with pytest.raises(HTTPException) as error:
+        await apply_bulk_task_changes(
+            BulkTaskApplyRequest(
+                mutations=request.mutations,
+                expected_task_versions=preview.expected_task_versions,
+                expected_plan_versions=preview.expected_plan_versions,
+            ),
+            session,
+            _auth(test_user_id),
+        )
+    assert error.value.status_code == 409
+
+
+@pytest.mark.parametrize(
+    ("disposition", "expected_status"),
+    [
+        (SwitchDisposition.COMPLETE, TaskStatus.COMPLETED),
+        (SwitchDisposition.PAUSE, TaskStatus.IN_PROGRESS),
+        (SwitchDisposition.DEFER, TaskStatus.PENDING),
+    ],
+)
+def test_runner_switch_is_atomic_and_saves_resume_context(
+    session, test_user_id, disposition, expected_status
+):
+    data = create_test_data(session, test_user_id)
+    tasks = TaskService()
+    current_task = tasks.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Current",
+            estimate_hours=Decimal("2"),
+        ),
+        test_user_id,
+    )
+    next_task = tasks.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Next",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    service = WorkSessionService()
+    service.start_session(
+        session,
+        WorkSessionStartRequest(
+            task_id=current_task.id,
+            planned_checkout_at=datetime.now(UTC) + timedelta(hours=1),
+        ),
+        test_user_id,
+    )
+    note = None if disposition == SwitchDisposition.COMPLETE else "ここから再開"
+    previous, current, log = service.switch_session(
+        session,
+        test_user_id,
+        WorkSessionSwitchRequest(
+            next_task_id=next_task.id,
+            disposition=disposition,
+            interruption_note=note,
+            planned_checkout_at=datetime.now(UTC) + timedelta(hours=1),
+        ),
+    )
+    session.refresh(current_task)
+    assert current_task.status == expected_status
+    assert previous.ended_at is not None
+    assert current.task_id == next_task.id
+    assert log.task_id == current_task.id
+    if note:
+        context = service.get_resume_context(session, test_user_id, current_task.id)
+        assert context is not None
+        assert context.interruption_note == note
+        assert context.remaining_estimate_hours is not None
+
+
+def test_bulk_request_rejects_more_than_one_hundred_items():
+    mutation = {
+        "task_id": "12345678-1234-1234-1234-123456789012",
+        "patch": {"priority": 1},
+    }
+    with pytest.raises(ValidationError):
+        BulkTaskRequest.model_validate({"mutations": [mutation] * 101})
+
+
+def test_ai_sanitizer_discards_out_of_scope_ids_and_invalid_fields():
+    task_id = uuid4()
+    goal_id = uuid4()
+    mutations, warnings = _sanitize_ai_bulk_mutations(
+        {
+            "mutations": [
+                {
+                    "task_id": str(task_id),
+                    "patch": {
+                        "priority": 2,
+                        "status": "not-a-status",
+                        "goal_id": str(uuid4()),
+                        "title": "must not change",
+                    },
+                    "plans": [
+                        {
+                            "scope": "daily",
+                            "action": "add",
+                            "target_date": "2030-01-02",
+                        },
+                        {"scope": "daily", "action": "add", "target_date": "bad"},
+                    ],
+                },
+                {"task_id": str(uuid4()), "patch": {"priority": 1}},
+            ]
+        },
+        {task_id},
+        {goal_id},
+    )
+    assert len(mutations) == 1
+    assert mutations[0].patch.priority == 2
+    assert mutations[0].patch.status is None
+    assert mutations[0].patch.goal_id is None
+    assert len(mutations[0].plans) == 1
+    assert len(warnings) >= 4
+
+
+@pytest.mark.asyncio
+async def test_natural_language_preview_without_api_key_does_not_write(
+    session, test_user_id
+):
+    data = create_test_data(session, test_user_id)
+    task = TaskService().create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="AI preview only",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    original_updated_at = task.updated_at
+    with pytest.raises(HTTPException) as error:
+        await preview_natural_language_bulk_changes(
+            NaturalLanguageBulkRequest(
+                instruction="優先度を上げる", task_ids=[task.id]
+            ),
+            session,
+            _auth(test_user_id),
+        )
+    assert error.value.status_code == 503
+    session.refresh(task)
+    assert task.priority == 3
+    assert task.updated_at == original_updated_at
+
+
+def test_runner_rejects_completed_target_without_ending_current_session(
+    session, test_user_id
+):
+    data = create_test_data(session, test_user_id)
+    tasks = TaskService()
+    current_task = tasks.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Current atomic",
+            estimate_hours=Decimal("1"),
+        ),
+        test_user_id,
+    )
+    completed_task = tasks.create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Completed target",
+            estimate_hours=Decimal("1"),
+            status=TaskStatus.COMPLETED,
+        ),
+        test_user_id,
+    )
+    service = WorkSessionService()
+    active = service.start_session(
+        session,
+        WorkSessionStartRequest(
+            task_id=current_task.id,
+            planned_checkout_at=datetime.now(UTC) + timedelta(hours=1),
+        ),
+        test_user_id,
+    )
+    with pytest.raises(HTTPException) as error:
+        service.switch_session(
+            session,
+            test_user_id,
+            WorkSessionSwitchRequest(
+                next_task_id=completed_task.id,
+                disposition=SwitchDisposition.COMPLETE,
+                planned_checkout_at=datetime.now(UTC) + timedelta(hours=1),
+            ),
+        )
+    assert error.value.status_code == 409
+    session.refresh(active)
+    assert active.ended_at is None
+
+
+@pytest.mark.asyncio
+async def test_daily_remove_deletes_assignment_and_recalculates_total(
+    session, test_user_id
+):
+    data = create_test_data(session, test_user_id)
+    task = TaskService().create_task(
+        session,
+        TaskCreate(
+            goal_id=data["goal"].id,
+            title="Placed today",
+            estimate_hours=Decimal("2"),
+        ),
+        test_user_id,
+    )
+    plan = Schedule(
+        id=uuid4(),
+        user_id=test_user_id,
+        date=datetime(2030, 1, 2),
+        plan_json={
+            "unknown": "preserve",
+            "planned_task_ids": [str(task.id)],
+            "assignments": [
+                {"task_id": str(task.id), "duration_hours": 1.5},
+                {"task_id": str(uuid4()), "duration_hours": 0.5},
+            ],
+            "total_scheduled_hours": 2,
+        },
+    )
+    session.add(plan)
+    session.commit()
+    request = BulkTaskRequest(
+        mutations=[
+            BulkTaskMutation(
+                task_id=task.id,
+                plans=[
+                    PlanMembershipMutation(
+                        scope="daily", action="remove", target_date="2030-01-02"
+                    )
+                ],
+            )
+        ]
+    )
+    preview = _preview_bulk(session, test_user_id, request)
+    await apply_bulk_task_changes(
+        BulkTaskApplyRequest(
+            mutations=request.mutations,
+            expected_task_versions=preview.expected_task_versions,
+            expected_plan_versions=preview.expected_plan_versions,
+        ),
+        session,
+        _auth(test_user_id),
+    )
+    session.refresh(plan)
+    assert plan.plan_json["unknown"] == "preserve"
+    assert str(task.id) not in plan.plan_json["planned_task_ids"]
+    assert len(plan.plan_json["assignments"]) == 1
+    assert plan.plan_json["total_scheduled_hours"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_weekly_draft_preserves_unknown_fields_and_rejects_stale_version(
+    session, test_user_id
+):
+    create_test_data(session, test_user_id)
+    schedule = WeeklySchedule(
+        id=uuid4(),
+        user_id=test_user_id,
+        week_start_date=datetime(2030, 1, 7),
+        schedule_json={"selected_task_ids": [], "legacy_unknown": {"keep": True}},
+    )
+    session.add(schedule)
+    session.commit()
+    session.refresh(schedule)
+    old_version = schedule.updated_at
+    saved = await update_weekly_schedule_draft(
+        "2030-01-07",
+        WeeklyScheduleDraftUpdate(
+            schedule_data={"selected_tasks": [], "capacity_hours": 20},
+            expected_updated_at=old_version,
+        ),
+        str(test_user_id),
+        session,
+    )
+    assert saved.schedule_json["legacy_unknown"] == {"keep": True}
+    assert saved.schedule_json["capacity_hours"] == 20
+
+    with pytest.raises(HTTPException) as error:
+        await update_weekly_schedule_draft(
+            "2030-01-07",
+            WeeklyScheduleDraftUpdate(
+                schedule_data={"capacity_hours": 30},
+                expected_updated_at=old_version,
+            ),
+            str(test_user_id),
+            session,
+        )
+    assert error.value.status_code == 409

--- a/apps/api/tests/test_task_workspace.py
+++ b/apps/api/tests/test_task_workspace.py
@@ -479,15 +479,18 @@ def test_extract_planned_task_ids_supports_camel_case_assignments(
         Schedule(
             id=uuid4(),
             user_id=test_user_id,
-            date=datetime.now(UTC),
+            # Schedule dates are stored as naive JST calendar dates. Using a raw
+            # UTC timestamp makes this test cross midnight nine hours too late.
+            date=_plan_date_windows()[0],
             plan_json={"assignments": [{"taskId": str(task_id)}]},
         )
     )
     session.flush()
 
-    today_ids, _ = _extract_planned_task_ids(session, test_user_id)
+    today_ids, _, placed_today_ids = _extract_planned_task_ids(session, test_user_id)
 
     assert str(task_id) in today_ids
+    assert str(task_id) in placed_today_ids
 
 
 def test_plan_date_windows_use_jst_calendar_boundaries():

--- a/apps/web/src/app/ai-planning/page.tsx
+++ b/apps/web/src/app/ai-planning/page.tsx
@@ -39,6 +39,7 @@ import { AppHeader } from "@/components/layout/app-header";
 import { WeeklyRecurringTaskSelector } from "@/components/weekly-recurring-task-selector";
 import { WeeklyRecurringTaskDialog } from "@/components/weekly-recurring-task-dialog";
 import { ProjectAllocationSettings } from "@/components/scheduling/project-allocation-settings";
+import { WeeklyPlanEditor } from "@/components/scheduling/weekly-plan-editor";
 import { toast } from "@/hooks/use-toast";
 import {
   aiPlanningApi,
@@ -49,11 +50,45 @@ import {
 import { getJSTDateString, getJSTISOString } from "@/lib/date-utils";
 import { getSelectableProjects } from "@/lib/project-filters";
 import type {
+  TaskPlan,
+  WeeklyScheduleData,
   WeeklyPlanResponse,
   SavedWeeklySchedule,
 } from "@/types/ai-planning";
 import type { WeeklyReportResponse } from "@/types/reports";
 import type { WeeklyRecurringTask } from "@/types/weekly-recurring-task";
+
+function normalizeSavedTaskPlans(data: WeeklyScheduleData): TaskPlan[] {
+  const legacy = data as unknown as Record<string, unknown>;
+  const rawTasks = Array.isArray(legacy.selected_tasks)
+    ? legacy.selected_tasks
+    : Array.isArray(legacy.selected_task_ids)
+      ? legacy.selected_task_ids
+      : [];
+  const assigned = (legacy.assigned_task_hours ?? {}) as Record<string, number>;
+  return rawTasks.flatMap((raw): TaskPlan[] => {
+    if (typeof raw === "string") {
+      return [{
+        task_id: raw,
+        task_title: `タスク ${raw.slice(0, 8)}`,
+        estimated_hours: Number(assigned[raw] ?? 1),
+        priority: 3,
+        rationale: "旧形式の週次計画から復元",
+      }];
+    }
+    if (!raw || typeof raw !== "object") return [];
+    const item = raw as Record<string, unknown>;
+    const taskId = String(item.task_id ?? item.taskId ?? item.id ?? "");
+    if (!taskId) return [];
+    return [{
+      task_id: taskId,
+      task_title: String(item.task_title ?? item.taskTitle ?? item.title ?? `タスク ${taskId.slice(0, 8)}`),
+      estimated_hours: Number(item.estimated_hours ?? item.estimate_hours ?? assigned[taskId] ?? 1),
+      priority: Number(item.priority ?? 3),
+      rationale: String(item.rationale ?? "保存済み週次計画から復元"),
+    }];
+  });
+}
 
 export default function AIPlanningPage() {
   const { user, session, loading: authLoading } = useAuth();
@@ -354,11 +389,19 @@ export default function AIPlanningPage() {
         project_allocations: weeklyPlan.project_allocations || [],
         optimization_insights: weeklyPlan.insights || [],
         recommendations: weeklyPlan.recommendations || [],
+        pinned_task_ids: weeklyPlan.pinned_task_ids || [],
         capacity_hours: capacityHours,
         generation_timestamp: getJSTISOString(),
       };
 
-      await weeklyScheduleApi.save(weeklyPlan.week_start_date, scheduleData);
+      const saved = await weeklyScheduleApi.updateDraft(
+        weeklyPlan.week_start_date,
+        scheduleData,
+        selectedSchedule?.week_start_date.slice(0, 10) === weeklyPlan.week_start_date
+          ? selectedSchedule.updated_at
+          : undefined,
+      );
+      setSelectedSchedule(saved);
 
       toast({
         title: "週間スケジュールを保存しました",
@@ -623,6 +666,18 @@ export default function AIPlanningPage() {
                   </div>
                 </CardHeader>
                 <CardContent className="space-y-4">
+                  <WeeklyPlanEditor
+                    plan={weeklyPlan}
+                    capacityHours={capacityHours}
+                    projects={selectableProjects}
+                    canRecalculate={
+                      selectedSchedule?.week_start_date.slice(0, 10) ===
+                      weeklyPlan.week_start_date
+                    }
+                    onChange={setWeeklyPlan}
+                  />
+
+                  <Separator />
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                     <Card>
                       <CardContent className="pt-6">
@@ -1076,7 +1131,7 @@ export default function AIPlanningPage() {
                           週の計画
                         </div>
                         <div className="text-sm text-gray-600">
-                          {schedule.schedule_json.selected_tasks.length}
+                          {normalizeSavedTaskPlans(schedule.schedule_json).length}
                           個のタスク・
                           {schedule.schedule_json.total_allocated_hours}時間
                         </div>
@@ -1123,10 +1178,37 @@ export default function AIPlanningPage() {
             {selectedSchedule && (
               <Card>
                 <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <Calendar className="h-5 w-5" />
-                    週間スケジュール詳細
-                  </CardTitle>
+                  <div className="flex items-center justify-between gap-3">
+                    <CardTitle className="flex items-center gap-2">
+                      <Calendar className="h-5 w-5" />
+                      週間スケジュール詳細
+                    </CardTitle>
+                    <Button
+                      variant="outline"
+                      onClick={() => {
+                        const data = selectedSchedule.schedule_json;
+                        const normalizedTasks = normalizeSavedTaskPlans(data);
+                        setCapacityHours(data.capacity_hours ?? data.total_allocated_hours ?? 40);
+                        setWeeklyPlan({
+                          success: true,
+                          week_start_date: selectedSchedule.week_start_date.slice(0, 10),
+                          total_planned_hours: data.total_allocated_hours ?? 0,
+                          task_plans: normalizedTasks,
+                          assigned_task_hours: data.assigned_task_hours ?? {},
+                          assigned_recurring_task_hours: data.assigned_recurring_task_hours ?? {},
+                          pinned_task_ids: data.pinned_task_ids ?? [],
+                          recommendations: data.recommendations ?? [],
+                          insights: data.optimization_insights ?? [],
+                          project_allocations: data.project_allocations ?? [],
+                          generated_at: data.generated_at ?? selectedSchedule.updated_at,
+                        });
+                        window.scrollTo({ top: 0, behavior: 'smooth' });
+                      }}
+                    >
+                      <Edit className="mr-2 h-4 w-4" />
+                      この計画を編集
+                    </Button>
+                  </div>
                   <CardDescription>
                     {new Date(
                       selectedSchedule.week_start_date,
@@ -1147,8 +1229,9 @@ export default function AIPlanningPage() {
                           <div>
                             <div className="text-2xl font-bold">
                               {
-                                selectedSchedule.schedule_json.selected_tasks
-                                  .length
+                                normalizeSavedTaskPlans(
+                                  selectedSchedule.schedule_json,
+                                ).length
                               }
                             </div>
                             <div className="text-xs text-gray-500">
@@ -1187,7 +1270,7 @@ export default function AIPlanningPage() {
                             <div className="text-2xl font-bold">
                               {
                                 selectedSchedule.schedule_json
-                                  .project_allocations.length
+                                  .project_allocations?.length ?? 0
                               }
                             </div>
                             <div className="text-xs text-gray-500">
@@ -1206,7 +1289,7 @@ export default function AIPlanningPage() {
                       選択されたタスク
                     </h4>
                     <div className="space-y-2">
-                      {selectedSchedule.schedule_json.selected_tasks.map(
+                      {normalizeSavedTaskPlans(selectedSchedule.schedule_json).map(
                         (task, index) => (
                           <div
                             key={index}

--- a/apps/web/src/app/ai-planning/page.tsx
+++ b/apps/web/src/app/ai-planning/page.tsx
@@ -48,7 +48,9 @@ import {
   reportsApi,
 } from "@/lib/api";
 import { getJSTDateString, getJSTISOString } from "@/lib/date-utils";
+import { ApiError } from "@/lib/errors";
 import { getSelectableProjects } from "@/lib/project-filters";
+import { saveWeeklyScheduleDraft } from "@/lib/weekly-schedule-draft";
 import type {
   TaskPlan,
   WeeklyScheduleData,
@@ -394,13 +396,12 @@ export default function AIPlanningPage() {
         generation_timestamp: getJSTISOString(),
       };
 
-      const saved = await weeklyScheduleApi.updateDraft(
-        weeklyPlan.week_start_date,
+      const saved = await saveWeeklyScheduleDraft({
+        api: weeklyScheduleApi,
+        weekStartDate: weeklyPlan.week_start_date,
         scheduleData,
-        selectedSchedule?.week_start_date.slice(0, 10) === weeklyPlan.week_start_date
-          ? selectedSchedule.updated_at
-          : undefined,
-      );
+        selectedSchedule,
+      });
       setSelectedSchedule(saved);
 
       toast({
@@ -413,6 +414,57 @@ export default function AIPlanningPage() {
         loadSavedSchedules();
       }
     } catch (error) {
+      if (error instanceof ApiError && error.statusCode === 409) {
+        try {
+          const latest = await weeklyScheduleApi.getByWeek(
+            weeklyPlan.week_start_date,
+          );
+          setSelectedSchedule(latest);
+          setSavedSchedules((current) => {
+            const withoutLatest = current.filter(
+              (schedule) =>
+                schedule.week_start_date.slice(0, 10) !==
+                weeklyPlan.week_start_date,
+            );
+            return [latest, ...withoutLatest];
+          });
+          toast({
+            title: "週間スケジュールが更新されています",
+            description:
+              "最新の保存状態を読み込みました。編集中の内容は保持されています。内容を確認して、もう一度保存してください。",
+            variant: "destructive",
+          });
+          return;
+        } catch (reloadError) {
+          if (
+            reloadError instanceof ApiError &&
+            reloadError.statusCode === 404
+          ) {
+            setSelectedSchedule(null);
+            setSavedSchedules((current) =>
+              current.filter(
+                (schedule) =>
+                  schedule.week_start_date.slice(0, 10) !==
+                  weeklyPlan.week_start_date,
+              ),
+            );
+            toast({
+              title: "保存済みの週間スケジュールが削除されています",
+              description:
+                "編集中の内容は保持されています。もう一度保存すると新しい計画として作成されます。",
+              variant: "destructive",
+            });
+            return;
+          }
+          toast({
+            title: "週間スケジュールが更新されています",
+            description:
+              "最新版を取得できませんでした。保存済み計画を再読み込みしてから、もう一度編集してください。",
+            variant: "destructive",
+          });
+          return;
+        }
+      }
       toast({
         title: "週間スケジュールの保存に失敗しました",
         description:

--- a/apps/web/src/app/scheduling/daily/page.tsx
+++ b/apps/web/src/app/scheduling/daily/page.tsx
@@ -101,6 +101,20 @@ export default function SchedulingPage() {
   // Active dragging state
   const [activeDragTask, setActiveDragTask] = useState<TaskInfo | null>(null);
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const source = params.get('source');
+    const weekStart = params.get('week_start');
+    const date = params.get('date');
+    if (date) setSelectedDate(date);
+    if (source === 'weekly_schedule' && weekStart) {
+      setTaskSource({
+        type: 'weekly_schedule',
+        weekly_schedule_date: weekStart,
+      });
+    }
+  }, []);
+
   // DnD sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {

--- a/apps/web/src/app/tasks/page.tsx
+++ b/apps/web/src/app/tasks/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useDeferredValue, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -21,6 +22,8 @@ import { AppHeader } from "@/components/layout/app-header";
 import { QuickTaskList } from "@/components/quick-tasks";
 import { TaskDependencyMap } from "@/components/tasks/task-dependency-map";
 import { TaskDependencyPanel } from "@/components/tasks/task-dependency-panel";
+import { TaskBulkToolbar } from "@/components/tasks/task-bulk-toolbar";
+import { TaskPickerDialog } from "@/components/runner/task-picker-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -72,9 +75,13 @@ const PRESETS: Array<{ id: Preset; label: string }> = [
 function TaskRow({
   task,
   onOpen,
+  selected,
+  onToggle,
 }: {
   task: TaskWorkspaceItem;
   onOpen: () => void;
+  selected: boolean;
+  onToggle: () => void;
 }) {
   const updateTask = useUpdateTask();
   const [dependenciesOpen, setDependenciesOpen] = useState(false);
@@ -106,7 +113,14 @@ function TaskRow({
 
   return (
     <div className="border-b border-border last:border-b-0">
-      <div className="grid gap-3 px-4 py-3 lg:grid-cols-[100px_minmax(240px,2fr)_minmax(180px,1fr)_120px_100px_80px_70px_170px] lg:items-center">
+      <div className="grid gap-3 px-4 py-3 lg:grid-cols-[36px_100px_minmax(240px,2fr)_minmax(180px,1fr)_120px_100px_80px_70px_170px] lg:items-center">
+        <input
+          type="checkbox"
+          aria-label={`${task.title}を選択`}
+          checked={selected}
+          onChange={onToggle}
+          className="h-4 w-4"
+        />
         <div>
           {task.status === "completed" ? (
             <Badge variant="success">完了</Badge>
@@ -129,7 +143,11 @@ function TaskRow({
             <span>
               {task.project_title} › {task.goal_title}
             </span>
-            {task.planned_today && <Badge variant="info">今日</Badge>}
+            {task.planned_today && (
+              <Badge variant="info">
+                {task.planned_today_unplaced ? "今日・未配置" : "今日"}
+              </Badge>
+            )}
             {!task.planned_today && task.planned_this_week && (
               <Badge variant="secondary">今週</Badge>
             )}
@@ -218,7 +236,7 @@ function TaskRow({
       </div>
 
       {dependenciesOpen && dependencies.length > 0 && (
-        <div className="border-t bg-muted/30 px-4 py-3 lg:pl-[336px]">
+        <div className="border-t bg-muted/30 px-4 py-3 lg:pl-[372px]">
           <div className="mb-2 text-xs font-medium text-muted-foreground">
             先に完了すべきタスク
           </div>
@@ -254,6 +272,7 @@ function TaskRow({
 
 export default function TasksPage() {
   const { user, loading: authLoading } = useAuth();
+  const router = useRouter();
   const queryClient = useQueryClient();
   const [preset, setPreset] = useState<Preset>(DEFAULT_TASK_WORKSPACE_PRESET);
   const [view, setView] = useState<"list" | "graph">("list");
@@ -268,6 +287,8 @@ export default function TasksPage() {
   const [convertGoalId, setConvertGoalId] = useState("");
   const [inboxVersion, setInboxVersion] = useState(0);
   const [isConverting, setIsConverting] = useState(false);
+  const [selectedTaskIds, setSelectedTaskIds] = useState<Set<string>>(new Set());
+  const [taskPickerOpen, setTaskPickerOpen] = useState(false);
 
   const { data: projects = [] } = useQuery({
     queryKey: ["projects", "task-workspace"],
@@ -349,14 +370,27 @@ export default function TasksPage() {
       <AppHeader currentPage="tasks" />
       <main className="mx-auto max-w-screen-2xl space-y-5 px-4 py-6 sm:px-6 lg:px-8">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold">
-            <ListTodo className="h-6 w-6" />
-            タスクワークスペース
-          </h1>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <h1 className="flex items-center gap-2 text-2xl font-bold">
+              <ListTodo className="h-6 w-6" />
+              タスクワークスペース
+            </h1>
+            <Button variant="outline" onClick={() => setTaskPickerOpen(true)}>
+              <Play className="mr-2 h-4 w-4" />
+              タスクを選んでRunnerへ
+            </Button>
+          </div>
           <p className="mt-1 text-sm text-muted-foreground">
             プロジェクト階層をまたいで、次に取り組むタスクを探して調整できます。
           </p>
         </div>
+
+        <TaskBulkToolbar
+          selectedTaskIds={[...selectedTaskIds]}
+          goals={goals}
+          onClear={() => setSelectedTaskIds(new Set())}
+          onApplied={() => setPage(0)}
+        />
 
         <div className="flex flex-col gap-3 xl:flex-row xl:items-stretch xl:justify-between">
           <div className="grid flex-1 grid-cols-2 gap-2 sm:grid-cols-5">
@@ -556,7 +590,22 @@ export default function TasksPage() {
 
             {view === "list" ? (
               <Card className="overflow-hidden">
-                <div className="sticky top-0 z-10 hidden grid-cols-[100px_minmax(240px,2fr)_minmax(180px,1fr)_120px_100px_80px_70px_170px] gap-3 border-b bg-muted/95 px-4 py-2 text-xs font-medium text-muted-foreground backdrop-blur lg:grid">
+                <div className="sticky top-0 z-10 hidden grid-cols-[36px_100px_minmax(240px,2fr)_minmax(180px,1fr)_120px_100px_80px_70px_170px] gap-3 border-b bg-muted/95 px-4 py-2 text-xs font-medium text-muted-foreground backdrop-blur lg:grid">
+                  <input
+                    type="checkbox"
+                    aria-label="表示中のタスクをすべて選択"
+                    checked={visibleTasks.length > 0 && visibleTasks.every((task) => selectedTaskIds.has(task.id))}
+                    onChange={(event) => {
+                      setSelectedTaskIds((current) => {
+                        const next = new Set(current);
+                        visibleTasks.forEach((task) => {
+                          if (event.target.checked && next.size < 100) next.add(task.id);
+                          if (!event.target.checked) next.delete(task.id);
+                        });
+                        return next;
+                      });
+                    }}
+                  />
                   <span>実行状態</span>
                   <span>タスク</span>
                   <span>依存状況</span>
@@ -584,6 +633,16 @@ export default function TasksPage() {
                       key={task.id}
                       task={task}
                       onOpen={() => setSelectedTaskId(task.id)}
+                      selected={selectedTaskIds.has(task.id)}
+                      onToggle={() => {
+                        setSelectedTaskIds((current) => {
+                          const next = new Set(current);
+                          if (next.has(task.id)) next.delete(task.id);
+                          else if (next.size < 100) next.add(task.id);
+                          else toast({ title: "一度に選択できるのは100件までです", variant: "destructive" });
+                          return next;
+                        });
+                      }}
                     />
                   ))
                 )}
@@ -638,6 +697,12 @@ export default function TasksPage() {
         availableTasks={visibleTasks}
         onClose={() => setSelectedTaskId(null)}
         onSelectTask={setSelectedTaskId}
+      />
+
+      <TaskPickerDialog
+        open={taskPickerOpen}
+        onOpenChange={setTaskPickerOpen}
+        onSelect={(task) => router.push(`/runner?taskId=${encodeURIComponent(task.id)}`)}
       />
 
       <Dialog

--- a/apps/web/src/components/runner/__tests__/manual-task-select-dialog.test.tsx
+++ b/apps/web/src/components/runner/__tests__/manual-task-select-dialog.test.tsx
@@ -4,7 +4,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
-import { projectsApi, tasksApi } from '@/lib/api';
+import { projectsApi, tasksApi, workSessionsApi } from '@/lib/api';
 import { ManualTaskSelectDialog } from '../manual-task-select-dialog';
 
 jest.mock('@/lib/api', () => ({
@@ -14,6 +14,9 @@ jest.mock('@/lib/api', () => ({
   tasksApi: {
     getById: jest.fn(),
     getWorkspace: jest.fn(),
+  },
+  workSessionsApi: {
+    getResumeContext: jest.fn(),
   },
 }));
 
@@ -51,6 +54,9 @@ function renderDialog(onStart = jest.fn().mockResolvedValue(undefined)) {
 }
 
 describe('ManualTaskSelectDialog recommended task flow', () => {
+  beforeEach(() => {
+    jest.mocked(workSessionsApi.getResumeContext).mockResolvedValue(null);
+  });
   it('loads the selected task directly and starts it without opening the task picker', async () => {
     jest.mocked(tasksApi.getById).mockResolvedValue(task);
 

--- a/apps/web/src/components/runner/__tests__/task-switch-dialog.test.tsx
+++ b/apps/web/src/components/runner/__tests__/task-switch-dialog.test.tsx
@@ -2,13 +2,17 @@
  * @jest-environment jsdom
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { toast } from '@/hooks/use-toast';
 import { workSessionsApi } from '@/lib/api';
 import { TaskSwitchDialog } from '../task-switch-dialog';
 
 jest.mock('@/lib/api', () => ({
   workSessionsApi: { getResumeContext: jest.fn() },
+}));
+jest.mock('@/hooks/use-toast', () => ({
+  toast: jest.fn(),
 }));
 
 const task = {
@@ -64,5 +68,36 @@ describe('TaskSwitchDialog', () => {
     expect(await screen.findByText(/前回の続き/)).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText('中断メモ'), { target: { value: 'ここから再開' } });
     expect(screen.getByRole('button', { name: '記録して切替' })).toBeEnabled();
+  });
+
+  it('shows a switch error and keeps the dialog open', async () => {
+    jest.mocked(workSessionsApi.getResumeContext).mockResolvedValue(null);
+    const onOpenChange = jest.fn();
+    const onSwitch = jest.fn().mockRejectedValue(new Error('Next task is blocked'));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TaskSwitchDialog
+          open
+          onOpenChange={onOpenChange}
+          task={task}
+          isSwitching={false}
+          onSwitch={onSwitch}
+        />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.change(screen.getByLabelText('中断メモ'), { target: { value: 'ここから再開' } });
+    fireEvent.click(screen.getByRole('button', { name: '記録して切替' }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith({
+        title: 'タスクの切替に失敗しました',
+        description: 'Next task is blocked',
+        variant: 'destructive',
+      });
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('中断メモ')).toHaveValue('ここから再開');
   });
 });

--- a/apps/web/src/components/runner/__tests__/task-switch-dialog.test.tsx
+++ b/apps/web/src/components/runner/__tests__/task-switch-dialog.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { workSessionsApi } from '@/lib/api';
+import { TaskSwitchDialog } from '../task-switch-dialog';
+
+jest.mock('@/lib/api', () => ({
+  workSessionsApi: { getResumeContext: jest.fn() },
+}));
+
+const task = {
+  id: 'task-next',
+  title: 'Next task',
+  description: null,
+  memo: null,
+  estimate_hours: 1,
+  due_date: null,
+  status: 'pending' as const,
+  work_type: 'deep_work' as const,
+  priority: 1,
+  goal_id: 'goal-1',
+  created_at: '2026-07-20T00:00:00Z',
+  updated_at: '2026-07-20T00:00:00Z',
+  dependencies: [],
+  project_id: 'project-1',
+  project_title: 'Project',
+  goal_title: 'Goal',
+  remaining_estimate_hours: 1,
+  is_blocked: false,
+  is_ready: true,
+  blocking_task_ids: [],
+  last_worked_at: null,
+  planned_today: false,
+  planned_today_unplaced: false,
+  planned_this_week: false,
+};
+
+describe('TaskSwitchDialog', () => {
+  it('requires an interruption note for pause and shows resume context', async () => {
+    jest.mocked(workSessionsApi.getResumeContext).mockResolvedValue({
+      task_id: task.id,
+      interruption_note: '前回の続き',
+      interrupted_at: '2026-07-20T01:00:00Z',
+      disposition: 'pause',
+      remaining_estimate_hours: 0.75,
+    });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TaskSwitchDialog
+          open
+          onOpenChange={jest.fn()}
+          task={task}
+          isSwitching={false}
+          onSwitch={jest.fn().mockResolvedValue(undefined)}
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(screen.getByRole('button', { name: '記録して切替' })).toBeDisabled();
+    expect(await screen.findByText(/前回の続き/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('中断メモ'), { target: { value: 'ここから再開' } });
+    expect(screen.getByRole('button', { name: '記録して切替' })).toBeEnabled();
+  });
+});

--- a/apps/web/src/components/runner/manual-task-select-dialog.tsx
+++ b/apps/web/src/components/runner/manual-task-select-dialog.tsx
@@ -16,6 +16,8 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useWorkSessionResumeContext } from '@/hooks/use-work-sessions';
 import {
   Select,
   SelectContent,
@@ -56,6 +58,7 @@ export function ManualTaskSelectDialog({
   const [chooseAnotherTask, setChooseAnotherTask] = useState(false);
   const isInitialTaskMode = Boolean(initialTaskId) && !chooseAnotherTask;
   const deferredSearch = useDeferredValue(searchQuery.trim());
+  const resumeContext = useWorkSessionResumeContext(selectedTaskId || undefined);
 
   // Fetch all projects
   const { data: projects = [], isLoading: projectsLoading } = useQuery({
@@ -209,6 +212,17 @@ export function ManualTaskSelectDialog({
                 別のタスクを選択
               </Button>
             </div>
+          )}
+
+          {selectedTask && resumeContext.data && (
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                前回の中断（{new Date(resumeContext.data.interrupted_at).toLocaleString('ja-JP')}）: {resumeContext.data.interruption_note}
+                {resumeContext.data.remaining_estimate_hours != null &&
+                  `（残り ${resumeContext.data.remaining_estimate_hours}h）`}
+              </AlertDescription>
+            </Alert>
           )}
 
           {/* Project filter */}

--- a/apps/web/src/components/runner/runner-page.tsx
+++ b/apps/web/src/components/runner/runner-page.tsx
@@ -27,6 +27,7 @@ import { formatDuration } from '@/types/runner';
 import type { RescheduleSuggestion } from '@/types/reschedule';
 import type { TaskWorkspaceItem } from '@/types/task';
 import { goalsApi, projectsApi, tasksApi } from '@/lib/api';
+import { consumeRunnerTaskId } from '@/lib/runner/route-task-id';
 
 export function RunnerPage() {
   const { user, loading: authLoading } = useAuth();
@@ -69,7 +70,8 @@ export function RunnerPage() {
   const [selectedNextTaskId, setSelectedNextTaskId] = useState<string | null>(null);
 
   useEffect(() => {
-    const taskId = new URLSearchParams(window.location.search).get('taskId');
+    if (isLoading) return;
+    const taskId = consumeRunnerTaskId();
     if (!taskId) return;
     if (!session) {
       setInitialTaskId(taskId);
@@ -100,7 +102,7 @@ export function RunnerPage() {
         setTaskPickerOpen(true);
       }
     })();
-  }, [session, switchTarget?.id]);
+  }, [isLoading, session, switchTarget?.id]);
 
   // Issue #227: Reschedule suggestion state
   const [lastRescheduleSuggestion, setLastRescheduleSuggestion] = useState<RescheduleSuggestion | null>(null);

--- a/apps/web/src/components/runner/runner-page.tsx
+++ b/apps/web/src/components/runner/runner-page.tsx
@@ -13,6 +13,8 @@ import { TaskSwitcher } from './task-switcher';
 import { TaskNotesSection } from './task-notes-section';
 import { StartSessionDialog } from './start-session-dialog';
 import { ManualTaskSelectDialog } from './manual-task-select-dialog';
+import { TaskPickerDialog } from './task-picker-dialog';
+import { TaskSwitchDialog } from './task-switch-dialog';
 import { CheckoutDialog } from './checkout-dialog';
 import { PauseDialog } from './pause-dialog';
 import { ResumeDialog } from './resume-dialog';
@@ -23,6 +25,8 @@ import { Play, AlertCircle, Pause, FolderOpen, Calendar } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { formatDuration } from '@/types/runner';
 import type { RescheduleSuggestion } from '@/types/reschedule';
+import type { TaskWorkspaceItem } from '@/types/task';
+import { goalsApi, projectsApi, tasksApi } from '@/lib/api';
 
 export function RunnerPage() {
   const { user, loading: authLoading } = useAuth();
@@ -40,10 +44,12 @@ export function RunnerPage() {
     isCheckingOut,
     isPausing,
     isResuming,
+    isSwitching,
     startSession,
     checkout,
     pauseSession,
     resumeSession,
+    switchSession,
     currentNotification,
     dismissNotification,
     snoozeSession,
@@ -54,6 +60,8 @@ export function RunnerPage() {
 
   const [startDialogOpen, setStartDialogOpen] = useState(false);
   const [manualTaskDialogOpen, setManualTaskDialogOpen] = useState(false);
+  const [taskPickerOpen, setTaskPickerOpen] = useState(false);
+  const [switchTarget, setSwitchTarget] = useState<TaskWorkspaceItem | null>(null);
   const [initialTaskId, setInitialTaskId] = useState<string | null>(null);
   const [checkoutDialogOpen, setCheckoutDialogOpen] = useState(false);
   const [pauseDialogOpen, setPauseDialogOpen] = useState(false);
@@ -62,11 +70,37 @@ export function RunnerPage() {
 
   useEffect(() => {
     const taskId = new URLSearchParams(window.location.search).get('taskId');
-    if (taskId) {
+    if (!taskId) return;
+    if (!session) {
       setInitialTaskId(taskId);
       setManualTaskDialogOpen(true);
+      return;
     }
-  }, []);
+    if (session.task_id === taskId || switchTarget?.id === taskId) return;
+    void (async () => {
+      try {
+        const task = await tasksApi.getById(taskId);
+        const goal = await goalsApi.getById(task.goal_id);
+        const project = await projectsApi.getById(goal.project_id);
+        setSwitchTarget({
+          ...task,
+          project_id: project.id,
+          project_title: project.title,
+          goal_title: goal.title,
+          remaining_estimate_hours: task.estimate_hours,
+          is_blocked: false,
+          is_ready: true,
+          blocking_task_ids: [],
+          last_worked_at: null,
+          planned_today: false,
+          planned_today_unplaced: false,
+          planned_this_week: false,
+        });
+      } catch {
+        setTaskPickerOpen(true);
+      }
+    })();
+  }, [session, switchTarget?.id]);
 
   // Issue #227: Reschedule suggestion state
   const [lastRescheduleSuggestion, setLastRescheduleSuggestion] = useState<RescheduleSuggestion | null>(null);
@@ -215,6 +249,11 @@ export function RunnerPage() {
               onResume={() => setResumeDialogOpen(true)}
             />
 
+            <Button variant="outline" onClick={() => setTaskPickerOpen(true)}>
+              <FolderOpen className="mr-2 h-4 w-4" />
+              別タスクへ切替
+            </Button>
+
             {/* Next candidates */}
             {nextCandidates.length > 0 && (
               <TaskSwitcher
@@ -265,7 +304,7 @@ export function RunnerPage() {
                     スケジュールから選択
                   </Button>
                   <Button
-                    onClick={() => setManualTaskDialogOpen(true)}
+                    onClick={() => setTaskPickerOpen(true)}
                     className="flex-1"
                     variant="outline"
                   >
@@ -327,6 +366,32 @@ export function RunnerPage() {
             } catch (error) {
               console.error('Start session failed:', error);
             }
+          }}
+        />
+
+        <TaskPickerDialog
+          open={taskPickerOpen}
+          onOpenChange={setTaskPickerOpen}
+          excludeTaskId={session?.task_id}
+          title={session ? '切替先のタスクを選択' : '開始するタスクを選択'}
+          onSelect={(task) => {
+            if (session) {
+              setSwitchTarget(task);
+            } else {
+              setInitialTaskId(task.id);
+              setManualTaskDialogOpen(true);
+            }
+          }}
+        />
+
+        <TaskSwitchDialog
+          open={Boolean(switchTarget)}
+          onOpenChange={(open) => !open && setSwitchTarget(null)}
+          task={switchTarget}
+          isSwitching={isSwitching}
+          onSwitch={async (...args) => {
+            await switchSession(...args);
+            setSwitchTarget(null);
           }}
         />
 

--- a/apps/web/src/components/runner/task-picker-dialog.tsx
+++ b/apps/web/src/components/runner/task-picker-dialog.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useDeferredValue, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Bot, Calendar, Clock3, Search } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { goalsApi, projectsApi, tasksApi } from '@/lib/api';
+import type { TaskWorkspaceItem } from '@/types/task';
+
+type PickerView = 'recommended' | 'today' | 'recent' | 'all';
+
+interface TaskPickerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (task: TaskWorkspaceItem) => void;
+  excludeTaskId?: string;
+  title?: string;
+}
+
+export function TaskPickerDialog({
+  open,
+  onOpenChange,
+  onSelect,
+  excludeTaskId,
+  title = 'タスクを選択',
+}: TaskPickerDialogProps) {
+  const [view, setView] = useState<PickerView>('recommended');
+  const [search, setSearch] = useState('');
+  const deferredSearch = useDeferredValue(search.trim());
+  const [projectId, setProjectId] = useState('');
+  const [goalId, setGoalId] = useState('');
+
+  const projects = useQuery({
+    queryKey: ['projects', 'task-picker'],
+    queryFn: () => projectsApi.getAll(0, 100),
+    enabled: open,
+  });
+  const goals = useQuery({
+    queryKey: ['goals', 'task-picker', projects.data?.map((item) => item.id).join(',')],
+    queryFn: async () => {
+      const results = await Promise.allSettled(
+        (projects.data ?? []).map((project) =>
+          goalsApi.getByProject(project.id, 0, 100),
+        ),
+      );
+      return results.flatMap((result) =>
+        result.status === 'fulfilled' ? result.value : [],
+      );
+    },
+    enabled: open && Boolean(projects.data?.length),
+  });
+  const recommendations = useQuery({
+    queryKey: ['tasks', 'picker', 'recommendations'],
+    queryFn: () => tasksApi.getRecommendations(),
+    enabled: open && view === 'recommended',
+  });
+  const workspace = useQuery({
+    queryKey: ['tasks', 'picker', view, deferredSearch, projectId, goalId],
+    queryFn: () =>
+      tasksApi.getWorkspace({
+        limit: 100,
+        status: ['pending', 'in_progress'],
+        plan: view === 'today' ? 'today' : undefined,
+        sortBy: view === 'recent' ? 'last_worked_at' : 'priority',
+        sortOrder: view === 'recent' ? 'desc' : 'asc',
+        search: view === 'all' ? deferredSearch || undefined : undefined,
+        projectId: projectId || undefined,
+        goalId: goalId || undefined,
+      }),
+    enabled: open && view !== 'recommended',
+  });
+
+  const items = useMemo(() => {
+    const source =
+      view === 'recommended'
+        ? (recommendations.data ?? []).map((item) => ({
+            task: item.task,
+            reason: item.reason,
+          }))
+        : (workspace.data?.items ?? []).map((task) => ({ task, reason: undefined }));
+    return source.filter(
+      ({ task }) => task.id !== excludeTaskId && !task.is_blocked,
+    );
+  }, [excludeTaskId, recommendations.data, view, workspace.data?.items]);
+  const filteredGoals = projectId
+    ? (goals.data ?? []).filter((goal) => goal.project_id === projectId)
+    : goals.data ?? [];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            おすすめ、今日の予定、最近の作業、全タスクから横断的に選べます。
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-wrap gap-2">
+          {([
+            ['recommended', 'おすすめ', Bot],
+            ['today', '今日', Calendar],
+            ['recent', '最近', Clock3],
+            ['all', '全タスク', Search],
+          ] as const).map(([id, label, Icon]) => (
+            <Button
+              key={id}
+              size="sm"
+              variant={view === id ? 'default' : 'outline'}
+              onClick={() => setView(id)}
+            >
+              <Icon className="mr-1 h-4 w-4" />
+              {label}
+            </Button>
+          ))}
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-3">
+          {view === 'all' && (
+            <div className="relative sm:col-span-3">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="タイトル・説明・メモを検索"
+                className="pl-9"
+              />
+            </div>
+          )}
+          <select
+            aria-label="プロジェクトで絞り込み"
+            className="h-10 rounded-md border bg-background px-3 text-sm"
+            value={projectId}
+            onChange={(event) => {
+              setProjectId(event.target.value);
+              setGoalId('');
+            }}
+          >
+            <option value="">全プロジェクト</option>
+            {(projects.data ?? []).map((project) => (
+              <option key={project.id} value={project.id}>{project.title}</option>
+            ))}
+          </select>
+          <select
+            aria-label="ゴールで絞り込み"
+            className="h-10 rounded-md border bg-background px-3 text-sm"
+            value={goalId}
+            onChange={(event) => setGoalId(event.target.value)}
+          >
+            <option value="">全ゴール</option>
+            {filteredGoals.map((goal) => (
+              <option key={goal.id} value={goal.id}>{goal.title}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="max-h-[52vh] space-y-2 overflow-y-auto pr-1">
+          {(recommendations.isLoading || workspace.isLoading) && (
+            <p className="py-8 text-center text-muted-foreground">読み込み中...</p>
+          )}
+          {items.map(({ task, reason }) => (
+            <button
+              key={task.id}
+              className="w-full rounded-lg border p-3 text-left hover:border-primary hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              onClick={() => {
+                onSelect(task);
+                onOpenChange(false);
+              }}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate font-medium">{task.title}</div>
+                  <div className="mt-1 truncate text-xs text-muted-foreground">
+                    {task.project_title} › {task.goal_title}
+                  </div>
+                  {reason && <div className="mt-2 text-xs">{reason}</div>}
+                </div>
+                <div className="flex shrink-0 gap-1">
+                  {task.planned_today && (
+                    <Badge variant="info">
+                      {task.planned_today_unplaced ? '今日・未配置' : '今日'}
+                    </Badge>
+                  )}
+                  <Badge variant="outline">P{task.priority}</Badge>
+                </div>
+              </div>
+            </button>
+          ))}
+          {!recommendations.isLoading && !workspace.isLoading && items.length === 0 && (
+            <p className="py-8 text-center text-muted-foreground">選択可能なタスクはありません</p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/runner/task-switch-dialog.tsx
+++ b/apps/web/src/components/runner/task-switch-dialog.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { toast } from '@/hooks/use-toast';
 import { useWorkSessionResumeContext } from '@/hooks/use-work-sessions';
 import type { SwitchDisposition } from '@/types/work-session';
 import type { TaskWorkspaceItem } from '@/types/task';
@@ -141,14 +142,25 @@ export function TaskSwitchDialog({
             disabled={isSwitching || duration < 5 || (noteRequired && !note.trim())}
             onClick={async () => {
               const checkout = new Date(Date.now() + duration * 60 * 1000).toISOString();
-              await onSwitch(
-                task.id,
-                disposition,
-                noteRequired ? note.trim() : undefined,
-                checkout,
-                outcome.trim() || undefined,
-              );
-              onOpenChange(false);
+              try {
+                await onSwitch(
+                  task.id,
+                  disposition,
+                  noteRequired ? note.trim() : undefined,
+                  checkout,
+                  outcome.trim() || undefined,
+                );
+                onOpenChange(false);
+              } catch (error) {
+                toast({
+                  title: 'タスクの切替に失敗しました',
+                  description:
+                    error instanceof Error
+                      ? error.message
+                      : '不明なエラーが発生しました',
+                  variant: 'destructive',
+                });
+              }
             }}
           >
             {isSwitching ? '切替中...' : '記録して切替'}

--- a/apps/web/src/components/runner/task-switch-dialog.tsx
+++ b/apps/web/src/components/runner/task-switch-dialog.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AlertCircle } from 'lucide-react';
+
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useWorkSessionResumeContext } from '@/hooks/use-work-sessions';
+import type { SwitchDisposition } from '@/types/work-session';
+import type { TaskWorkspaceItem } from '@/types/task';
+
+interface TaskSwitchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  task: TaskWorkspaceItem | null;
+  isSwitching: boolean;
+  onSwitch: (
+    taskId: string,
+    disposition: SwitchDisposition,
+    note: string | undefined,
+    plannedCheckoutAt: string,
+    plannedOutcome?: string,
+  ) => Promise<void>;
+}
+
+export function TaskSwitchDialog({
+  open,
+  onOpenChange,
+  task,
+  isSwitching,
+  onSwitch,
+}: TaskSwitchDialogProps) {
+  const [disposition, setDisposition] = useState<SwitchDisposition>('pause');
+  const [note, setNote] = useState('');
+  const [duration, setDuration] = useState(60);
+  const [outcome, setOutcome] = useState('');
+  const resumeContext = useWorkSessionResumeContext(task?.id);
+
+  useEffect(() => {
+    if (!open) {
+      setDisposition('pause');
+      setNote('');
+      setDuration(60);
+      setOutcome('');
+    }
+  }, [open]);
+  if (!task) return null;
+  const noteRequired = disposition !== 'complete';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>「{task.title}」へ切り替える</DialogTitle>
+          <DialogDescription>
+            現在のセッションを記録してから、次のセッションを開始します。
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          {resumeContext.data && (
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                前回の中断（{new Date(resumeContext.data.interrupted_at).toLocaleString('ja-JP')}）: {resumeContext.data.interruption_note}
+                {resumeContext.data.remaining_estimate_hours != null &&
+                  `（残り ${resumeContext.data.remaining_estimate_hours}h）`}
+              </AlertDescription>
+            </Alert>
+          )}
+          <div className="space-y-2">
+            <Label>現在のタスクの扱い</Label>
+            <div className="grid gap-2 sm:grid-cols-3">
+              {([
+                ['complete', '完了'],
+                ['pause', '一時停止して切替'],
+                ['defer', '後回し'],
+              ] as const).map(([value, label]) => (
+                <Button
+                  key={value}
+                  type="button"
+                  size="sm"
+                  variant={disposition === value ? 'default' : 'outline'}
+                  onClick={() => setDisposition(value)}
+                >
+                  {label}
+                </Button>
+              ))}
+            </div>
+          </div>
+          {noteRequired && (
+            <div className="space-y-2">
+              <Label htmlFor="interruption-note">中断メモ</Label>
+              <Textarea
+                id="interruption-note"
+                value={note}
+                maxLength={2000}
+                onChange={(event) => setNote(event.target.value)}
+                placeholder="次回どこから再開するかを記録"
+              />
+            </div>
+          )}
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="switch-duration">次の作業時間（分）</Label>
+              <Input
+                id="switch-duration"
+                type="number"
+                min={5}
+                max={480}
+                step={5}
+                value={duration}
+                onChange={(event) => setDuration(Number(event.target.value))}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="switch-outcome">次の目標（任意）</Label>
+              <Input
+                id="switch-outcome"
+                value={outcome}
+                onChange={(event) => setOutcome(event.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            キャンセル
+          </Button>
+          <Button
+            disabled={isSwitching || duration < 5 || (noteRequired && !note.trim())}
+            onClick={async () => {
+              const checkout = new Date(Date.now() + duration * 60 * 1000).toISOString();
+              await onSwitch(
+                task.id,
+                disposition,
+                noteRequired ? note.trim() : undefined,
+                checkout,
+                outcome.trim() || undefined,
+              );
+              onOpenChange(false);
+            }}
+          >
+            {isSwitching ? '切替中...' : '記録して切替'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/scheduling/__tests__/weekly-plan-editor.test.tsx
+++ b/apps/web/src/components/scheduling/__tests__/weekly-plan-editor.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { tasksApi } from '@/lib/api';
+import type { WeeklyPlanResponse } from '@/types/ai-planning';
+import { WeeklyPlanEditor } from '../weekly-plan-editor';
+
+jest.mock('@/lib/api', () => ({
+  tasksApi: { getWorkspace: jest.fn() },
+}));
+
+const backlogTask = {
+  id: 'task-backlog',
+  title: 'Backlog task',
+  description: null,
+  memo: null,
+  estimate_hours: 3,
+  due_date: null,
+  status: 'pending' as const,
+  work_type: 'deep_work' as const,
+  priority: 2,
+  goal_id: 'goal-1',
+  created_at: '2026-07-20T00:00:00Z',
+  updated_at: '2026-07-20T00:00:00Z',
+  dependencies: [],
+  project_id: 'project-1',
+  project_title: 'Project',
+  goal_title: 'Goal',
+  remaining_estimate_hours: 3,
+  is_blocked: false,
+  is_ready: true,
+  blocking_task_ids: [],
+  last_worked_at: null,
+  planned_today: false,
+  planned_today_unplaced: false,
+  planned_this_week: false,
+};
+
+const plan: WeeklyPlanResponse = {
+  success: true,
+  week_start_date: '2026-07-20',
+  total_planned_hours: 2,
+  task_plans: [{
+    task_id: 'task-selected',
+    task_title: 'Selected task',
+    estimated_hours: 2,
+    priority: 1,
+    rationale: 'test',
+  }],
+  assigned_task_hours: { 'task-selected': 2 },
+  project_allocations: [{
+    project_id: 'project-1',
+    project_title: 'Project',
+    target_hours: 4,
+    max_hours: 6,
+    priority_weight: 1,
+  }],
+  recommendations: [],
+  insights: [],
+  generated_at: '2026-07-20T00:00:00Z',
+};
+
+function renderEditor(onChange = jest.fn()) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <WeeklyPlanEditor
+        plan={plan}
+        capacityHours={1}
+        canRecalculate
+        projects={[{
+          id: 'project-1',
+          title: 'Project',
+          description: null,
+          status: 'in_progress',
+          owner_id: 'user-1',
+          created_at: '2026-07-20T00:00:00Z',
+          updated_at: '2026-07-20T00:00:00Z',
+        }]}
+        onChange={onChange}
+      />
+    </QueryClientProvider>,
+  );
+  return onChange;
+}
+
+describe('WeeklyPlanEditor', () => {
+  it('shows capacity and allocation feedback and supports keyboard-friendly add', async () => {
+    jest.mocked(tasksApi.getWorkspace).mockResolvedValue({
+      items: [
+        backlogTask,
+        { ...backlogTask, id: 'task-selected', title: 'Selected task' },
+      ],
+      total: 2,
+      skip: 0,
+      limit: 100,
+    });
+    const onChange = renderEditor();
+
+    const addButton = await screen.findByRole('button', { name: 'Backlog taskを今週に追加' });
+    expect(screen.getByText('1.0h 超過')).toBeInTheDocument();
+    expect(screen.getByText(/実績 2.0h \/ 目標 4.0h/)).toBeInTheDocument();
+    fireEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task_plans: expect.arrayContaining([
+            expect.objectContaining({ task_id: backlogTask.id }),
+          ]),
+        }),
+      );
+    });
+  });
+});

--- a/apps/web/src/components/scheduling/weekly-plan-editor.tsx
+++ b/apps/web/src/components/scheduling/weekly-plan-editor.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowDown, ArrowUp, CalendarClock, Lock, Plus, Trash2, Unlock } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { tasksApi } from '@/lib/api';
+import type { WeeklyPlanResponse } from '@/types/ai-planning';
+import type { Project } from '@/types/project';
+
+interface WeeklyPlanEditorProps {
+  plan: WeeklyPlanResponse;
+  capacityHours: number;
+  projects: Project[];
+  canRecalculate: boolean;
+  onChange: (plan: WeeklyPlanResponse) => void;
+}
+
+export function WeeklyPlanEditor({
+  plan,
+  capacityHours,
+  projects,
+  canRecalculate,
+  onChange,
+}: WeeklyPlanEditorProps) {
+  const [draggedTaskId, setDraggedTaskId] = useState<string | null>(null);
+  const [recalculateDate, setRecalculateDate] = useState(plan.week_start_date);
+  useEffect(() => setRecalculateDate(plan.week_start_date), [plan.week_start_date]);
+  const backlog = useQuery({
+    queryKey: ['tasks', 'weekly-editor', plan.week_start_date],
+    queryFn: () => tasksApi.getWorkspace({
+      limit: 100,
+      status: ['pending', 'in_progress'],
+      sortBy: 'priority',
+    }),
+  });
+  const selectedIds = new Set(plan.task_plans.map((task) => task.task_id));
+  const backlogTasks = (backlog.data?.items ?? []).filter(
+    (task) => !selectedIds.has(task.id) && !task.is_blocked,
+  );
+  const workspaceById = useMemo(
+    () => new Map((backlog.data?.items ?? []).map((task) => [task.id, task])),
+    [backlog.data?.items],
+  );
+  const assignedHours = plan.assigned_task_hours ?? Object.fromEntries(
+    plan.task_plans.map((task) => [task.task_id, task.estimated_hours]),
+  );
+  const totalHours = Object.values(assignedHours).reduce((sum, hours) => sum + Number(hours || 0), 0);
+  const pinned = new Set(plan.pinned_task_ids ?? []);
+  const distribution = plan.task_plans.reduce<Record<string, number>>((result, task) => {
+    const projectId = workspaceById.get(task.task_id)?.project_id ?? 'unknown';
+    result[projectId] = (result[projectId] ?? 0) + Number(assignedHours[task.task_id] ?? task.estimated_hours);
+    return result;
+  }, {});
+  const allocationTargets = new Map(
+    (plan.project_allocations ?? []).map((allocation) => [
+      allocation.project_id,
+      allocation.target_hours,
+    ]),
+  );
+
+  const updateTasks = (
+    taskPlans: WeeklyPlanResponse['task_plans'],
+    nextAssigned = assignedHours,
+    nextPinned = [...pinned],
+  ) => onChange({
+    ...plan,
+    task_plans: taskPlans,
+    assigned_task_hours: nextAssigned,
+    pinned_task_ids: nextPinned,
+    total_planned_hours: Object.values(nextAssigned).reduce((sum, hours) => sum + Number(hours || 0), 0),
+  });
+  const addTask = (taskId: string) => {
+    const task = workspaceById.get(taskId);
+    if (!task || selectedIds.has(taskId)) return;
+    updateTasks(
+      [...plan.task_plans, {
+        task_id: task.id,
+        task_title: task.title,
+        estimated_hours: task.remaining_estimate_hours,
+        priority: task.priority,
+        rationale: '週次計画エディタから手動追加',
+      }],
+      { ...assignedHours, [task.id]: task.remaining_estimate_hours },
+    );
+  };
+  const removeTask = (taskId: string) => {
+    const nextAssigned = { ...assignedHours };
+    delete nextAssigned[taskId];
+    updateTasks(
+      plan.task_plans.filter((task) => task.task_id !== taskId),
+      nextAssigned,
+      [...pinned].filter((id) => id !== taskId),
+    );
+  };
+  const moveTask = (taskId: string, offset: number) => {
+    const index = plan.task_plans.findIndex((task) => task.task_id === taskId);
+    const target = index + offset;
+    if (index < 0 || target < 0 || target >= plan.task_plans.length) return;
+    const next = [...plan.task_plans];
+    [next[index], next[target]] = [next[target]!, next[index]!];
+    updateTasks(next);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Card>
+          <CardContent className="pt-4"><div className="text-xs text-muted-foreground">割当時間</div><div className="text-2xl font-bold">{totalHours.toFixed(1)}h</div></CardContent>
+        </Card>
+        <Card className={totalHours > capacityHours ? 'border-destructive' : ''}>
+          <CardContent className="pt-4"><div className="text-xs text-muted-foreground">週間容量</div><div className="text-2xl font-bold">{capacityHours}h</div>{totalHours > capacityHours && <p className="text-xs text-destructive">{(totalHours - capacityHours).toFixed(1)}h 超過</p>}</CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4"><div className="text-xs text-muted-foreground">計画タスク</div><div className="text-2xl font-bold">{plan.task_plans.length}</div></CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={() => draggedTaskId && removeTask(draggedTaskId)}
+        >
+          <CardHeader><CardTitle className="text-base">Backlog</CardTitle></CardHeader>
+          <CardContent className="max-h-96 space-y-2 overflow-y-auto">
+            {backlogTasks.map((task) => (
+              <div key={task.id} draggable onDragStart={() => setDraggedTaskId(task.id)} className="flex items-center justify-between gap-2 rounded-md border p-2">
+                <div className="min-w-0"><div className="truncate text-sm font-medium">{task.title}</div><div className="truncate text-xs text-muted-foreground">{task.project_title} › {task.goal_title}</div></div>
+                <Button size="icon" variant="ghost" aria-label={`${task.title}を今週に追加`} onClick={() => addTask(task.id)}><Plus className="h-4 w-4" /></Button>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={() => draggedTaskId && addTask(draggedTaskId)}
+        >
+          <CardHeader><CardTitle className="text-base">今週</CardTitle></CardHeader>
+          <CardContent className="max-h-96 space-y-2 overflow-y-auto">
+            {plan.task_plans.map((task, index) => (
+              <div key={task.task_id} draggable onDragStart={() => setDraggedTaskId(task.task_id)} className="rounded-md border p-2">
+                <div className="flex items-center gap-2">
+                  <div className="min-w-0 flex-1"><div className="truncate text-sm font-medium">{task.task_title}</div><div className="text-xs text-muted-foreground">P{task.priority}</div></div>
+                  <Input
+                    aria-label={`${task.task_title}の割当時間`}
+                    className="h-8 w-20"
+                    type="number"
+                    min={0.25}
+                    max={999}
+                    step={0.25}
+                    value={assignedHours[task.task_id] ?? task.estimated_hours}
+                    onChange={(event) => updateTasks(plan.task_plans, { ...assignedHours, [task.task_id]: Number(event.target.value) })}
+                  />
+                  <Button size="icon" variant="ghost" aria-label="固定切替" onClick={() => {
+                    const next = new Set(pinned);
+                    if (next.has(task.task_id)) next.delete(task.task_id); else next.add(task.task_id);
+                    updateTasks(plan.task_plans, assignedHours, [...next]);
+                  }}>{pinned.has(task.task_id) ? <Lock className="h-4 w-4" /> : <Unlock className="h-4 w-4" />}</Button>
+                  <Button size="icon" variant="ghost" disabled={index === 0} onClick={() => moveTask(task.task_id, -1)}><ArrowUp className="h-4 w-4" /></Button>
+                  <Button size="icon" variant="ghost" disabled={index === plan.task_plans.length - 1} onClick={() => moveTask(task.task_id, 1)}><ArrowDown className="h-4 w-4" /></Button>
+                  <Button size="icon" variant="ghost" onClick={() => removeTask(task.task_id)}><Trash2 className="h-4 w-4" /></Button>
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader><CardTitle className="text-base">プロジェクト別時間配分</CardTitle></CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          {Object.entries(distribution).map(([projectId, hours]) => (
+            <Badge key={projectId} variant="outline">
+              {projects.find((project) => project.id === projectId)?.title ?? '不明'}: 実績 {hours.toFixed(1)}h
+              {allocationTargets.has(projectId) && ` / 目標 ${Number(allocationTargets.get(projectId)).toFixed(1)}h`}
+            </Badge>
+          ))}
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Input
+          aria-label="再計算する日"
+          className="w-44"
+          type="date"
+          min={plan.week_start_date}
+          max={new Date(new Date(`${plan.week_start_date}T00:00:00Z`).getTime() + 6 * 86400000).toISOString().slice(0, 10)}
+          value={recalculateDate}
+          onChange={(event) => setRecalculateDate(event.target.value)}
+        />
+        {canRecalculate ? (
+          <Button asChild variant="outline">
+            <Link href={`/scheduling/daily?source=weekly_schedule&week_start=${encodeURIComponent(plan.week_start_date)}&date=${encodeURIComponent(recalculateDate)}`}>
+              <CalendarClock className="mr-2 h-4 w-4" />
+              日次計画を再計算
+            </Link>
+          </Button>
+        ) : (
+          <Button disabled variant="outline">
+            <CalendarClock className="mr-2 h-4 w-4" />
+            保存後に日次計画を再計算
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/tasks/__tests__/task-bulk-toolbar.test.tsx
+++ b/apps/web/src/components/tasks/__tests__/task-bulk-toolbar.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { tasksApi } from '@/lib/api';
+import { TaskBulkToolbar } from '../task-bulk-toolbar';
+
+jest.mock('@/lib/api', () => ({
+  tasksApi: {
+    previewBulk: jest.fn(),
+    previewNaturalLanguage: jest.fn(),
+    applyBulk: jest.fn(),
+  },
+}));
+
+describe('TaskBulkToolbar', () => {
+  it('never applies before preview confirmation', async () => {
+    const preview = {
+      mutations: [{ task_id: 'task-1', patch: { status: 'pending' }, plans: [] }],
+      items: [{
+        task_id: 'task-1',
+        title: 'Task one',
+        diffs: [{ field: 'status', before: 'in_progress', after: 'pending' }],
+      }],
+      affected_count: 1,
+      warnings: [],
+      expected_task_versions: { 'task-1': '2026-07-20T00:00:00Z' },
+      expected_plan_versions: {},
+    };
+    jest.mocked(tasksApi.previewBulk).mockResolvedValue(preview);
+    jest.mocked(tasksApi.applyBulk).mockResolvedValue(preview);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TaskBulkToolbar
+          selectedTaskIds={['task-1']}
+          goals={[]}
+          onClear={jest.fn()}
+          onApplied={jest.fn()}
+        />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '差分を確認' }));
+    expect(tasksApi.applyBulk).not.toHaveBeenCalled();
+    expect(await screen.findByText('1件の変更を適用しますか？')).toBeInTheDocument();
+    expect(screen.getByText(/in_progress.*pending/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '確認して適用' }));
+    await waitFor(() => expect(tasksApi.applyBulk).toHaveBeenCalledWith({
+      mutations: preview.mutations,
+      expected_task_versions: preview.expected_task_versions,
+      expected_plan_versions: preview.expected_plan_versions,
+    }));
+  });
+});

--- a/apps/web/src/components/tasks/__tests__/task-dependency-panel.test.tsx
+++ b/apps/web/src/components/tasks/__tests__/task-dependency-panel.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+
+import { TaskDependencyPanel } from "../task-dependency-panel";
+import type { Task } from "@/types/task";
+
+const task: Task = {
+  id: "task-1",
+  title: "Deep linked task",
+  description: null,
+  estimate_hours: 1,
+  due_date: null,
+  status: "pending",
+  priority: 2,
+  goal_id: "goal-1",
+  created_at: "2026-07-23T00:00:00Z",
+  updated_at: "2026-07-23T00:00:00Z",
+  dependencies: [],
+};
+
+jest.mock("@/hooks/use-tasks-query", () => ({
+  useTask: () => ({ data: task, isLoading: false }),
+  useTaskDependencyContext: () => ({
+    data: { prerequisites: [], dependents: [] },
+    isLoading: false,
+  }),
+}));
+
+jest.mock("@/hooks/use-goals-query", () => ({
+  useGoal: () => ({
+    data: { id: "goal-1", project_id: "project-1" },
+    isLoading: false,
+  }),
+}));
+
+jest.mock("@/components/tasks/task-edit-dialog", () => ({
+  TaskEditDialog: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+describe("TaskDependencyPanel", () => {
+  it("links directly to the selected task detail page", () => {
+    render(
+      <TaskDependencyPanel
+        taskId={task.id}
+        availableTasks={[task]}
+        onClose={jest.fn()}
+        onSelectTask={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: "タスク詳細ページを開く" }),
+    ).toHaveAttribute(
+      "href",
+      "/projects/project-1/goals/goal-1/tasks/task-1",
+    );
+  });
+});

--- a/apps/web/src/components/tasks/task-bulk-toolbar.tsx
+++ b/apps/web/src/components/tasks/task-bulk-toolbar.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { Bot, Layers3 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/hooks/use-toast';
+import { tasksApi } from '@/lib/api';
+import { getJSTDateString } from '@/lib/date-utils';
+import type { Goal } from '@/types/goal';
+import type {
+  BulkTaskMutation,
+  BulkTaskPreview,
+  TaskStatus,
+} from '@/types/task';
+
+type BulkAction =
+  | 'status'
+  | 'priority'
+  | 'due_date'
+  | 'goal'
+  | 'cancel'
+  | 'daily_add'
+  | 'daily_remove'
+  | 'weekly_add'
+  | 'weekly_remove'
+  | 'natural';
+
+function currentWeekStart(): string {
+  const today = getJSTDateString();
+  const date = new Date(`${today}T12:00:00+09:00`);
+  const day = (date.getUTCDay() + 6) % 7;
+  date.setUTCDate(date.getUTCDate() - day);
+  return date.toISOString().slice(0, 10);
+}
+
+interface TaskBulkToolbarProps {
+  selectedTaskIds: string[];
+  goals: Goal[];
+  onClear: () => void;
+  onApplied: () => void;
+}
+
+export function TaskBulkToolbar({
+  selectedTaskIds,
+  goals,
+  onClear,
+  onApplied,
+}: TaskBulkToolbarProps) {
+  const queryClient = useQueryClient();
+  const [action, setAction] = useState<BulkAction>('status');
+  const [value, setValue] = useState('pending');
+  const [targetDate, setTargetDate] = useState(getJSTDateString());
+  const [instruction, setInstruction] = useState('');
+  const [preview, setPreview] = useState<BulkTaskPreview | null>(null);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [isApplying, setIsApplying] = useState(false);
+  const weekStart = useMemo(currentWeekStart, []);
+
+  if (selectedTaskIds.length === 0) return null;
+
+  const buildMutations = (): BulkTaskMutation[] =>
+    selectedTaskIds.map((taskId) => {
+      const mutation: BulkTaskMutation = { task_id: taskId, patch: {}, plans: [] };
+      if (action === 'status') mutation.patch = { status: value as TaskStatus };
+      if (action === 'priority') mutation.patch = { priority: Number(value) };
+      if (action === 'due_date') {
+        mutation.patch = { due_date: value ? `${value}T00:00:00+09:00` : null };
+      }
+      if (action === 'goal') mutation.patch = { goal_id: value };
+      if (action === 'cancel') mutation.patch = { status: 'cancelled' };
+      if (action.startsWith('daily_') || action.startsWith('weekly_')) {
+        const [scope, operation] = action.split('_') as [
+          'daily' | 'weekly',
+          'add' | 'remove',
+        ];
+        mutation.plans = [
+          {
+            scope,
+            action: operation,
+            target_date: targetDate,
+          },
+        ];
+      }
+      return mutation;
+    });
+
+  const runPreview = async () => {
+    setIsPreviewing(true);
+    try {
+      const result =
+        action === 'natural'
+          ? await tasksApi.previewNaturalLanguage(instruction, selectedTaskIds)
+          : await tasksApi.previewBulk(buildMutations());
+      setPreview(result);
+    } catch (error) {
+      toast({
+        title: '変更案を作成できませんでした',
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsPreviewing(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="sticky top-2 z-20 rounded-lg border bg-background/95 p-3 shadow-lg backdrop-blur">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="mr-2 flex items-center gap-2 text-sm font-medium">
+            <Layers3 className="h-4 w-4" />
+            {selectedTaskIds.length}件選択
+          </div>
+          <select
+            aria-label="一括操作"
+            className="h-9 rounded-md border bg-background px-2 text-sm"
+            value={action}
+            onChange={(event) => {
+              const next = event.target.value as BulkAction;
+              setAction(next);
+              if (next === 'status') setValue('pending');
+              if (next === 'priority') setValue('3');
+              if (next === 'goal') setValue(goals[0]?.id ?? '');
+              if (next === 'daily_add' || next === 'daily_remove')
+                setTargetDate(getJSTDateString());
+              if (next === 'weekly_add' || next === 'weekly_remove')
+                setTargetDate(weekStart);
+            }}
+          >
+            <option value="status">ステータス変更</option>
+            <option value="priority">優先度変更</option>
+            <option value="due_date">期限変更</option>
+            <option value="goal">所属ゴール変更</option>
+            <option value="daily_add">今日／指定日に追加</option>
+            <option value="daily_remove">今日／指定日から除外</option>
+            <option value="weekly_add">週次計画に追加</option>
+            <option value="weekly_remove">週次計画から除外</option>
+            <option value="cancel">キャンセル</option>
+            <option value="natural">AIに自然言語で依頼</option>
+          </select>
+
+          {action === 'status' && (
+            <select className="h-9 rounded-md border bg-background px-2 text-sm" value={value} onChange={(e) => setValue(e.target.value)}>
+              <option value="pending">未着手</option>
+              <option value="in_progress">進行中</option>
+              <option value="completed">完了</option>
+              <option value="cancelled">キャンセル</option>
+            </select>
+          )}
+          {action === 'priority' && (
+            <select className="h-9 rounded-md border bg-background px-2 text-sm" value={value} onChange={(e) => setValue(e.target.value)}>
+              {[1, 2, 3, 4, 5].map((priority) => <option key={priority} value={priority}>P{priority}</option>)}
+            </select>
+          )}
+          {action === 'goal' && (
+            <select className="h-9 max-w-56 rounded-md border bg-background px-2 text-sm" value={value} onChange={(e) => setValue(e.target.value)}>
+              {goals.map((goal) => <option key={goal.id} value={goal.id}>{goal.title}</option>)}
+            </select>
+          )}
+          {action === 'due_date' && (
+            <Input className="h-9 w-40" type="date" value={value} onChange={(e) => setValue(e.target.value)} />
+          )}
+          {(action.startsWith('daily_') || action.startsWith('weekly_')) && (
+            <Input className="h-9 w-40" type="date" value={targetDate} onChange={(e) => setTargetDate(e.target.value)} />
+          )}
+          {action === 'natural' && (
+            <div className="relative min-w-64 flex-1">
+              <Bot className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input className="h-9 pl-9" value={instruction} onChange={(e) => setInstruction(e.target.value)} placeholder="例: すべて来週に移して優先度を2にする" />
+            </div>
+          )}
+          <Button size="sm" onClick={runPreview} disabled={isPreviewing || (action === 'natural' && !instruction.trim())}>
+            {isPreviewing ? '確認中...' : '差分を確認'}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={onClear}>選択解除</Button>
+        </div>
+      </div>
+
+      <Dialog open={Boolean(preview)} onOpenChange={(open) => !open && setPreview(null)}>
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{preview?.affected_count ?? 0}件の変更を適用しますか？</DialogTitle>
+            <DialogDescription>内容を確認するまでデータは変更されません。</DialogDescription>
+          </DialogHeader>
+          {preview?.interpretation && <p className="rounded-md bg-muted p-3 text-sm">{preview.interpretation}</p>}
+          <div className="space-y-2">
+            {preview?.items.map((item) => (
+              <div key={item.task_id} className="rounded-md border p-3">
+                <div className="font-medium">{item.title}</div>
+                {item.diffs.length === 0 ? (
+                  <div className="mt-1 text-xs text-muted-foreground">変更なし</div>
+                ) : item.diffs.map((diff) => (
+                  <div key={diff.field} className="mt-1 text-xs">
+                    {diff.field}: {String(diff.before ?? 'なし')} → {String(diff.after ?? 'なし')}
+                  </div>
+                ))}
+              </div>
+            ))}
+            {preview?.warnings.map((warning) => <p key={warning} className="text-xs text-amber-700">{warning}</p>)}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setPreview(null)}>戻る</Button>
+            <Button
+              disabled={isApplying || !preview || preview.affected_count === 0}
+              onClick={async () => {
+                if (!preview) return;
+                setIsApplying(true);
+                try {
+                  await tasksApi.applyBulk({
+                    mutations: preview.mutations,
+                    expected_task_versions: preview.expected_task_versions,
+                    expected_plan_versions: preview.expected_plan_versions,
+                  });
+                  await Promise.all([
+                    queryClient.invalidateQueries({ queryKey: ['tasks'] }),
+                    queryClient.invalidateQueries({ queryKey: ['schedule'] }),
+                  ]);
+                  toast({ title: `${preview.affected_count}件を更新しました` });
+                  setPreview(null);
+                  onClear();
+                  onApplied();
+                } catch (error) {
+                  toast({
+                    title: '一括変更を適用できませんでした',
+                    description: error instanceof Error ? error.message : undefined,
+                    variant: 'destructive',
+                  });
+                } finally {
+                  setIsApplying(false);
+                }
+              }}
+            >
+              {isApplying ? '適用中...' : '確認して適用'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/tasks/task-dependency-panel.tsx
+++ b/apps/web/src/components/tasks/task-dependency-panel.tsx
@@ -17,8 +17,13 @@ import {
 import { TaskEditDialog } from "@/components/tasks/task-edit-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useGoal } from "@/hooks/use-goals-query";
 import { useTask, useTaskDependencyContext } from "@/hooks/use-tasks-query";
-import type { Task, TaskDependencyContextTask } from "@/types/task";
+import type {
+  Task,
+  TaskDependencyContextTask,
+  TaskWorkspaceItem,
+} from "@/types/task";
 import { taskStatusLabels } from "@/types/task";
 
 interface TaskDependencyPanelProps {
@@ -73,10 +78,20 @@ export function TaskDependencyPanel({
 }: TaskDependencyPanelProps) {
   const taskQuery = useTask(taskId ?? "");
   const contextQuery = useTaskDependencyContext(taskId ?? undefined);
+  const goalQuery = useGoal(taskQuery.data?.goal_id ?? "");
   if (!taskId) return null;
 
   const task = taskQuery.data;
   const context = contextQuery.data;
+  const workspaceTask = availableTasks.find(
+    (item): item is TaskWorkspaceItem =>
+      item.id === taskId && "project_id" in item,
+  );
+  const projectId = workspaceTask?.project_id ?? goalQuery.data?.project_id;
+  const taskDetailHref =
+    task && projectId
+      ? `/projects/${projectId}/goals/${task.goal_id}/tasks/${task.id}`
+      : null;
   const hasCancelledPrerequisite = context?.prerequisites.some(
     (item) => item.status === "cancelled",
   );
@@ -234,12 +249,27 @@ export function TaskDependencyPanel({
                   編集・依存設定
                 </Button>
               </TaskEditDialog>
-              <Button variant="ghost" className="sm:col-span-2" asChild>
-                <Link href={`/projects`}>
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  プロジェクト画面を開く
-                </Link>
-              </Button>
+              {taskDetailHref ? (
+                <Button variant="ghost" className="sm:col-span-2" asChild>
+                  <Link href={taskDetailHref}>
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    タスク詳細ページを開く
+                  </Link>
+                </Button>
+              ) : (
+                <Button
+                  variant="ghost"
+                  className="sm:col-span-2"
+                  disabled
+                >
+                  {goalQuery.isLoading ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                  )}
+                  タスク詳細ページを開く
+                </Button>
+              )}
             </div>
           </div>
         )}

--- a/apps/web/src/hooks/use-runner.ts
+++ b/apps/web/src/hooks/use-runner.ts
@@ -14,6 +14,7 @@ import {
   useCheckoutWorkSession,
   usePauseWorkSession,
   useResumeWorkSession,
+  useSwitchWorkSession,
   getSessionOverdueStatus,
   isSessionPaused,
 } from './use-work-sessions';
@@ -23,7 +24,7 @@ import { schedulingApi, tasksApi, goalsApi, projectsApi, workSessionsApi } from 
 import { queryKeys } from '@/lib/query-keys';
 import type { Goal } from '@/types/goal';
 import type { Project } from '@/types/project';
-import type { SessionDecision } from '@/types/work-session';
+import type { SessionDecision, SwitchDisposition } from '@/types/work-session';
 import type { RescheduleSuggestion } from '@/types/reschedule';
 import type {
   UseRunnerReturn,
@@ -132,6 +133,7 @@ export function useRunner(): UseRunnerReturn {
   const checkoutMutation = useCheckoutWorkSession();
   const pauseMutation = usePauseWorkSession();
   const resumeMutation = useResumeWorkSession();
+  const switchMutation = useSwitchWorkSession();
 
   // Issue #228: Notification integration
   const {
@@ -276,6 +278,23 @@ export function useRunner(): UseRunnerReturn {
     queryClient.invalidateQueries({ queryKey: ['runner'] });
   };
 
+  const switchSession = async (
+    taskId: string,
+    disposition: SwitchDisposition,
+    interruptionNote: string | undefined,
+    plannedCheckoutAt: string,
+    plannedOutcome?: string,
+  ): Promise<void> => {
+    await switchMutation.mutateAsync({
+      next_task_id: taskId,
+      disposition,
+      interruption_note: interruptionNote,
+      planned_checkout_at: plannedCheckoutAt,
+      planned_outcome: plannedOutcome,
+    });
+    queryClient.invalidateQueries({ queryKey: ['runner'] });
+  };
+
   return {
     // State
     session: session ?? null,
@@ -293,12 +312,14 @@ export function useRunner(): UseRunnerReturn {
     isCheckingOut: checkoutMutation.isPending,
     isPausing: pauseMutation.isPending,
     isResuming: resumeMutation.isPending,
+    isSwitching: switchMutation.isPending,
 
     // Actions
     startSession,
     checkout,
     pauseSession,
     resumeSession,
+    switchSession,
 
     // Refresh
     refetchSession,

--- a/apps/web/src/hooks/use-work-sessions.ts
+++ b/apps/web/src/hooks/use-work-sessions.ts
@@ -18,6 +18,8 @@ import type {
   WorkSessionCheckoutRequest,
   WorkSessionUpdateRequest,
   WorkSessionResumeRequest,
+  WorkSessionSwitchRequest,
+  WorkSessionSwitchResponse,
 } from '@/types/work-session';
 import type { WorkSessionWithReschedule } from '@/types/reschedule';
 
@@ -125,6 +127,32 @@ export function useCheckoutWorkSession() {
         queryClient.invalidateQueries({ queryKey: queryKeys.reschedule.suggestions() });
       }
     },
+  });
+}
+
+export function useSwitchWorkSession() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: WorkSessionSwitchRequest) => workSessionsApi.switch(data),
+    onSuccess: (result: WorkSessionSwitchResponse) => {
+      queryClient.setQueryData(
+        queryKeys.workSessions.current(),
+        result.current_session,
+      );
+      queryClient.invalidateQueries({ queryKey: queryKeys.workSessions.all });
+      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.logs.all });
+      queryClient.invalidateQueries({ queryKey: queryKeys.progress.all });
+    },
+  });
+}
+
+export function useWorkSessionResumeContext(taskId?: string) {
+  return useQuery({
+    queryKey: [...queryKeys.workSessions.all, 'resume-context', taskId],
+    queryFn: () => workSessionsApi.getResumeContext(taskId as string),
+    enabled: Boolean(taskId),
+    staleTime: 30 * 1000,
   });
 }
 

--- a/apps/web/src/lib/__tests__/weekly-schedule-draft.test.ts
+++ b/apps/web/src/lib/__tests__/weekly-schedule-draft.test.ts
@@ -1,0 +1,92 @@
+import { ApiError } from '@/lib/errors';
+import { saveWeeklyScheduleDraft } from '@/lib/weekly-schedule-draft';
+import type { SavedWeeklySchedule } from '@/types/ai-planning';
+
+const existingSchedule = {
+  id: 'schedule-1',
+  week_start_date: '2026-07-20T00:00:00Z',
+  schedule_json: {},
+  created_at: '2026-07-20T00:00:00Z',
+  updated_at: '2026-07-21T00:00:00Z',
+} as SavedWeeklySchedule;
+
+describe('saveWeeklyScheduleDraft', () => {
+  it('uses the loaded schedule version without fetching it again', async () => {
+    const api = {
+      getByWeek: jest.fn(),
+      updateDraft: jest.fn().mockResolvedValue(existingSchedule),
+    };
+
+    await saveWeeklyScheduleDraft({
+      api,
+      weekStartDate: '2026-07-20',
+      scheduleData: { selected_tasks: [] },
+      selectedSchedule: existingSchedule,
+    });
+
+    expect(api.getByWeek).not.toHaveBeenCalled();
+    expect(api.updateDraft).toHaveBeenCalledWith(
+      '2026-07-20',
+      { selected_tasks: [] },
+      existingSchedule.updated_at,
+    );
+  });
+
+  it('loads the current version before replacing an existing generated week', async () => {
+    const api = {
+      getByWeek: jest.fn().mockResolvedValue(existingSchedule),
+      updateDraft: jest.fn().mockResolvedValue(existingSchedule),
+    };
+
+    await saveWeeklyScheduleDraft({
+      api,
+      weekStartDate: '2026-07-20',
+      scheduleData: { selected_tasks: [] },
+      selectedSchedule: null,
+    });
+
+    expect(api.getByWeek).toHaveBeenCalledWith('2026-07-20');
+    expect(api.updateDraft).toHaveBeenCalledWith(
+      '2026-07-20',
+      { selected_tasks: [] },
+      existingSchedule.updated_at,
+    );
+  });
+
+  it('creates a new week when no saved schedule exists', async () => {
+    const api = {
+      getByWeek: jest.fn().mockRejectedValue(new ApiError(404, 'Not found')),
+      updateDraft: jest.fn().mockResolvedValue(existingSchedule),
+    };
+
+    await saveWeeklyScheduleDraft({
+      api,
+      weekStartDate: '2026-07-20',
+      scheduleData: { selected_tasks: [] },
+      selectedSchedule: null,
+    });
+
+    expect(api.updateDraft).toHaveBeenCalledWith(
+      '2026-07-20',
+      { selected_tasks: [] },
+      undefined,
+    );
+  });
+
+  it('does not hide lookup failures other than a missing week', async () => {
+    const api = {
+      getByWeek: jest.fn().mockRejectedValue(new ApiError(500, 'Server error')),
+      updateDraft: jest.fn(),
+    };
+
+    await expect(
+      saveWeeklyScheduleDraft({
+        api,
+        weekStartDate: '2026-07-20',
+        scheduleData: { selected_tasks: [] },
+        selectedSchedule: null,
+      }),
+    ).rejects.toThrow('Server error');
+    expect(api.updateDraft).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -22,6 +22,9 @@ import type {
   TaskWorkspaceItem,
   TaskWorkspacePage,
   TaskWorkspaceSummary,
+  BulkTaskMutation,
+  BulkTaskPreview,
+  BulkTaskApplyRequest,
 } from "@/types/task";
 import type { Log, LogCreate, LogUpdate } from "@/types/log";
 import type {
@@ -65,6 +68,9 @@ import type {
   WorkSessionCheckoutRequest,
   WorkSessionUpdateRequest,
   WorkSessionResumeRequest,
+  WorkSessionSwitchRequest,
+  WorkSessionSwitchResponse,
+  WorkSessionResumeContext,
 } from "@/types/work-session";
 import type {
   RescheduleSuggestion,
@@ -585,6 +591,37 @@ class ApiClient {
     }));
   }
 
+  async previewBulkTaskChanges(
+    mutations: BulkTaskMutation[],
+  ): Promise<BulkTaskPreview> {
+    return this.request<BulkTaskPreview>("/api/tasks/bulk/preview", {
+      method: "POST",
+      body: JSON.stringify({ mutations }),
+    });
+  }
+
+  async applyBulkTaskChanges(
+    request: BulkTaskApplyRequest,
+  ): Promise<BulkTaskPreview> {
+    return this.request<BulkTaskPreview>("/api/tasks/bulk/apply", {
+      method: "POST",
+      body: JSON.stringify(request),
+    });
+  }
+
+  async previewNaturalLanguageTaskChanges(
+    instruction: string,
+    taskIds: string[],
+  ): Promise<BulkTaskPreview> {
+    return this.request<BulkTaskPreview>(
+      "/api/tasks/bulk/natural-language/preview",
+      {
+        method: "POST",
+        body: JSON.stringify({ instruction, task_ids: taskIds }),
+      },
+    );
+  }
+
   async getTaskWorkspaceSummary(
     filters: Pick<TaskWorkspaceFilters, "projectId" | "goalId" | "search"> = {},
   ): Promise<TaskWorkspaceSummary> {
@@ -1069,6 +1106,23 @@ class ApiClient {
     });
   }
 
+  async updateWeeklyScheduleDraft(
+    weekStartDate: string,
+    scheduleData: Record<string, unknown>,
+    expectedUpdatedAt?: string | null,
+  ): Promise<SavedWeeklySchedule> {
+    return this.request<SavedWeeklySchedule>(
+      `/api/weekly-schedule/${weekStartDate}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          schedule_data: scheduleData,
+          expected_updated_at: expectedUpdatedAt ?? null,
+        }),
+      },
+    );
+  }
+
   async deleteWeeklySchedule(
     weekStartDate: string,
   ): Promise<{ message: string }> {
@@ -1249,6 +1303,23 @@ class ApiClient {
         method: "POST",
         body: JSON.stringify(data),
       },
+    );
+  }
+
+  async switchWorkSession(
+    data: WorkSessionSwitchRequest,
+  ): Promise<WorkSessionSwitchResponse> {
+    return this.request<WorkSessionSwitchResponse>("/api/work-sessions/switch", {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  }
+
+  async getWorkSessionResumeContext(
+    taskId: string,
+  ): Promise<WorkSessionResumeContext | null> {
+    return this.request<WorkSessionResumeContext | null>(
+      `/api/work-sessions/task/${taskId}/resume-context`,
     );
   }
 
@@ -1793,6 +1864,12 @@ export const tasksApi = {
   getWorkspace: (filters?: TaskWorkspaceFilters) =>
     apiClient.getTaskWorkspace(filters),
   getRecommendations: () => apiClient.getTaskRecommendations(),
+  previewBulk: (mutations: BulkTaskMutation[]) =>
+    apiClient.previewBulkTaskChanges(mutations),
+  applyBulk: (request: BulkTaskApplyRequest) =>
+    apiClient.applyBulkTaskChanges(request),
+  previewNaturalLanguage: (instruction: string, taskIds: string[]) =>
+    apiClient.previewNaturalLanguageTaskChanges(instruction, taskIds),
   getSummary: (
     filters?: Pick<TaskWorkspaceFilters, "projectId" | "goalId" | "search">,
   ) => apiClient.getTaskWorkspaceSummary(filters),
@@ -1920,6 +1997,16 @@ export const weeklyScheduleApi = {
     apiClient.getWeeklySchedule(weekStartDate),
   save: (weekStartDate: string, scheduleData: any) =>
     apiClient.saveWeeklySchedule(weekStartDate, scheduleData),
+  updateDraft: (
+    weekStartDate: string,
+    scheduleData: Record<string, unknown>,
+    expectedUpdatedAt?: string | null,
+  ) =>
+    apiClient.updateWeeklyScheduleDraft(
+      weekStartDate,
+      scheduleData,
+      expectedUpdatedAt,
+    ),
   delete: (weekStartDate: string) =>
     apiClient.deleteWeeklySchedule(weekStartDate),
 };
@@ -1987,6 +2074,9 @@ export const workSessionsApi = {
   start: (data: WorkSessionStartRequest) => apiClient.startWorkSession(data),
   checkout: (data: WorkSessionCheckoutRequest) =>
     apiClient.checkoutWorkSession(data),
+  switch: (data: WorkSessionSwitchRequest) => apiClient.switchWorkSession(data),
+  getResumeContext: (taskId: string) =>
+    apiClient.getWorkSessionResumeContext(taskId),
   getCurrent: () => apiClient.getCurrentWorkSession(),
   getHistory: (skip?: number, limit?: number) =>
     apiClient.getWorkSessionHistory(skip, limit),

--- a/apps/web/src/lib/runner/__tests__/route-task-id.test.ts
+++ b/apps/web/src/lib/runner/__tests__/route-task-id.test.ts
@@ -1,0 +1,27 @@
+import { consumeRunnerTaskId } from "../route-task-id";
+
+describe("consumeRunnerTaskId", () => {
+  it("consumes the task id once and preserves the rest of the URL", () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/runner?taskId=task-1&source=workspace#focus",
+    );
+
+    expect(consumeRunnerTaskId()).toBe("task-1");
+    expect(window.location.pathname).toBe("/runner");
+    expect(window.location.search).toBe("?source=workspace");
+    expect(window.location.hash).toBe("#focus");
+    expect(consumeRunnerTaskId()).toBeNull();
+  });
+
+  it("does not rewrite the URL when no task id is present", () => {
+    window.history.replaceState({}, "", "/runner?source=workspace");
+    const replaceState = jest.spyOn(window.history, "replaceState");
+
+    expect(consumeRunnerTaskId()).toBeNull();
+    expect(replaceState).not.toHaveBeenCalled();
+
+    replaceState.mockRestore();
+  });
+});

--- a/apps/web/src/lib/runner/route-task-id.ts
+++ b/apps/web/src/lib/runner/route-task-id.ts
@@ -1,0 +1,18 @@
+/**
+ * Read and remove the task deep-link parameter so Runner handles it once.
+ *
+ * Other query parameters and the hash are preserved.
+ */
+export function consumeRunnerTaskId(): string | null {
+  const url = new URL(window.location.href);
+  const taskId = url.searchParams.get("taskId");
+  if (!taskId) return null;
+
+  url.searchParams.delete("taskId");
+  window.history.replaceState(
+    window.history.state,
+    "",
+    `${url.pathname}${url.search}${url.hash}`,
+  );
+  return taskId;
+}

--- a/apps/web/src/lib/weekly-schedule-draft.ts
+++ b/apps/web/src/lib/weekly-schedule-draft.ts
@@ -1,0 +1,52 @@
+import { ApiError } from '@/lib/errors';
+import type { SavedWeeklySchedule } from '@/types/ai-planning';
+
+interface WeeklyScheduleDraftApi {
+  getByWeek: (weekStartDate: string) => Promise<SavedWeeklySchedule>;
+  updateDraft: (
+    weekStartDate: string,
+    scheduleData: Record<string, unknown>,
+    expectedUpdatedAt?: string | null,
+  ) => Promise<SavedWeeklySchedule>;
+}
+
+interface SaveWeeklyScheduleDraftOptions {
+  api: WeeklyScheduleDraftApi;
+  weekStartDate: string;
+  scheduleData: Record<string, unknown>;
+  selectedSchedule: SavedWeeklySchedule | null;
+}
+
+function isSameWeek(
+  schedule: SavedWeeklySchedule | null,
+  weekStartDate: string,
+): schedule is SavedWeeklySchedule {
+  return schedule?.week_start_date.slice(0, 10) === weekStartDate;
+}
+
+export async function saveWeeklyScheduleDraft({
+  api,
+  weekStartDate,
+  scheduleData,
+  selectedSchedule,
+}: SaveWeeklyScheduleDraftOptions): Promise<SavedWeeklySchedule> {
+  let currentSchedule = isSameWeek(selectedSchedule, weekStartDate)
+    ? selectedSchedule
+    : null;
+
+  if (!currentSchedule) {
+    try {
+      currentSchedule = await api.getByWeek(weekStartDate);
+    } catch (error) {
+      if (!(error instanceof ApiError) || error.statusCode !== 404) {
+        throw error;
+      }
+    }
+  }
+
+  return api.updateDraft(
+    weekStartDate,
+    scheduleData,
+    currentSchedule?.updated_at,
+  );
+}

--- a/apps/web/src/types/ai-planning.ts
+++ b/apps/web/src/types/ai-planning.ts
@@ -91,6 +91,8 @@ export interface WeeklyPlanResponse {
   total_planned_hours: number;
   /** タスク計画一覧 */
   task_plans: TaskPlan[];
+  /** 手動編集で固定したタスクID */
+  pinned_task_ids?: string[];
   /** 通常タスクの割り当て時間（キー: タスクID, 値: 時間） */
   assigned_task_hours?: Record<string, number>;
   /** 週課の割り当て時間（キー: 週課ID, 値: 時間） */
@@ -367,6 +369,8 @@ export interface WeeklyScheduleData {
   week_start_date: string;
   /** 選択されたタスク一覧 */
   selected_tasks: TaskPlan[];
+  /** 手動編集で固定されたタスク */
+  pinned_task_ids?: string[];
   /** 通常タスクの割り当て時間（キー: タスクID, 値: 時間） */
   assigned_task_hours?: Record<string, number>;
   /** 週課の割り当て時間（キー: 週課ID, 値: 時間） */
@@ -377,6 +381,10 @@ export interface WeeklyScheduleData {
   project_allocations: ProjectAllocation[];
   /** 最適化インサイト */
   optimization_insights: string[];
+  /** 計画生成・編集時の推奨事項 */
+  recommendations?: string[];
+  /** 設定した週間容量 */
+  capacity_hours?: number;
   /** 制約分析結果 */
   constraint_analysis: ConstraintAnalysis;
   /** ソルバーメトリクス */

--- a/apps/web/src/types/runner.ts
+++ b/apps/web/src/types/runner.ts
@@ -2,7 +2,7 @@
  * Runner/Focus mode type definitions
  */
 
-import type { WorkSession, SessionDecision, ContinueReason } from './work-session';
+import type { WorkSession, SessionDecision, ContinueReason, SwitchDisposition } from './work-session';
 import type { Task } from './task';
 import type { Goal } from './goal';
 import type { Project } from './project';
@@ -72,6 +72,7 @@ export interface UseRunnerReturn {
   isCheckingOut: boolean;
   isPausing: boolean;
   isResuming: boolean;
+  isSwitching: boolean;
 
   // Actions
   startSession: (
@@ -83,6 +84,13 @@ export interface UseRunnerReturn {
   checkout: (decision: SessionDecision, options?: CheckoutOptions) => Promise<RescheduleSuggestion | null>;
   pauseSession: () => Promise<void>;
   resumeSession: (extendCheckout?: boolean) => Promise<void>;
+  switchSession: (
+    taskId: string,
+    disposition: SwitchDisposition,
+    interruptionNote: string | undefined,
+    plannedCheckoutAt: string,
+    plannedOutcome?: string,
+  ) => Promise<void>;
 
   // Refresh
   refetchSession: () => void;

--- a/apps/web/src/types/task.ts
+++ b/apps/web/src/types/task.ts
@@ -137,6 +137,7 @@ export interface TaskWorkspaceItem extends Task {
   blocking_task_ids: string[];
   last_worked_at: string | null;
   planned_today: boolean;
+  planned_today_unplaced: boolean;
   planned_this_week: boolean;
 }
 
@@ -206,8 +207,47 @@ export interface TaskWorkspaceFilters {
   search?: string;
   blocked?: boolean;
   plan?: 'today' | 'week' | 'unplanned';
-  sortBy?: 'due_date' | 'priority' | 'status' | 'title' | 'updated_at';
+  sortBy?: 'due_date' | 'priority' | 'status' | 'title' | 'updated_at' | 'last_worked_at';
   sortOrder?: 'asc' | 'desc';
+}
+
+export interface PlanMembershipMutation {
+  scope: 'daily' | 'weekly';
+  action: 'add' | 'remove';
+  target_date: string;
+}
+
+export interface BulkTaskPatch {
+  status?: TaskStatus;
+  priority?: number;
+  due_date?: string | null;
+  goal_id?: string;
+}
+
+export interface BulkTaskMutation {
+  task_id: string;
+  patch?: BulkTaskPatch;
+  plans?: PlanMembershipMutation[];
+}
+
+export interface BulkTaskPreview {
+  mutations: BulkTaskMutation[];
+  items: Array<{
+    task_id: string;
+    title: string;
+    diffs: Array<{ field: string; before: unknown; after: unknown }>;
+  }>;
+  affected_count: number;
+  warnings: string[];
+  expected_task_versions: Record<string, string>;
+  expected_plan_versions: Record<string, string | null>;
+  interpretation?: string | null;
+}
+
+export interface BulkTaskApplyRequest {
+  mutations: BulkTaskMutation[];
+  expected_task_versions: Record<string, string>;
+  expected_plan_versions: Record<string, string | null>;
 }
 
 export interface TaskRecommendation {

--- a/apps/web/src/types/work-session.ts
+++ b/apps/web/src/types/work-session.ts
@@ -14,6 +14,7 @@ export type CheckoutType = 'manual' | 'scheduled' | 'overdue' | 'interrupted';
  * Decision made at session checkout
  */
 export type SessionDecision = 'continue' | 'switch' | 'break' | 'complete';
+export type SwitchDisposition = 'complete' | 'pause' | 'defer';
 
 /**
  * Reason for continuing a session
@@ -42,6 +43,8 @@ export interface WorkSession {
   checkout_type: CheckoutType | null;
   decision: SessionDecision | null;
   continue_reason: ContinueReason | null;
+  switch_disposition?: SwitchDisposition | null;
+  interruption_note?: string | null;
   kpt_keep: string | null;
   kpt_problem: string | null;
   kpt_try: string | null;
@@ -110,6 +113,29 @@ export interface WorkSessionPauseRequest {
  */
 export interface WorkSessionResumeRequest {
   extend_checkout?: boolean;
+}
+
+export interface WorkSessionSwitchRequest {
+  next_task_id: string;
+  disposition: SwitchDisposition;
+  interruption_note?: string;
+  planned_checkout_at: string;
+  planned_outcome?: string;
+  remaining_estimate_hours?: number;
+}
+
+export interface WorkSessionSwitchResponse {
+  previous_session: WorkSession;
+  current_session: WorkSession;
+  generated_log: Log;
+}
+
+export interface WorkSessionResumeContext {
+  task_id: string;
+  interruption_note: string;
+  interrupted_at: string;
+  disposition: SwitchDisposition;
+  remaining_estimate_hours: number | null;
 }
 
 /**


### PR DESCRIPTION
## 概要

Issue #318 のMVP後項目5件を実装しました。

- 最大100件のタスク一括選択と、差分プレビュー・明示確認・楽観的ロック付き一括適用
- Runnerでの横断タスク切替、中断メモ、再開コンテキスト、共通タスク選択ダイアログ
- 今日／週次計画への追加・除外と「今日・未配置」タスクの表示
- Backlogとの移動、固定、並べ替え、割当時間・容量・配分を編集できる週次計画
- 選択済みタスクに限定した、自然言語による安全な一括調整プレビュー

## 主な変更

- `POST /api/tasks/bulk/preview`、`POST /api/tasks/bulk/apply`、自然言語プレビューAPIを追加
- `POST /api/work-sessions/switch` とタスク別再開コンテキストAPIを追加
- `GET /api/tasks?sort_by=last_worked_at` を追加
- 日次計画に後方互換な `planned_task_ids` を追加
- 週次計画の旧形式正規化、未知フィールド保持、更新日時競合検出を追加
- WorkSessionの切替状態と中断メモを保存する非破壊マイグレーションを追加

## 検証

- API: `pytest -s` — 445 passed, 5 skipped
- API: Ruff check / format check — passed
- API: mypy — passed
- Web (Node 24): type-check — passed
- Web (Node 24): lint — passed
- Web (Node 24): production build — passed
- 関連Jest — 29 passed

全Jestでは既存の未変更6スイートで28件が失敗し、290件は成功しました。失敗対象は fetch fallback、project/goals query hooks、timeline utils、config の既存テストです。

Closes #318
