### PR TITLE
fix(tasks): filter blocked workspace to actionable tasks

### DIFF
--- a/apps/web/src/components/tasks/__tests__/goal-task-list.test.tsx
+++ b/apps/web/src/components/tasks/__tests__/goal-task-list.test.tsx
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 import { fireEvent, render, screen } from '@testing-library/react'
 
 import { GoalTaskList } from '../goal-task-list'

--- a/apps/web/src/components/tasks/__tests__/task-dependency-map.test.tsx
+++ b/apps/web/src/components/tasks/__tests__/task-dependency-map.test.tsx
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 /**
  * @jest-environment jsdom
  */

--- a/apps/web/src/components/tasks/goal-task-list.tsx
+++ b/apps/web/src/components/tasks/goal-task-list.tsx
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 'use client'
 
 import { useMemo, useState } from 'react'

--- a/apps/web/src/components/tasks/task-dependency-map.tsx
+++ b/apps/web/src/components/tasks/task-dependency-map.tsx
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";

--- a/apps/web/src/components/tasks/task-dependency-panel.tsx
+++ b/apps/web/src/components/tasks/task-dependency-panel.tsx
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 "use client";
 
 import Link from "next/link";

--- a/apps/web/src/lib/tasks/__tests__/dependency-graph-layout.test.ts
+++ b/apps/web/src/lib/tasks/__tests__/dependency-graph-layout.test.ts
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 import {
   collectConnectedTaskIds,
   layoutTaskDependencyGraph,

--- a/apps/web/src/lib/tasks/__tests__/task-decision.test.ts
+++ b/apps/web/src/lib/tasks/__tests__/task-decision.test.ts
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 import { getTaskDecisionSummary } from '../task-decision'
 import type { Task, TaskDependency, TaskStatus } from '@/types/task'
 

--- a/apps/web/src/lib/tasks/__tests__/workspace-filters.test.ts
+++ b/apps/web/src/lib/tasks/__tests__/workspace-filters.test.ts
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 import {
   buildTaskWorkspaceFilters,
   DEFAULT_TASK_WORKSPACE_PRESET,
@@ -33,6 +39,7 @@ describe("task workspace filters", () => {
       search: "publish",
     });
 
+    expect(filters.status).toEqual(["pending", "in_progress"]);
     expect(filters.blocked).toBe(true);
     expect(filters.projectId).toBe("project-1");
     expect(filters.search).toBe("publish");

--- a/apps/web/src/lib/tasks/dependency-graph-layout.ts
+++ b/apps/web/src/lib/tasks/dependency-graph-layout.ts
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 import type {
   TaskDependencyGraphEdge,
   TaskDependencyGraphNode,

--- a/apps/web/src/lib/tasks/task-decision.ts
+++ b/apps/web/src/lib/tasks/task-decision.ts
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 import type { Task, TaskDependency } from '@/types/task'
 
 export type TaskDecisionState = 'ready' | 'blocked' | 'completed' | 'cancelled'

--- a/apps/web/src/lib/tasks/workspace-filters.ts
+++ b/apps/web/src/lib/tasks/workspace-filters.ts
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2024-2025 Masato Fukushima <masa1063fuk@gmail.com>
+//
+// This file is part of HumanCompiler.
+// For commercial licensing, see COMMERCIAL-LICENSE.md or contact masa1063fuk@gmail.com
+
 import type { TaskStatus, TaskWorkspaceFilters } from "@/types/task";
 
 export type TaskWorkspacePreset =
@@ -36,7 +42,9 @@ export function buildTaskWorkspaceFilters({
   let statuses = status ? [status] : undefined;
   if (
     !status &&
-    ["ready", "overdue", "today", "week", "unplanned"].includes(preset)
+    ["ready", "overdue", "today", "week", "unplanned", "blocked"].includes(
+      preset,
+    )
   ) {
     statuses = actionableStatuses;
   }


### PR DESCRIPTION
## Summary

- limit the blocked task workspace preset to actionable `pending` and `in_progress` tasks
- add regression coverage for the blocked preset status filter
- add the required AGPL SPDX headers to the task dependency source and test files introduced by the earlier feature work

## Why

The blocked preset previously sent only `blocked=true`. Because dependency blocking is independent of the dependent task's own status, completed or cancelled tasks could appear in the blocked workspace when they still had an incomplete prerequisite. The other decision-oriented presets already restrict results to actionable statuses.

The affected task dependency files were also added without the SPDX headers required by the repository contribution guidelines.

## Impact

The blocked view now focuses on tasks that can still require user action, while explicit status selections continue to take precedence. License metadata is brought into compliance without changing runtime behavior in the other files.

## Validation

- `pnpm --filter web test -- --runInBand src/components/tasks/__tests__/goal-task-list.test.tsx src/components/tasks/__tests__/task-dependency-map.test.tsx src/lib/tasks/__tests__/dependency-graph-layout.test.ts src/lib/tasks/__tests__/task-decision.test.ts src/lib/tasks/__tests__/workspace-filters.test.ts`
- `pnpm --filter web type-check`
- pre-commit hooks