### PR TITLE
Add night mode and improve mobile layouts

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -151,8 +151,8 @@ export default function DashboardPage() {
           <div className="mb-8">
             <Card>
               <CardHeader>
-                <div className="flex items-center justify-between">
-                  <div>
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0">
                     <CardTitle className="flex items-center gap-2">
                       <Calendar className="h-5 w-5 text-blue-600" />
                       本日のスケジュール
@@ -169,7 +169,7 @@ export default function DashboardPage() {
                       })()}
                     </CardDescription>
                   </div>
-                  <div className="flex gap-2">
+                  <div className="grid grid-cols-2 gap-2 sm:flex sm:shrink-0">
                     <Button
                       variant="outline"
                       size="sm"
@@ -194,14 +194,14 @@ export default function DashboardPage() {
                   {todaySchedule.plan_json.assignments
                     .sort((a, b) => a.start_time.localeCompare(b.start_time))
                     .map((assignment, index: number) => (
-                    <div key={index} className="flex items-center justify-between p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
-                      <div className="flex items-center gap-3">
-                        <div className="text-lg font-semibold text-gray-600">
+                    <div key={index} className="flex min-w-0 items-start justify-between gap-3 rounded-lg border p-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800">
+                      <div className="flex min-w-0 items-start gap-3">
+                        <div className="shrink-0 text-lg font-semibold text-gray-600">
                           {assignment.start_time}
                         </div>
-                        <div>
-                          <div className="font-medium">{assignment.task_title}</div>
-                          <div className="text-sm text-gray-500 flex items-center gap-2">
+                        <div className="min-w-0">
+                          <div className="break-words font-medium">{assignment.task_title}</div>
+                          <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500">
                             <Clock className="h-3 w-3" />
                             {assignment.duration_hours.toFixed(1)}時間
                             <span className="text-gray-400">•</span>
@@ -214,7 +214,7 @@ export default function DashboardPage() {
                       {assignment.project_id && assignment.goal_id && (
                         <Link
                           href={`/projects/${assignment.project_id}/goals/${assignment.goal_id}`}
-                          className="text-blue-500 hover:text-blue-700 transition-colors"
+                          className="shrink-0 p-2 text-blue-500 transition-colors hover:text-blue-700"
                         >
                           <ExternalLink className="h-4 w-4" />
                         </Link>

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -21,14 +21,14 @@ export default function GlobalError({
   return (
     <html lang="ja">
       <body>
-        <div className="min-h-screen flex items-center justify-center p-4 bg-gray-50">
-          <div className="w-full max-w-lg bg-white rounded-lg shadow-lg p-6">
+        <div className="flex min-h-screen items-center justify-center bg-background p-4 text-foreground">
+          <div className="w-full max-w-lg rounded-lg border bg-card p-6 shadow-lg">
             <div className="flex items-center gap-2 text-red-600 mb-4">
               <AlertTriangle className="h-6 w-6" />
               <h2 className="text-xl font-bold">エラーが発生しました</h2>
             </div>
 
-            <p className="text-gray-600 mb-6">
+            <p className="mb-6 text-muted-foreground">
               申し訳ございませんが、問題が発生しました。
             </p>
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -125,12 +125,31 @@
   * {
     @apply border-border;
   }
+  html {
+    color-scheme: light;
+  }
+  html.dark {
+    color-scheme: dark;
+  }
   body {
-    @apply bg-background text-foreground;
+    @apply min-w-0 overflow-x-hidden bg-background text-foreground;
+  }
+  main,
+  .container {
+    min-width: 0;
+  }
+  h1,
+  h2,
+  h3 {
+    overflow-wrap: anywhere;
   }
 }
 
 @layer components {
+  .container {
+    @apply px-4 sm:px-6 lg:px-8;
+  }
+
   .context-note-content {
     color: hsl(var(--foreground));
     font-size: 0.9375rem;
@@ -280,5 +299,32 @@
 
   .context-note-editor .ProseMirror {
     caret-color: hsl(var(--primary));
+  }
+}
+
+@layer utilities {
+  /* Keep legacy screens readable while their fixed gray utilities are migrated. */
+  html.dark .text-gray-900:not([class*="dark:text-"]),
+  html.dark .text-gray-800:not([class*="dark:text-"]) {
+    color: hsl(var(--foreground));
+  }
+
+  html.dark .text-gray-700:not([class*="dark:text-"]),
+  html.dark .text-gray-600:not([class*="dark:text-"]),
+  html.dark .text-gray-500:not([class*="dark:text-"]) {
+    color: hsl(var(--muted-foreground));
+  }
+
+  html.dark .bg-white:not([class*="dark:bg-"]) {
+    background-color: hsl(var(--card));
+  }
+
+  html.dark .bg-gray-50:not([class*="dark:bg-"]) {
+    background-color: hsl(var(--muted));
+  }
+
+  html.dark .border-gray-200:not([class*="dark:border-"]),
+  html.dark .border-gray-300:not([class*="dark:border-"]) {
+    border-color: hsl(var(--border));
   }
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -27,7 +27,11 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  themeColor: '#000000',
+  colorScheme: 'light dark',
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#f8fafc' },
+    { media: '(prefers-color-scheme: dark)', color: '#020617' },
+  ],
 }
 
 export default function RootLayout({

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -290,13 +290,14 @@ export default function ProjectsPage() {
       <AppHeader currentPage="projects" />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="flex justify-between items-center mb-8">
-          <div>
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="min-w-0">
             <h1 className="text-3xl font-bold">プロジェクト一覧</h1>
-            <p className="text-gray-600 mt-2">研究・開発プロジェクトを管理します。</p>
+            <p className="mt-2 text-muted-foreground">研究・開発プロジェクトを管理します。</p>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex w-full flex-col gap-3 sm:w-auto sm:shrink-0 sm:flex-row sm:items-center">
             <SortDropdown
+              className="w-full sm:w-auto"
               currentSort={sortOptions}
               onSortChange={setSortOptions}
               sortFields={[
@@ -308,7 +309,7 @@ export default function ProjectsPage() {
             />
             <Button
               onClick={() => setShowCreateForm(true)}
-              className="flex items-center gap-2"
+              className="flex w-full items-center gap-2 sm:w-auto"
             >
               <Plus className="h-4 w-4" />
               新規プロジェクト作成
@@ -414,12 +415,12 @@ export default function ProjectsPage() {
                 className="hover:shadow-lg transition-shadow relative"
               >
                 <CardHeader>
-                  <div className="flex justify-between items-start">
+                  <div className="flex min-w-0 items-start justify-between gap-2">
                     <div
-                      className="flex-1 cursor-pointer"
+                      className="min-w-0 flex-1 cursor-pointer"
                       onClick={() => router.push(`/projects/${project.id}`)}
                     >
-                      <CardTitle className="line-clamp-1 pr-8">{project.title}</CardTitle>
+                      <CardTitle className="line-clamp-2">{project.title}</CardTitle>
                       <CardDescription className="line-clamp-2">
                         {project.description || 'プロジェクトの説明がありません'}
                       </CardDescription>
@@ -428,7 +429,7 @@ export default function ProjectsPage() {
                       <DropdownMenuTrigger asChild>
                         <Button
                           variant="ghost"
-                          className="h-8 w-8 p-0"
+                          className="h-8 w-8 shrink-0 p-0"
                           onClick={(e) => e.stopPropagation()}
                         >
                           <span className="sr-only">アクションメニューを開く</span>
@@ -461,8 +462,8 @@ export default function ProjectsPage() {
                 </CardHeader>
                 <CardContent>
                   <div className="space-y-3">
-                    <div className="flex items-center justify-between">
-                      <div className="text-sm text-gray-500">
+                    <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="text-sm text-muted-foreground">
                         作成日: {new Date(project.created_at).toLocaleDateString('ja-JP')}
                       </div>
                       <div onClick={(e) => e.stopPropagation()}>

--- a/apps/web/src/app/schedule-history/page.tsx
+++ b/apps/web/src/app/schedule-history/page.tsx
@@ -118,8 +118,8 @@ export default function ScheduleHistoryPage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="flex items-center gap-4">
-              <div className="flex-1">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:gap-4">
+              <div className="min-w-0 flex-1">
                 <Label htmlFor="date-filter">日付で絞り込み</Label>
                 <Input
                   id="date-filter"
@@ -132,7 +132,7 @@ export default function ScheduleHistoryPage() {
               <Button
                 variant="outline"
                 onClick={() => setSelectedDate('')}
-                className="mt-6"
+                className="w-full sm:w-auto"
               >
                 リセット
               </Button>
@@ -171,8 +171,8 @@ export default function ScheduleHistoryPage() {
           {filteredSchedules.map((schedule) => (
             <Card key={schedule.id} className="hover:shadow-md transition-shadow">
               <CardHeader>
-                <div className="flex items-center justify-between">
-                  <div>
+                <div className="flex min-w-0 flex-col items-start gap-3 sm:flex-row sm:justify-between">
+                  <div className="min-w-0">
                     <CardTitle className="flex items-center gap-2">
                       <Calendar className="h-5 w-5 text-blue-600" />
                       {formatDate(schedule.date)}
@@ -186,7 +186,7 @@ export default function ScheduleHistoryPage() {
                       )}
                     </CardDescription>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex shrink-0 items-center gap-2">
                     <Badge variant={schedule.plan_json.success ? 'default' : 'destructive'}>
                       {schedule.plan_json.optimization_status}
                     </Badge>
@@ -216,18 +216,18 @@ export default function ScheduleHistoryPage() {
                 {schedule.plan_json.assignments.length > 0 && (
                   <div>
                     <h4 className="font-semibold mb-2">スケジュール済みタスク</h4>
-                    <div className="space-y-2 max-h-80 overflow-y-auto border border-gray-200 rounded-lg p-2">
+                    <div className="max-h-80 space-y-2 overflow-y-auto rounded-lg border border-gray-200 p-2">
                       {schedule.plan_json.assignments
                         .sort((a, b) => a.start_time.localeCompare(b.start_time))
                         .map((assignment, index) => (
-                        <div key={index} className="flex items-center justify-between p-2 bg-gray-50 rounded">
-                          <div className="flex items-center gap-3">
-                            <div className="text-sm font-semibold text-gray-600">
+                        <div key={index} className="flex min-w-0 flex-col items-start gap-3 rounded bg-gray-50 p-2 sm:flex-row sm:items-center sm:justify-between">
+                          <div className="flex min-w-0 items-start gap-3">
+                            <div className="shrink-0 text-sm font-semibold text-gray-600">
                               {assignment.start_time}
                             </div>
-                            <div>
-                              <div className="text-sm font-medium">{assignment.task_title}</div>
-                              <div className="text-xs text-gray-500 flex items-center gap-1">
+                            <div className="min-w-0">
+                              <div className="break-words text-sm font-medium">{assignment.task_title}</div>
+                              <div className="flex flex-wrap items-center gap-1 text-xs text-gray-500">
                                 <Clock className="h-3 w-3" />
                                 {assignment.duration_hours.toFixed(1)}h
                                 <span className="text-gray-400">•</span>
@@ -237,7 +237,7 @@ export default function ScheduleHistoryPage() {
                               </div>
                             </div>
                           </div>
-                          <div className="flex items-center gap-2">
+                          <div className="flex shrink-0 items-center gap-2 self-end sm:self-auto">
                             <LogFormDialog
                               taskId={assignment.task_id}
                               taskTitle={assignment.task_title}

--- a/apps/web/src/app/weekly-tasks/page.tsx
+++ b/apps/web/src/app/weekly-tasks/page.tsx
@@ -100,15 +100,15 @@ export default function WeeklyTasksPage() {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       <AppHeader currentPage="ai-planning" />
-      <div className="container mx-auto p-6">
-      <div className="flex justify-between items-center mb-6">
-        <div>
+      <div className="container mx-auto py-6">
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
           <h1 className="text-3xl font-bold">週課管理</h1>
           <p className="text-muted-foreground mt-2">
             定期的に行う週単位のタスクを管理します
           </p>
         </div>
-        <Button onClick={handleCreateTask} className="flex items-center gap-2">
+        <Button onClick={handleCreateTask} className="flex w-full items-center gap-2 sm:w-auto sm:shrink-0">
           <Plus className="h-4 w-4" />
           新しい週課を追加
         </Button>
@@ -118,8 +118,8 @@ export default function WeeklyTasksPage() {
         {tasks.map((task) => (
           <Card key={task.id} className={`${!task.is_active ? "opacity-50" : ""}`}>
             <CardHeader className="pb-3">
-              <div className="flex justify-between items-start">
-                <div className="flex-1">
+              <div className="flex min-w-0 flex-col items-start gap-3 sm:flex-row sm:justify-between">
+                <div className="min-w-0 flex-1">
                   <CardTitle className="text-lg">{task.title}</CardTitle>
                   <div className="flex items-center gap-2 mt-2">
                     <Badge className={getCategoryColor(task.category)}>

--- a/apps/web/src/app/work-session-history/page.tsx
+++ b/apps/web/src/app/work-session-history/page.tsx
@@ -343,9 +343,9 @@ export default function WorkSessionHistoryPage() {
                   className="hover:shadow-md transition-shadow"
                 >
                   <CardHeader className="pb-2">
-                    <div className="flex items-center justify-between">
-                      <div className="flex-1">
-                        <CardTitle className="text-lg flex items-center gap-2">
+                    <div className="flex min-w-0 flex-col items-start gap-3 sm:flex-row sm:justify-between">
+                      <div className="min-w-0 flex-1">
+                        <CardTitle className="flex flex-wrap items-center gap-2 text-lg">
                           {session.task?.title || 'タスク名不明'}
                           {!session.ended_at && (
                             <Badge variant="secondary" className="text-xs">
@@ -353,7 +353,7 @@ export default function WorkSessionHistoryPage() {
                             </Badge>
                           )}
                         </CardTitle>
-                        <CardDescription className="flex items-center gap-4 mt-1">
+                        <CardDescription className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1">
                           <span className="flex items-center gap-1">
                             <Calendar className="h-4 w-4" />
                             {format(new Date(session.started_at), 'yyyy/MM/dd (E)', {
@@ -380,7 +380,7 @@ export default function WorkSessionHistoryPage() {
                           </span>
                         </CardDescription>
                       </div>
-                      <div className="flex items-center gap-2">
+                      <div className="flex shrink-0 flex-wrap items-center gap-2">
                         {session.checkout_type && (
                           <Badge variant="outline">
                             {CHECKOUT_TYPE_LABELS[session.checkout_type]}

--- a/apps/web/src/components/goals/goal-card.tsx
+++ b/apps/web/src/components/goals/goal-card.tsx
@@ -42,9 +42,11 @@ export const GoalCard = memo(function GoalCard({
       aria-label={`ゴール: ${goal.title}`}
     >
       <CardHeader>
-        <div className="flex justify-between items-start mb-2">
-          <CardTitle className="line-clamp-1 flex-1">{goal.title}</CardTitle>
-          <GoalStatusDropdown goal={goal} />
+        <div className="mb-2 flex min-w-0 flex-col items-start gap-3 sm:flex-row sm:justify-between">
+          <CardTitle className="line-clamp-2 min-w-0 flex-1">{goal.title}</CardTitle>
+          <div className="shrink-0">
+            <GoalStatusDropdown goal={goal} />
+          </div>
         </div>
         <CardDescription className="line-clamp-2">
           {goal.description || 'ゴールの説明がありません'}
@@ -52,7 +54,7 @@ export const GoalCard = memo(function GoalCard({
       </CardHeader>
       <CardContent className="pt-4">
         <div className="space-y-4">
-          <div className="flex justify-between items-center">
+          <div className="flex flex-wrap items-center justify-between gap-2">
             <div className="text-sm text-muted-foreground flex items-center gap-2">
               <span className="inline-flex items-center px-2.5 py-1 rounded-md bg-info/10 text-info font-medium">
                 見積: {goal.estimate_hours}h

--- a/apps/web/src/components/goals/goal-list.tsx
+++ b/apps/web/src/components/goals/goal-list.tsx
@@ -27,12 +27,12 @@ export function GoalList({
 }: GoalListProps) {
   return (
     <div className="space-y-6">
-      <div className="flex justify-between items-center">
-        <div>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
           <h2 className="text-2xl font-bold">ゴール一覧</h2>
-          <p className="text-gray-600 mt-2">このプロジェクトの目標を管理します。</p>
+          <p className="mt-2 text-muted-foreground">このプロジェクトの目標を管理します。</p>
         </div>
-        <div className="flex gap-2">
+        <div className="grid grid-cols-2 gap-2 sm:flex sm:shrink-0">
           <GoalTaskAssistantDialog
             projectId={projectId}
             mode="project_goals"
@@ -40,13 +40,13 @@ export function GoalList({
             defaultMessage="プロジェクトノートと既存のゴールをもとに、次に作るべきゴールと初期タスクを提案してください。"
             onApplied={onRefetch}
           >
-            <Button variant="outline">
+            <Button variant="outline" className="w-full sm:w-auto">
               <Sparkles className="h-4 w-4 mr-2" />
               AI提案
             </Button>
           </GoalTaskAssistantDialog>
           <GoalFormDialog projectId={projectId}>
-            <Button>
+            <Button className="w-full sm:w-auto">
               <Plus className="h-4 w-4 mr-2" />
               新規ゴール作成
             </Button>

--- a/apps/web/src/components/layout/app-header.tsx
+++ b/apps/web/src/components/layout/app-header.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link'
 
 // UI components
 import { Button } from '@/components/ui/button'
+import { ThemeToggle } from '@/components/theme-toggle'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import {
   DropdownMenu,
@@ -87,7 +88,7 @@ export function AppHeader({ currentPage }: AppHeaderProps) {
   return (
     <header className="bg-card/95 backdrop-blur-sm shadow-md border-b border-border/60 sticky top-0 z-50">
       <div className="mx-auto max-w-screen-2xl px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-16 gap-2 xl:gap-3">
+        <div className="flex h-16 items-center justify-between gap-2 xl:gap-3">
           <div className="flex min-w-0 flex-1 items-center gap-3 overflow-hidden xl:gap-4">
             <div className="flex shrink-0 items-center space-x-3">
               <Image
@@ -190,7 +191,7 @@ export function AppHeader({ currentPage }: AppHeaderProps) {
             </nav>
 
             {/* Mobile Navigation */}
-            <div className="lg:hidden">
+            <div className="shrink-0 lg:hidden">
               <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
                 <DialogTrigger asChild>
                   <Button variant="ghost" size="sm" aria-label="メニューを開く">
@@ -277,15 +278,18 @@ export function AppHeader({ currentPage }: AppHeaderProps) {
               </Dialog>
             </div>
           </div>
-          <div className="hidden shrink-0 lg:flex items-center gap-2 xl:gap-3">
-            {user?.email && (
-              <span className="hidden max-w-[220px] truncate rounded-full bg-muted/50 px-3 py-1.5 text-sm text-muted-foreground 2xl:inline-block">
-                {user.email}
-              </span>
-            )}
-            <Button variant="outline" onClick={signOut} className="border-border hover:bg-destructive/10 hover:text-destructive hover:border-destructive/50 whitespace-nowrap">
-              ログアウト
-            </Button>
+          <div className="flex shrink-0 items-center gap-1 sm:gap-2 xl:gap-3">
+            <ThemeToggle />
+            <div className="hidden items-center gap-2 lg:flex xl:gap-3">
+              {user?.email && (
+                <span className="hidden max-w-[220px] truncate rounded-full bg-muted/50 px-3 py-1.5 text-sm text-muted-foreground 2xl:inline-block">
+                  {user.email}
+                </span>
+              )}
+              <Button variant="outline" onClick={signOut} className="border-border hover:bg-destructive/10 hover:text-destructive hover:border-destructive/50 whitespace-nowrap">
+                ログアウト
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/projects/project-header.tsx
+++ b/apps/web/src/components/projects/project-header.tsx
@@ -13,9 +13,9 @@ interface ProjectHeaderProps {
 export function ProjectHeader({ project }: ProjectHeaderProps) {
   return (
     <div className="mb-8">
-      <div className="flex items-center justify-between mb-2">
-        <h1 className="text-3xl font-bold">{project.title}</h1>
-        <div className="flex items-center gap-2">
+      <div className="mb-3 flex min-w-0 flex-col items-start gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <h1 className="min-w-0 text-3xl font-bold">{project.title}</h1>
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
           <Button variant="outline" size="sm" asChild>
             <Link href={`/projects/${project.id}/notes`}>
               <FileText className="h-4 w-4 mr-2" />
@@ -25,13 +25,13 @@ export function ProjectHeader({ project }: ProjectHeaderProps) {
           <ProjectStatusDropdown project={project} />
         </div>
       </div>
-      <p className="text-gray-600 dark:text-gray-400 mb-4">
+      <p className="mb-4 break-words text-gray-600 dark:text-gray-400">
         {project.description || 'プロジェクトの説明がありません'}
       </p>
-      <div className="text-sm text-gray-500 dark:text-gray-400">
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
         作成日: {new Date(project.created_at).toLocaleDateString('ja-JP')}
         {project.updated_at !== project.created_at && (
-          <span className="ml-4">
+          <span>
             更新日: {new Date(project.updated_at).toLocaleDateString('ja-JP')}
           </span>
         )}

--- a/apps/web/src/components/quick-tasks/quick-task-card.tsx
+++ b/apps/web/src/components/quick-tasks/quick-task-card.tsx
@@ -64,7 +64,7 @@ export function QuickTaskCard({
               </Button>
             )}
             <Inbox className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-            <span className="font-medium text-sm truncate">{task.title}</span>
+            <span className="min-w-0 break-words text-sm font-medium">{task.title}</span>
           </div>
 
           <DropdownMenu>

--- a/apps/web/src/components/quick-tasks/quick-task-list.tsx
+++ b/apps/web/src/components/quick-tasks/quick-task-list.tsx
@@ -158,8 +158,8 @@ export function QuickTaskList({
     <>
       <Card>
         {showHeader && (
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-lg font-medium flex items-center gap-2">
+          <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0 pb-2">
+            <CardTitle className="min-w-0 text-lg font-medium flex items-center gap-2">
               <Inbox className="h-5 w-5" />
               クイックタスク
               {tasks.length > 0 && (

--- a/apps/web/src/components/runner/task-picker-dialog.tsx
+++ b/apps/web/src/components/runner/task-picker-dialog.tsx
@@ -177,15 +177,15 @@ export function TaskPickerDialog({
                 onOpenChange(false);
               }}
             >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <div className="truncate font-medium">{task.title}</div>
+              <div className="flex min-w-0 flex-col items-start gap-3 sm:flex-row sm:justify-between">
+                <div className="min-w-0 flex-1">
+                  <div className="break-words font-medium">{task.title}</div>
                   <div className="mt-1 truncate text-xs text-muted-foreground">
                     {task.project_title} › {task.goal_title}
                   </div>
                   {reason && <div className="mt-2 text-xs">{reason}</div>}
                 </div>
-                <div className="flex shrink-0 gap-1">
+                <div className="flex shrink-0 flex-wrap gap-1">
                   {task.planned_today && (
                     <Badge variant="info">
                       {task.planned_today_unplaced ? '今日・未配置' : '今日'}

--- a/apps/web/src/components/tasks/goal-task-list.tsx
+++ b/apps/web/src/components/tasks/goal-task-list.tsx
@@ -169,21 +169,21 @@ function DependencyButton({
 
 function TaskActions({ task, tasks }: { task: Task; tasks: Task[] }) {
   return (
-    <div className="flex flex-wrap gap-1">
+    <div className="grid grid-cols-3 gap-2 sm:flex sm:flex-wrap sm:gap-1">
       <LogFormDialog
         taskId={task.id}
         taskTitle={task.title}
         trigger={
-          <Button variant="outline" size="sm">
+          <Button variant="outline" size="sm" className="w-full sm:w-auto">
             時間記録
           </Button>
         }
       />
       <TaskEditDialog task={task} availableTasks={tasks}>
-        <Button variant="outline" size="sm">編集</Button>
+        <Button variant="outline" size="sm" className="w-full sm:w-auto">編集</Button>
       </TaskEditDialog>
       <TaskDeleteDialog task={task}>
-        <Button variant="outline" size="sm">削除</Button>
+        <Button variant="outline" size="sm" className="w-full sm:w-auto">削除</Button>
       </TaskDeleteDialog>
     </div>
   )
@@ -420,8 +420,8 @@ function TaskMobileCard({
   return (
     <Card>
       <CardContent className="space-y-4 p-4">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
+        <div className="flex min-w-0 flex-col items-start gap-3 sm:flex-row sm:justify-between">
+          <div className="min-w-0 flex-1">
             <TaskDecisionBadge task={task} />
             <Link
               href={`/projects/${projectId}/goals/${goalId}/tasks/${task.id}`}
@@ -435,7 +435,9 @@ function TaskMobileCard({
               </p>
             )}
           </div>
-          <TaskStatusSelect task={task} />
+          <div className="shrink-0">
+            <TaskStatusSelect task={task} />
+          </div>
         </div>
 
         <div className="grid grid-cols-2 gap-3 rounded-lg bg-muted/50 p-3 text-sm">

--- a/apps/web/src/components/tasks/task-card.tsx
+++ b/apps/web/src/components/tasks/task-card.tsx
@@ -47,7 +47,7 @@ export function TaskCard({
       <CardContent className="p-4 space-y-2">
         <Link
           href={linkHref}
-          className="block font-medium text-sm hover:underline"
+          className="block break-words text-sm font-medium hover:underline"
         >
           {title}
         </Link>

--- a/apps/web/src/components/tasks/task-logs-memo-panel.tsx
+++ b/apps/web/src/components/tasks/task-logs-memo-panel.tsx
@@ -158,7 +158,7 @@ export function TaskLogsMemoPanel({
       </CollapsibleTrigger>
 
       <CollapsibleContent>
-        <div className="pl-6 pt-2 pb-4 space-y-4">
+        <div className="space-y-4 pb-4 pt-2 sm:pl-6">
           {/* Memo Section */}
           <Card>
             <CardHeader className="pb-3">
@@ -254,8 +254,8 @@ export function TaskLogsMemoPanel({
                         className="p-3 bg-gray-50 rounded-md space-y-2"
                       >
                         {/* Session metadata */}
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                        <div className="flex min-w-0 items-start justify-between gap-2">
+                          <div className="flex min-w-0 flex-wrap items-center gap-2 text-sm text-muted-foreground">
                             <span>
                               {format(new Date(session.started_at), 'MM/dd (E) HH:mm', { locale: ja })}
                             </span>
@@ -357,9 +357,9 @@ export function TaskLogsMemoPanel({
                   {logs.map((logEntry) => (
                     <div
                       key={logEntry.id}
-                      className="flex items-start justify-between p-3 bg-gray-50 rounded-md"
+                      className="flex min-w-0 items-start justify-between gap-2 rounded-md bg-gray-50 p-3"
                     >
-                      <div className="flex-1">
+                      <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2 mb-1">
                           <Badge variant="secondary" className="text-xs">
                             {(logEntry.actual_minutes / 60).toFixed(1)}h

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Moon, Sun } from 'lucide-react'
+import { useTheme } from 'next-themes'
+
+import { Button } from '@/components/ui/button'
+
+export function ThemeToggle() {
+  const [mounted, setMounted] = useState(false)
+  const { resolvedTheme, setTheme } = useTheme()
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const isDark = mounted && resolvedTheme === 'dark'
+  const label = isDark ? 'ライトモードに切り替える' : 'ナイトモードに切り替える'
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="shrink-0"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      aria-label={label}
+      title={label}
+      disabled={!mounted}
+    >
+      {isDark ? (
+        <Sun className="h-5 w-5" aria-hidden="true" />
+      ) : (
+        <Moon className="h-5 w-5" aria-hidden="true" />
+      )}
+    </Button>
+  )
+}

--- a/apps/web/src/components/timeline/timeline-error-boundary.tsx
+++ b/apps/web/src/components/timeline/timeline-error-boundary.tsx
@@ -74,12 +74,12 @@ function DefaultErrorFallback({ error, resetErrorBoundary }: ErrorFallbackProps)
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-gray-600">
+        <p className="text-muted-foreground">
           タイムラインの表示中にエラーが発生しました。以下のボタンをクリックして再試行するか、ページをリロードしてください。
         </p>
 
         {isDevelopment && (
-          <details className="bg-gray-50 p-4 rounded-lg">
+          <details className="rounded-lg bg-muted p-4">
             <summary className="cursor-pointer font-medium text-gray-700 mb-2">
               エラー詳細 (開発環境)
             </summary>
@@ -105,7 +105,7 @@ function DefaultErrorFallback({ error, resetErrorBoundary }: ErrorFallbackProps)
           </Button>
         </div>
 
-        <div className="text-sm text-gray-500 border-t pt-4 mt-4">
+        <div className="mt-4 border-t pt-4 text-sm text-muted-foreground">
           <p>
             この問題が継続する場合は、以下をお試しください：
           </p>

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border border-border/60 bg-card text-card-foreground shadow-md hover:shadow-lg transition-all duration-200",
+      "min-w-0 rounded-xl border border-border/60 bg-card text-card-foreground shadow-md hover:shadow-lg transition-all duration-200",
       className
     )}
     {...props}
@@ -21,7 +21,7 @@ const CardHeader = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6 border-b border-border/40", className)} {...props} />
+  <div ref={ref} className={cn("flex min-w-0 flex-col space-y-1.5 border-b border-border/40 p-[clamp(1rem,4vw,1.5rem)]", className)} {...props} />
 ))
 CardHeader.displayName = "CardHeader"
 
@@ -32,7 +32,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-xl font-semibold leading-none tracking-tight text-foreground",
+      "min-w-0 break-words text-xl font-semibold leading-snug tracking-tight text-foreground",
       className
     )}
     {...props}
@@ -46,7 +46,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("min-w-0 break-words text-sm text-muted-foreground", className)}
     {...props}
   />
 ))
@@ -56,7 +56,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("min-w-0 p-[clamp(1rem,4vw,1.5rem)] pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -64,7 +64,7 @@ const CardFooter = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("flex items-center p-6 pt-4 border-t border-border/40 bg-muted/30", className)} {...props} />
+  <div ref={ref} className={cn("flex min-w-0 items-center border-t border-border/40 bg-muted/30 p-[clamp(1rem,4vw,1.5rem)] pt-4", className)} {...props} />
 ))
 CardFooter.displayName = "CardFooter"
 

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-[calc(100%-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-[clamp(1rem,4vw,1.5rem)] shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:w-full sm:rounded-lg",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/sort-dropdown.tsx
+++ b/apps/web/src/components/ui/sort-dropdown.tsx
@@ -56,11 +56,11 @@ export function SortDropdown({
   };
 
   return (
-    <div className={cn('flex items-center gap-2', className)}>
+    <div className={cn('flex min-w-0 items-center gap-2', className)}>
       {/* Sort Field Dropdown */}
-      <Menu as="div" className="relative inline-block text-left">
+      <Menu as="div" className="relative min-w-0 flex-1 text-left sm:inline-block sm:flex-none">
         <div>
-          <Menu.Button className="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50">
+          <Menu.Button className="inline-flex w-full justify-center gap-x-1.5 rounded-md bg-background px-3 py-2 text-sm font-semibold text-foreground shadow-sm ring-1 ring-inset ring-border hover:bg-muted">
             {currentField.label}
             <ChevronDownIcon className="-mr-1 h-5 w-5 text-gray-400" aria-hidden="true" />
           </Menu.Button>
@@ -75,7 +75,7 @@ export function SortDropdown({
           leaveFrom="transform opacity-100 scale-100"
           leaveTo="transform opacity-0 scale-95"
         >
-          <Menu.Items className="absolute right-0 z-10 mt-2 w-36 origin-top-right divide-y divide-gray-100 rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+          <Menu.Items className="absolute right-0 z-10 mt-2 w-36 origin-top-right divide-y divide-border rounded-md bg-popover text-popover-foreground shadow-lg ring-1 ring-border focus:outline-none">
             <div className="py-1">
               {sortFields.map((field) => (
                 <Menu.Item key={field.value}>
@@ -83,8 +83,8 @@ export function SortDropdown({
                     <button
                       onClick={() => handleSortFieldChange(field.value)}
                       className={cn(
-                        active ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
-                        currentSort.sortBy === field.value && 'bg-blue-50 text-blue-700 font-medium',
+                        active ? 'bg-muted text-foreground' : 'text-popover-foreground',
+                        currentSort.sortBy === field.value && 'bg-primary/10 text-primary font-medium',
                         'block w-full px-4 py-2 text-left text-sm'
                       )}
                     >
@@ -101,7 +101,7 @@ export function SortDropdown({
       {/* Sort Order Toggle Button */}
       <button
         onClick={handleSortOrderToggle}
-        className="inline-flex items-center justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        className="inline-flex shrink-0 items-center justify-center rounded-md bg-background px-3 py-2 text-sm font-semibold text-foreground shadow-sm ring-1 ring-inset ring-border hover:bg-muted"
         title={isAscending ? '昇順' : '降順'}
         aria-label={`並び順を${isAscending ? '降順' : '昇順'}に変更`}
       >

--- a/apps/web/src/types/task.ts
+++ b/apps/web/src/types/task.ts
@@ -321,10 +321,10 @@ export const taskStatusLabels: Record<TaskStatus, string> = {
  * タスクステータスのTailwind CSSカラークラス
  */
 export const taskStatusColors: Record<TaskStatus, string> = {
-  pending: 'bg-gray-100 text-gray-800',
-  in_progress: 'bg-blue-100 text-blue-800',
-  completed: 'bg-green-100 text-green-800',
-  cancelled: 'bg-red-100 text-red-800',
+  pending: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
+  in_progress: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200',
+  completed: 'bg-green-100 text-green-800 dark:bg-green-950 dark:text-green-200',
+  cancelled: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200',
 };
 
 /**
@@ -340,9 +340,9 @@ export const workTypeLabels: Record<WorkType, string> = {
  * 作業種別のTailwind CSSカラークラス
  */
 export const workTypeColors: Record<WorkType, string> = {
-  light_work: 'bg-yellow-100 text-yellow-800',
-  study: 'bg-purple-100 text-purple-800',
-  focused_work: 'bg-orange-100 text-orange-800',
+  light_work: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950 dark:text-yellow-200',
+  study: 'bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-200',
+  focused_work: 'bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-200',
 };
 
 /**
@@ -360,9 +360,9 @@ export const taskPriorityLabels: Record<number, string> = {
  * 優先度のTailwind CSSカラークラス
  */
 export const taskPriorityColors: Record<number, string> = {
-  1: 'bg-red-100 text-red-800',
-  2: 'bg-orange-100 text-orange-800',
-  3: 'bg-yellow-100 text-yellow-800',
-  4: 'bg-blue-100 text-blue-800',
-  5: 'bg-gray-100 text-gray-800',
+  1: 'bg-red-100 text-red-800 dark:bg-red-950 dark:text-red-200',
+  2: 'bg-orange-100 text-orange-800 dark:bg-orange-950 dark:text-orange-200',
+  3: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-950 dark:text-yellow-200',
+  4: 'bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-200',
+  5: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-200',
 };


### PR DESCRIPTION
## 概要

HumanCompiler に手動で切り替えられるナイトモードを追加し、長いタイトルや操作ボタンがある画面のスマホレイアウトを改善します。

## 背景・原因

- ダークテーマ用の配色変数と `next-themes` は導入済みでしたが、ユーザーが切り替えるUIがありませんでした。
- 一部の画面にはライトテーマ固定のグレー系クラスが残り、ダーク表示時のコントラストが不足していました。
- 見出しと操作ボタンを常に横並びにする構造や、flex要素の最小幅指定不足により、長い文字列がボタンを押し出していました。

## 変更内容

- ヘッダーにライト／ナイトモード切り替えボタンを追加し、選択を永続化
- 既存画面の固定グレー配色をダークテーマでも読みやすく補正
- タスクのステータス・作業種別・優先度バッジにダーク配色を追加
- 共通カード、ダイアログ、並び替えメニューをレスポンシブ化
- プロジェクト、ゴール、タスク、ダッシュボード、スケジュール履歴、作業履歴などで、長いタイトルの折り返しと操作領域の縦積みを追加
- スマホ向けの余白、モーダル最大高、横方向のはみ出しを調整

## ユーザーへの影響

ナイトモードを任意に利用でき、スマホでも長いプロジェクト名・ゴール名・タスク名と操作ボタンが重ならず、一覧やダイアログを操作しやすくなります。

## 検証

- `pnpm --filter web type-check`
- 関連UIテスト 3スイート／6テスト成功
- `pnpm --filter web build`
- 全体テストは 31スイート成功、既存の6スイートが失敗（fetchテスト環境の `Response` 未定義、timeline utilityの期待値差分、既存hook/configテスト）。今回変更したUIファイルに起因する失敗はありません。